### PR TITLE
docs(readme): fix broken Twitter/X follow badge (closes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Dependabot Badge](https://flat.badgen.net/dependabot/@webarkit/jsfeat-next?icon=dependabot)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![CI](https://github.com/webarkit/jsfeatNext/actions/workflows/CI.yml/badge.svg)](https://github.com/webarkit/jsfeatNext/actions/workflows/CI.yml)
-![twitter](https://flat.badgen.net/twitter/follow/WebarkitO)
+[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/WebarkitO)](https://x.com/WebarkitO)
 
 # jsfeatNext 🚀
 


### PR DESCRIPTION
Closes #78.

badgen.net's Twitter integration has been broken since the X API lockdown, so the follow badge at the top of the README rendered empty. This switches to the shields.io equivalent and makes it a clickable link to the X profile (consistent with the CI and prettier badges).

```diff
-![twitter](https://flat.badgen.net/twitter/follow/WebarkitO)
+[![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/WebarkitO)](https://x.com/WebarkitO)
```

**Note on the URL:** the suggested fix in #78 used `/follow/:WebarkitO`. I verified against shields.io that the leading colon becomes part of the *displayed handle* (renders as "Follow @**:WebarkitO**"), so I used the colon-free `/follow/WebarkitO` which renders correctly as "Follow @WebarkitO". shields.io no longer shows a follower count (X API deprecation), so the badge is a plain "Follow @WebarkitO" button — still working and clickable, unlike the old broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)