### PR TITLE
chore(ci): pin runners to ubuntu-24.04 and run tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     check-and-test:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
 
         steps:
             - name: Checkout repository
@@ -33,6 +33,8 @@ jobs:
               run: |
                   npm install
 
-            - name: Tests
-              run: |
-                  npm run format-check
+            - name: Format check
+              run: npm run format-check
+
+            - name: Test
+              run: npm run test --if-present

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
     check-and-test:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
## Why

CI jobs on the open PRs were stuck at **"Waiting for a runner to pick up this job…"** with `Requested labels: ubuntu-20.04`. That hosted-runner image has been **retired**, so no runner ever picks the job up. This was the real (and only) CI blocker.

## Changes
- **Pin `runs-on: ubuntu-24.04`** in both `.github/workflows/CI.yml` and `build.yml` (was the removed `ubuntu-20.04`).
- **Run tests in CI:** split the CI "Tests" step into a `Format check` step and a `Test` step using **`npm run test --if-present`** — so the Vitest parity suite runs once a branch has it, and is a safe no-op on branches/`main` that don't yet (e.g. before #49 merges). Keeps runner + format + test in one PR without breaking anything regardless of merge order.
- Prettier-formatted the two workflow YAML files.

## Notes for reviewer
- **No source reformatting needed.** Under the pinned `prettier@3.5.1` (the exact version CI installs from the lockfile), `format-check` already passes on `main`. An earlier assumption that ~8 files had Prettier debt was a false alarm from a transiently-resolved different prettier during a dep install.
- Because a PR runs the workflow from **its own branch**, this branch's CI will actually execute (on `ubuntu-24.04`) rather than hang — so this PR's own checks validate the fix.
- Suggested merge order: this PR first, then #49 (its `npm test` will then run green in CI), then #48.

🤖 Generated with [Claude Code](https://claude.com/claude-code)