### PR TITLE
fix(motion_estimator): restore affine2d error() and check_subset() (#51)

### DIFF
--- a/src/jsfeatNext.ts
+++ b/src/jsfeatNext.ts
@@ -2186,13 +2186,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                             ? cmp(tb, tc)
                                 ? b
                                 : cmp(ta, tc)
-                                ? c
-                                : a
+                                  ? c
+                                  : a
                             : cmp(tc, tb)
-                            ? b
-                            : cmp(ta, tc)
-                            ? a
-                            : c;
+                              ? b
+                              : cmp(ta, tc)
+                                ? a
+                                : c;
 
                         (a = pivot - d), (b = pivot), (c = pivot + d);
                         (ta = array[a]), (tb = array[b]), (tc = array[c]);
@@ -2200,13 +2200,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                             ? cmp(tb, tc)
                                 ? b
                                 : cmp(ta, tc)
-                                ? c
-                                : a
+                                  ? c
+                                  : a
                             : cmp(tc, tb)
-                            ? b
-                            : cmp(ta, tc)
-                            ? a
-                            : c;
+                              ? b
+                              : cmp(ta, tc)
+                                ? a
+                                : c;
 
                         (a = right - (d << 1)), (b = right - d), (c = right);
                         (ta = array[a]), (tb = array[b]), (tc = array[c]);
@@ -2214,13 +2214,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                             ? cmp(tb, tc)
                                 ? b
                                 : cmp(ta, tc)
-                                ? c
-                                : a
+                                  ? c
+                                  : a
                             : cmp(tc, tb)
-                            ? b
-                            : cmp(ta, tc)
-                            ? a
-                            : c;
+                              ? b
+                              : cmp(ta, tc)
+                                ? a
+                                : c;
                     }
 
                     (a = left), (b = pivot), (c = right);
@@ -2229,13 +2229,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                         ? cmp(tb, tc)
                             ? b
                             : cmp(ta, tc)
-                            ? c
-                            : a
+                              ? c
+                              : a
                         : cmp(tc, tb)
-                        ? b
-                        : cmp(ta, tc)
-                        ? a
-                        : c;
+                          ? b
+                          : cmp(ta, tc)
+                            ? a
+                            : c;
                     if (pivot != left0) {
                         t = array[pivot];
                         array[pivot] = array[left0];

--- a/src/jsfeatNext.ts
+++ b/src/jsfeatNext.ts
@@ -271,6 +271,28 @@ class affine2d extends motion_model {
 
         return 1;
     }
+
+    // Per-point reprojection error for the affine model. Ported from original
+    // jsfeat's affine2d; jsfeatNext was missing it, which made RANSAC/LMEDS
+    // with an affine2d kernel throw. See issue #51.
+    error(from: point_t[], to: point_t[], model: matrix_t, err: Int32Array | Float32Array, count: number): void {
+        let i = 0;
+        let pt0, pt1;
+        const m = model.data;
+
+        for (; i < count; ++i) {
+            pt0 = from[i];
+            pt1 = to[i];
+
+            err[i] =
+                this.sqr(pt1.x - m[0] * pt0.x - m[1] * pt0.y - m[2]) +
+                this.sqr(pt1.y - m[3] * pt0.x - m[4] * pt0.y - m[5]);
+        }
+    }
+
+    check_subset(from: point_t[], to: point_t[], count: number): boolean {
+        return true; // all good
+    }
 }
 
 class homography2d extends motion_model {
@@ -2164,13 +2186,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                             ? cmp(tb, tc)
                                 ? b
                                 : cmp(ta, tc)
-                                  ? c
-                                  : a
+                                ? c
+                                : a
                             : cmp(tc, tb)
-                              ? b
-                              : cmp(ta, tc)
-                                ? a
-                                : c;
+                            ? b
+                            : cmp(ta, tc)
+                            ? a
+                            : c;
 
                         (a = pivot - d), (b = pivot), (c = pivot + d);
                         (ta = array[a]), (tb = array[b]), (tc = array[c]);
@@ -2178,13 +2200,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                             ? cmp(tb, tc)
                                 ? b
                                 : cmp(ta, tc)
-                                  ? c
-                                  : a
+                                ? c
+                                : a
                             : cmp(tc, tb)
-                              ? b
-                              : cmp(ta, tc)
-                                ? a
-                                : c;
+                            ? b
+                            : cmp(ta, tc)
+                            ? a
+                            : c;
 
                         (a = right - (d << 1)), (b = right - d), (c = right);
                         (ta = array[a]), (tb = array[b]), (tc = array[c]);
@@ -2192,13 +2214,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                             ? cmp(tb, tc)
                                 ? b
                                 : cmp(ta, tc)
-                                  ? c
-                                  : a
+                                ? c
+                                : a
                             : cmp(tc, tb)
-                              ? b
-                              : cmp(ta, tc)
-                                ? a
-                                : c;
+                            ? b
+                            : cmp(ta, tc)
+                            ? a
+                            : c;
                     }
 
                     (a = left), (b = pivot), (c = right);
