### PR TITLE
chore(pkg): stop shipping raw src/ in the published npm package (closes #60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
   },
   "files": [
     "dist",
-    "types",
-    "src"
+    "types"
   ],
   "scripts": {
     "build-ts": "vite build",


### PR DESCRIPTION
Closes #60. Designed via `/brainstorming` (understanding lock + decision log below).

## Change
One line: remove `"src"` from `package.json`'s `files` array.

```diff
  "files": [
    "dist",
-   "types",
-   "src"
+   "types"
  ],
```

## Why this is the complete fix
- `main`, `module`, `types` and the `exports` map already resolve exclusively into `dist/` (UMD+ESM bundles) and `types/` (declarations) — never into `src/`.
- No source maps reference `src/` paths (`sourcemap: false` in `vite.config.mts`).
- `src/` was pure dead weight in the tarball: 264.5 KB of the 510 KB unpacked package (52%).

## Why not `.npmignore`
`files` is already an exact whitelist — a `.npmignore` only matters for excluding things *within* an already-included directory. Removing a whole top-level entry from `files` is the complete, simpler fix; adding a `.npmignore` on top would be redundant.

## Verification (`npm pack --dry-run`)
| | Before | After | Δ |
|---|---|---|---|
| Entries | 73 | 39 | −34 |
| Unpacked | 522,391 B | 251,525 B | **−52%** |
| Packed (gzip) | 114,131 B | 74,331 B | **−35%** |

Zero `src/` entries remain; `dist/`, `types/`, `LICENSE`, `README.md`, `package.json` all still ship.

Also verified: `npm run build-ts` succeeds, `npm test` → 57/57, `tsc --noEmit` clean, `prettier --check .` clean, UMD bundle still resolves (`require()` → `VERSION` intact).

## Decision log
| Decision | Alternative | Why |
|---|---|---|
| Pure packaging trim, no source-map work | Add source maps for debugging | Out of scope for #60 |
| Trim `files` array | Add `.npmignore` | `files` is already an exact whitelist; redundant |
| No version bump here | Bump now | Bundled into the planned 0.8.0 release alongside #61 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)