### PR TITLE
ci(release): automate tag-triggered npm publish with git-cliff changelog (closes #61)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,74 @@
+name: Release
+
+# Triggers on a bare X.Y.Z tag push (jsfeatNext's tag convention -- never
+# vX.Y.Z, see MAINTAINERS.md), or manually via workflow_dispatch to retry a
+# failed publish without re-tagging.
+on:
+    push:
+        tags:
+            - "[0-9]+.[0-9]+.[0-9]+"
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Existing tag to (re-)publish, e.g. 0.8.0"
+                required: true
+
+permissions:
+    contents: write # to create the GitHub Release
+    id-token: write # for npm provenance
+
+jobs:
+    release:
+        runs-on: ubuntu-24.04
+
+        steps:
+            - name: Resolve tag
+              id: tag
+              run: echo "name=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+
+            - name: Checkout repository
+              uses: actions/checkout@v7
+              with:
+                  ref: ${{ steps.tag.outputs.name }}
+                  fetch-depth: 0 # full history: git-cliff needs every commit since the previous tag
+
+            - name: Use Node.js from .nvmrc
+              uses: actions/setup-node@v6
+              with:
+                  node-version-file: ".nvmrc"
+                  registry-url: "https://registry.npmjs.org"
+
+            - name: Install
+              run: npm ci
+
+            - name: Test
+              run: npm test
+
+            - name: Build (rebuild dist/ + types/ fresh from this tag's source)
+              run: npm run build-ts
+
+            - name: Inspect published package contents (informational, see #60)
+              run: npm pack --dry-run
+
+            - name: Generate release notes with git-cliff
+              uses: orhun/git-cliff-action@v4
+              id: changelog
+              with:
+                  config: cliff.toml
+                  args: --latest --strip header
+                  # ref is the tag, so --latest resolves to the range since
+                  # the previous tag automatically.
+                  output: release-notes.md
+
+            - name: Create GitHub Release
+              env:
+                  GH_TOKEN: ${{ github.token }}
+              run: |
+                  gh release create "${{ steps.tag.outputs.name }}" \
+                    --title "${{ steps.tag.outputs.name }}" \
+                    --notes-file release-notes.md
+
+            - name: Publish to npm
+              run: npm publish --provenance --access public
+              env:
+                  NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,85 @@
+# Maintainers Guide for jsfeatNext
+
+This document is intended for the core maintainers of the `webarkit/jsfeatNext` repository. It outlines review responsibilities and the exact steps required to publish a new release.
+
+## Current Maintainers
+
+- **Walter Perdan** ([@kalwalt](https://github.com/kalwalt)) - Creator & Lead Maintainer
+
+## 1. Code Review Mandates
+
+When reviewing Pull Requests, maintainers must ensure the following (see [`AGENTS.md`](AGENTS.md) for the full canonical rules):
+
+- **Target branch:** PRs must target `dev`, never `main`. `dev` is the integration branch; `main` is release-only and reflects the latest published version.
+- **Conventional Commits:** commit messages and PR titles follow `type(scope): summary` (`feat:`, `fix:`, `chore:`, `docs:`, `test:`, `refactor:`, `perf:`, `ci:`, `build:`). This is not just style — the release workflow's changelog generation (git-cliff) parses these to group release notes, so non-conforming commits get silently dropped from the changelog.
+- **Numeric/behavioral parity:** algorithm code must preserve parity with the original [jsfeat](https://github.com/inspirit/jsfeat). Any change touching `src/**` (excluding `tests/`) should keep `npm test` green (57+ characterization tests assert parity against a vendored jsfeat oracle).
+- **Typing:** avoid `any` in new code; the project runs `noImplicitAny: true`.
+- **No `.idea/`** (JetBrains IDE files) ever committed.
+- **Tag format:** release tags are bare `X.Y.Z` (e.g. `0.8.0`) — **never** `vX.Y.Z`. This has caused a real mixup before (see the 0.7.6 release) and the automated release workflow (below) only triggers on the bare pattern.
+
+## 2. Release Process
+
+Publishing a new version is a two-phase process: a **manual** phase you control (version bump, build, promotion to `main`), and an **automated** phase that takes over the moment you push the release tag.
+
+### Phase A — Manual: prepare the release
+
+1. **Pre-release checks.** Make sure `dev` is up to date and CI (`CI.yml`, `build.yml`) is green on the latest commit.
+2. **Bump the version.** Update `"version"` in `package.json`, then regenerate the lockfile:
+   ```bash
+   npm install
+   ```
+   > Regenerate the lockfile with **npm 11**, not an older local npm — an npm <11 install can omit other-platform optional native binaries (e.g. Vite/vitest's native deps) and produce a lockfile that fails `npm ci` in CI. Use `npx npm@11 install` if your local npm is older.
+3. **Rebuild the published artifacts.**
+   ```bash
+   npm run build-ts
+   ```
+   This regenerates `dist/jsfeatNext.js` (UMD), `dist/jsfeatNext.mjs` (ESM) and `types/`. All three are committed to the repo.
+4. **Commit and PR to `dev`.** Commit the version bump + rebuilt `dist/`/`types/` (Conventional Commit, e.g. `chore(release): bump version to X.Y.Z and rebuild dist`), push a branch, open a PR **against `dev`**, get it green, merge.
+5. **Promote `dev` to `main`.** Once `dev` has everything intended for the release:
+   ```bash
+   git checkout main
+   git pull origin main
+   git merge dev
+   git push origin main
+   ```
+   (`main` requires 1 approving review — either get a review or use the admin-bypass merge option if you are the sole maintainer.)
+
+### Phase B — Automated: tag, changelog, release, publish
+
+6. **Tag the release** on `main`, using the **bare** version number (no `v` prefix):
+   ```bash
+   git tag -a X.Y.Z -m "X.Y.Z"
+   git push origin X.Y.Z
+   ```
+   Pushing this tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml), which automatically:
+   - runs `npm ci`, `npm test`, `npm run build-ts` (rebuilds `dist/`/`types/` fresh from the tagged commit as a safety check — the workflow does **not** trust whatever happens to be committed)
+   - runs `npm pack --dry-run` and logs the resulting tarball contents/size (informational; see the packaging trim in #60)
+   - generates release notes from Conventional Commits with **[git-cliff](https://git-cliff.org/)** (config: [`cliff.toml`](cliff.toml)), covering everything since the previous tag
+   - creates the **GitHub Release** for the tag with those generated notes as the body
+   - runs `npm publish --provenance --access public`
+
+   You can watch it under the repo's **Actions** tab. If a step fails (e.g. a transient npm registry error during publish), you do **not** need to re-tag — re-run it manually via **Actions → Release → Run workflow**, entering the existing tag.
+
+7. **Verify.** Check:
+   - the new [GitHub Release](https://github.com/webarkit/jsfeatNext/releases) has sensible notes
+   - `npm view @webarkit/jsfeat-next version` shows the new version
+   - `npm view @webarkit/jsfeat-next dist-tags` shows `latest` pointing at it
+
+### Notes
+
+- **There is no committed `CHANGELOG.md`.** The GitHub Release page for each tag *is* the changelog — this avoids fighting `main`'s branch protection to auto-commit a file back to the repo. If you want to read the changelog for a specific version, look at its GitHub Release.
+- **Phase A is intentionally still manual.** The release workflow only automates from the tag onward; it does not bump versions or open PRs on its own. If full version-bump automation (a `release-please`-style bot PR) is ever wanted, that is a separate, bigger change — see [webarkit/jsfeatNext#61](https://github.com/webarkit/jsfeatNext/issues/61) for the discussion.
+
+## 3. One-Time Setup: `NPM_TOKEN`
+
+The release workflow needs an `NPM_TOKEN` repository secret to run `npm publish`. To set it up (only needs doing once, or when the token is rotated):
+
+1. On [npmjs.com](https://www.npmjs.com/), generate a **Granular Access Token** scoped to:
+   - **Packages:** `@webarkit/jsfeat-next` only (read + write / publish)
+   - **Expiration:** set a reasonable rotation window
+2. In the GitHub repo: **Settings → Secrets and variables → Actions → New repository secret**
+   - Name: `NPM_TOKEN`
+   - Value: the token from step 1
+3. Confirm the workflow has `permissions: id-token: write` (already set in `release.yml`) — required for npm provenance attestation.
+
+Without this secret, everything in Phase B runs successfully **except** the final `npm publish` step, which will fail with an auth error.

--- a/cliff.toml
+++ b/cliff.toml
@@ -19,7 +19,7 @@ body = """
     ## Unreleased
 {% endif %}\
 {% for group, commits in commits | group_by(attribute="group") %}
-    ### {{ group | upper_first }}
+    ### {{ group }}
     {% for commit in commits %}
         - {{ commit.message | upper_first | trim }} ({{ commit.id | truncate(length=7, end="") }})
     {% endfor %}
@@ -39,15 +39,16 @@ tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
 sort_commits = "oldest"
 
 commit_parsers = [
-    { message = "^feat", group = "Features" },
-    { message = "^fix", group = "Bug Fixes" },
-    { message = "^refactor", group = "Refactoring" },
-    { message = "^perf", group = "Performance" },
-    { message = "^doc", group = "Documentation" },
-    { message = "^test", group = "Testing" },
-    { message = "^build", group = "Build" },
-    { message = "^ci", group = "CI" },
+    { message = "^feat", group = "🚀 Features" },
+    { message = "^fix", group = "🐛 Bug Fixes" },
+    { message = "^refactor", group = "♻️ Refactoring" },
+    { message = "^perf", group = "⚡ Performance" },
+    { message = "^doc", group = "📚 Documentation" },
+    { message = "^style", group = "🎨 Style" },
+    { message = "^test", group = "🧪 Testing" },
+    { message = "^build", group = "📦 Build" },
+    { message = "^ci", group = "👷 CI" },
     { message = "^chore\\(release\\)", skip = true },
-    { message = "^chore", group = "Miscellaneous" },
-    { message = "^revert", group = "Reverted" },
+    { message = "^chore", group = "🧹 Miscellaneous" },
+    { message = "^revert", group = "⏪ Reverted" },
 ]

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,53 @@
+## Configuration for git-cliff (https://git-cliff.org/)
+##
+## Generates release notes / changelog entries from Conventional Commits
+## (already mandated project-wide, see AGENTS.md). Used by
+## .github/workflows/release.yml to build the GitHub Release body for each
+## tag, and locally via `npx git-cliff --latest` to preview it.
+
+[changelog]
+header = ""
+# NB: deliberately does NOT reference `commit.remote.*` -- that makes
+# git-cliff fetch commit metadata from the GitHub API, which is slow, can
+# hit rate limits in CI, and fails hard (not gracefully) without network
+# access. Commit subjects already read fine on their own since this repo's
+# Conventional Commits are written for humans.
+body = """
+{% if version %}\
+    ## {{ version | trim_start_matches(pat="v") }} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## Unreleased
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | upper_first }}
+    {% for commit in commits %}
+        - {{ commit.message | upper_first | trim }} ({{ commit.id | truncate(length=7, end="") }})
+    {% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+# jsfeatNext tags are bare X.Y.Z (never vX.Y.Z) -- see AGENTS.md / MAINTAINERS.md.
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = false
+filter_commits = false
+tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+sort_commits = "oldest"
+
+commit_parsers = [
+    { message = "^feat", group = "Features" },
+    { message = "^fix", group = "Bug Fixes" },
+    { message = "^refactor", group = "Refactoring" },
+    { message = "^perf", group = "Performance" },
+    { message = "^doc", group = "Documentation" },
+    { message = "^test", group = "Testing" },
+    { message = "^build", group = "Build" },
+    { message = "^ci", group = "CI" },
+    { message = "^chore\\(release\\)", skip = true },
+    { message = "^chore", group = "Miscellaneous" },
+    { message = "^revert", group = "Reverted" },
+]


### PR DESCRIPTION
Closes #61. Designed via `/brainstorming` — full understanding-lock and decision log below.

## What this adds
1. **`.github/workflows/release.yml`** — triggered by a bare `X.Y.Z` tag push (our convention, never `vX.Y.Z`) or `workflow_dispatch` (manual retry without re-tagging). Runs `npm ci` → `npm test` → `npm run build-ts` (rebuilds `dist/`+`types/` fresh from the tagged commit — a safety check, doesn't trust whatever's committed) → `npm pack --dry-run` (informational, ties into #60) → generates release notes via **git-cliff** → creates the GitHub Release → `npm publish --provenance --access public`.
2. **`cliff.toml`** — Conventional Commits parser config, bare `X.Y.Z` tag pattern, grouped changelog sections (Features/Bug Fixes/Refactoring/etc.).
3. **`MAINTAINERS.md`** — maintainer list, review mandates (from `AGENTS.md`), the full two-phase release runbook, and one-time `NPM_TOKEN` setup steps. Adapted from the [WebARKitLib-rs template](https://github.com/webarkit/WebARKitLib-rs/blob/main/MAINTAINERS.md) you linked, corrected for jsfeatNext's actual conventions.

## Scope (confirmed during brainstorming)
- **Automates only from the tag onward** (Phase B). Version bump, `dist/` rebuild-and-commit, and `dev`→`main` promotion stay manual — same control you have today, just no more manual changelog writing / GitHub Release creation / `npm publish`.
- **No `CHANGELOG.md` committed to the repo** — release notes live on the GitHub Release page only, avoiding branch-protection friction on `main` (which requires 1 review).
- **No `release-please`-style version-bump automation** — noted as a possible future addition, explicitly out of scope here.

## A real bug caught during local testing
My first `cliff.toml` draft used `commit.remote.*` for PR-number linking, which makes git-cliff fetch commit metadata from the GitHub API — and it **crashes hard** (not gracefully) without network access, rather than just skipping the links. Removed that entirely; commit subjects read fine on their own, and it's now been verified working locally against this repo's real history with `git-cliff` 2.13.1.

## ⚠️ Action required from @kalwalt before this can actually publish
The workflow needs an **`NPM_TOKEN`** repository secret (I can't create this myself — no access to npm credentials or repo secrets):
1. On npmjs.com, generate a **Granular Access Token** scoped to publish only `@webarkit/jsfeat-next`.
2. Add it as a repo secret named `NPM_TOKEN` (Settings → Secrets and variables → Actions).

Full steps are in `MAINTAINERS.md` §3. Everything else in the workflow (test, build, changelog, GitHub Release) runs and is useful without the token — only the final `npm publish` step needs it.

## Verification
- `release.yml` YAML syntax validated
- `cliff.toml` tested locally against real repo history — clean, correctly-grouped output, no crash
- `npm test` → 57/57
- `npm run build-ts` succeeds
- `prettier --check .` clean

## Decision log
| Decision | Alternative | Why |
|---|---|---|
| Tag push + `workflow_dispatch` fallback | Tag-only | Retry a failed publish without re-tagging |
| Automate Phase B only | Also automate version-bump PR (release-please) | Keeps your existing control over what becomes a release |
| GitHub Release notes only, no `CHANGELOG.md` | Auto-PR a CHANGELOG.md | Avoids branch-protection friction on `main` |
| `npm pack --dry-run` informational only | Hard-coded size threshold | Avoids a brittle baseline (YAGNI) |
| No `commit.remote.*` PR linking in cliff.toml | Keep PR-number links | Requires GitHub API network access; crashes hard without it |
| Add `MAINTAINERS.md` | Skip / rely on issues only | User request; durable runbook |

🤖 Generated with [Claude Code](https://claude.com/claude-code)