@@ -2207,13 +2229,13 @@ jsfeatNext.math = class math extends jsfeatNext {
                         ? cmp(tb, tc)
                             ? b
                             : cmp(ta, tc)
-                              ? c
-                              : a
+                            ? c
+                            : a
                         : cmp(tc, tb)
-                          ? b
-                          : cmp(ta, tc)
-                            ? a
-                            : c;
+                        ? b
+                        : cmp(ta, tc)
+                        ? a
+                        : c;
                     if (pivot != left0) {
                         t = array[pivot];
                         array[pivot] = array[left0];

--- a/tests/parity/motion_estimator.test.ts
+++ b/tests/parity/motion_estimator.test.ts
@@ -149,11 +149,10 @@ describe("parity: motion_estimator vs original jsfeat.motion_estimator", () => {
             to.push({ x: X, y: Y });
         }
 
-        // BUG FOUND BY THIS SUITE (documented divergence, see the tracking
-        // issue): jsfeatNext's motion_model base class lost the default
-        // check_subset() (original jsfeat returns true there; only
-        // homography2d overrides it), so RANSAC with an affine2d kernel
-        // throws TypeError in jsfeatNext while it works in original jsfeat.
+        // Regression test for #51: jsfeatNext's motion_model base class was
+        // missing the default check_subset() (original jsfeat returns true
+        // there; only homography2d overrides it), which made RANSAC with an
+        // affine2d kernel throw TypeError. Now fixed — full parity check.
         const params = new jsfeatNext.ransac_params_t(3, 3.0, 0.5, 0.99);
         const me = new jsfeatNext.motion_estimator();
         const kernel = new jsfeatNext.affine2d();
@@ -161,23 +160,29 @@ describe("parity: motion_estimator vs original jsfeat.motion_estimator", () => {
         const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
 
         seededRandom(31337);
-        expect(() => me.ransac(params, kernel, from, to, N, model, mask, 1000)).toThrow(TypeError);
+        const okN = me.ransac(params, kernel, from, to, N, model, mask, 1000);
         vi.restoreAllMocks();
 
-        // ...whereas the original jsfeat succeeds on the same data:
         const paramsO = new jsfeat.ransac_params_t(3, 3.0, 0.5, 0.99);
         const kernelO = new jsfeat.motion_model.affine2d();
         const modelO = new jsfeat.matrix_t(3, 3, jsfeat.F32_t | jsfeat.C1_t);
         const maskO = new jsfeat.matrix_t(N, 1, jsfeat.U8_t | jsfeat.C1_t);
 
-        seededRandom(31337);
+        seededRandom(31337); // identical random sequence for the oracle
         const okO = jsfeat.motion_estimator.ransac(paramsO, kernelO, from, to, N, modelO, maskO, 1000);
         vi.restoreAllMocks();
 
-        expect(okO).toBe(true);
-        // the oracle also rejects the synthetic outliers
+        expect(okN).toBe(okO);
+        expect(okN).toBe(true);
+        for (let i = 0; i < N; i++) {
+            expect(mask.data[i]).toBe(maskO.data[i]);
+        }
+        for (let i = 0; i < 9; i++) {
+            expect(model.data[i]).toBeCloseTo(modelO.data[i], 4);
+        }
+        // the outliers must be rejected on both sides
         for (let i = 0; i < OUT; i++) {
-            expect(maskO.data[i]).toBe(0);
+            expect(mask.data[i]).toBe(0);
         }
     });
 });


### PR DESCRIPTION
Closes #51. First fix guarded by the new parity suite (Phase 0, #39).

## Bug
jsfeatNext's `affine2d` kernel was missing the `error()` and `check_subset()` methods that original jsfeat defines on it. So `motion_estimator.ransac()` / `lmeds()` with an `affine2d` kernel threw `TypeError: kernel.check_subset is not a function` (then `kernel.error is not a function`) — affine motion estimation was completely broken, while homography2d worked (it has its own overrides).

Surfaced by the characterization test added in #49, which had to *pin the crash* to stay green.

## Fix
Port both methods onto `affine2d` from original jsfeat (`src/jsfeat_motion_estimator.js`):
- `error()` — affine reprojection residual `sqr(dx) + sqr(dy)`
- `check_subset()` — returns `true`

## Test
The parity test is flipped from `expect(...).toThrow(TypeError)` to a **full parity check**: affine2d RANSAC now returns the same `true`, the same 3×3 model (to 4 decimals), and the **same inlier mask** as the oracle on identical seeded data, and rejects the synthetic outliers.

- `npm test` → **57 passed**
- `tsc --noEmit` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)