### PR TITLE
refactor(pyramid_t): de-duplicate pyramid_t module (#47)

### DIFF
--- a/src/jsfeatNext.ts
+++ b/src/jsfeatNext.ts
@@ -507,49 +507,7 @@ class homography2d extends motion_model {
 
 jsfeatNext.cache = cache;
 
-jsfeatNext.pyramid_t = class pyramid_t extends jsfeatNext {
-    public levels: number;
-    public data: any;
-    private pyrdown: any;
-
-    constructor(levels: number) {
-        super();
-        this.levels = levels | 0;
-        this.data = new Array(levels);
-        const _imgproc = new jsfeatNext.imgproc();
-        this.pyrdown = _imgproc.pyrdown;
-    }
-
-    allocate(start_w: number, start_h: number, data_type: number): void {
-        let i = this.levels;
-        while (--i >= 0) {
-            this.data[i] = new matrix_t(start_w >> i, start_h >> i, data_type);
-        }
-    }
-
-    build(input: matrix_t, skip_first_level: boolean): void {
-        if (typeof skip_first_level === "undefined") {
-            skip_first_level = true;
-        }
-        // just copy data to first level
-        let i = 2,
-            a = input,
-            b: any = this.data[0];
-        if (!skip_first_level) {
-            let j = input.cols * input.rows;
-            while (--j >= 0) {
-                b.data[j] = input.data[j];
-            }
-        }
-        b = this.data[1];
-        this.pyrdown(a, b);
-        for (; i < this.levels; ++i) {
-            a = b;
-            b = this.data[i];
-            this.pyrdown(a, b);
-        }
-    }
-};
+jsfeatNext.pyramid_t = pyramid_t;
 
 jsfeatNext.transform = transform;
 

--- a/src/pyramid_t/pyramid_t.ts
+++ b/src/pyramid_t/pyramid_t.ts
@@ -1,8 +1,54 @@
+import jsfeatNext from "../core/core";
 import { matrix_t } from "../matrix_t/matrix_t";
-export class pyramid_t {
-    data: any;
-    levels: number;
-    constructor(levels: number) {}
-    allocate(start_w: number, start_h: number, data_type: number): void {}
-    build(input: matrix_t, skip_first_level: boolean): void {}
+import { imgproc } from "../imgproc/imgproc";
+
+/**
+ * Real implementation, moved out of the src/jsfeatNext.ts monolith (issue #47).
+ * This file previously held a type-only stub — the implementation below is the
+ * inline code from the monolith, verbatim (the only change: the constructor
+ * instantiates the imgproc module directly instead of via the
+ * jsfeatNext.imgproc static slot).
+ */
+export class pyramid_t extends jsfeatNext {
+    public levels: number;
+    public data: any;
+    private pyrdown: any;
+
+    constructor(levels: number) {
+        super();
+        this.levels = levels | 0;
+        this.data = new Array(levels);
+        const _imgproc = new imgproc();
+        this.pyrdown = _imgproc.pyrdown;
+    }
+
+    allocate(start_w: number, start_h: number, data_type: number): void {
+        let i = this.levels;
+        while (--i >= 0) {
+            this.data[i] = new matrix_t(start_w >> i, start_h >> i, data_type);
+        }
+    }
+
+    build(input: matrix_t, skip_first_level: boolean): void {
+        if (typeof skip_first_level === "undefined") {
+            skip_first_level = true;
+        }
+        // just copy data to first level
+        let i = 2,
+            a = input,
+            b: any = this.data[0];
+        if (!skip_first_level) {
+            let j = input.cols * input.rows;
+            while (--j >= 0) {
+                b.data[j] = input.data[j];
+            }
+        }
+        b = this.data[1];
+        this.pyrdown(a, b);
+        for (; i < this.levels; ++i) {
+            a = b;
+            b = this.data[i];
+            this.pyrdown(a, b);
+        }
+    }
 }


### PR DESCRIPTION
Fourth slice of #47 — fresh branch off the integration branch (no stacking, so no squash-merge conflicts this time).

## What changed
- **`src/pyramid_t/pyramid_t.ts`** — type-only stub replaced by the real implementation, verbatim from the monolith (`allocate`, `build`). One deliberate change: the constructor instantiates `imgproc` via direct module import instead of the `jsfeatNext.imgproc` static slot (same class, removes attach-order coupling — same pattern as #63's `gaussian_blur`).
- **`src/jsfeatNext.ts`** — ~43 lines removed.

## Verification
- `tsc --noEmit` → clean
- `npm test` → **57/57** (the `optical_flow_lk` parity test exercises `pyramid_t` against the original-jsfeat oracle)
- UMD bundle smoke-checked: `instanceof` chain, `allocate`/`build` produce correct per-level dimensions on a synthetic image
- `dist/`/`types/` untouched (rebuilt when the integration branch merges to `dev`)

Advances #47. Remaining: `linalg` → `orb` → `yape06` → `motion_estimator` (+ inline kernels → tightens the `any` slots in `core.ts`) → `optical_flow_lk`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)