### PR TITLE
refactor(types): replace all `any` in src with shared types/interfaces (closes #85)

### DIFF
--- a/src/cache/cache.ts
+++ b/src/cache/cache.ts
@@ -6,11 +6,11 @@ import _pool_node_t from "./../node_utils/_pool_node_t";
  */
 export interface ICache {
     /** Pre-allocates the pool with `capacity` nodes of `data_size` bytes each. */
-    allocate: (capacity: any, data_size: number) => void;
+    allocate: (capacity: number, data_size: number) => void;
     /** Borrows a node with at least `size_in_bytes` of storage from the pool. */
     get_buffer: (size_in_bytes: number) => _pool_node_t;
     /** Returns a previously borrowed node to the pool. */
-    put_buffer: (node: any) => void;
+    put_buffer: (node: _pool_node_t) => void;
 }
 
 /**
@@ -44,7 +44,7 @@ export class cache implements ICache {
      * @param capacity  Number of pool nodes to create.
      * @param data_size Initial byte size of each node's buffer.
      */
-    allocate(capacity: any, data_size: number): void {
+    allocate(capacity: number, data_size: number): void {
         this._pool_head = this._pool_tail = new _pool_node_t(data_size);
         for (let i = 0; i < capacity; ++i) {
             const node = new _pool_node_t(data_size);
@@ -82,7 +82,7 @@ export class cache implements ICache {
      *
      * @param node The node previously obtained from {@link get_buffer}.
      */
-    put_buffer(node: any): void {
+    put_buffer(node: _pool_node_t): void {
         this._pool_tail = this._pool_tail.next = node;
         this._pool_size++;
     }

--- a/src/fast_corners/fast_private.ts
+++ b/src/fast_corners/fast_private.ts
@@ -1,4 +1,5 @@
 // private functions
+import type { TypedArray } from "../types";
 
 /**
  * Computes the FAST-16 corner score for a candidate pixel: the largest
@@ -17,7 +18,7 @@
  * @returns The corner score (always ≥ `threshold` for detected corners).
  */
 export function _cmp_score_16(
-    src: Uint8Array,
+    src: TypedArray,
     off: number,
     pixel: Uint8Array | Int32Array,
     d: Uint8Array | Int32Array,

--- a/src/imgproc/convol.ts
+++ b/src/imgproc/convol.ts
@@ -1,3 +1,5 @@
+import type { TypedArray } from "../types";
+
 /**
  * Separable 2D convolution for `U8` images with an integer kernel — the
  * fixed-point fast path of `imgproc.gaussian_blur`. Runs a horizontal then a
@@ -15,8 +17,8 @@
  */
 export function _convol_u8(
     buf: Int32Array | Float32Array,
-    src_d: number[],
-    dst_d: number[],
+    src_d: TypedArray,
+    dst_d: TypedArray,
     w: number,
     h: number,
     filter: Int32Array | Float32Array,
@@ -138,8 +140,8 @@ export function _convol_u8(
  */
 export function _convol(
     buf: Int32Array | Float32Array,
-    src_d: number[],
-    dst_d: number[],
+    src_d: TypedArray,
+    dst_d: TypedArray,
     w: number,
     h: number,
     filter: Int32Array | Float32Array,

--- a/src/imgproc/imgproc.ts
+++ b/src/imgproc/imgproc.ts
@@ -695,7 +695,7 @@ export class imgproc extends jsfeatNext {
      * @param dst_sqsum  Output for squared-pixel sums, or falsy to skip.
      * @param dst_tilted Output for 45°-tilted sums, or falsy to skip.
      */
-    compute_integral_image(src: matrix_t, dst_sum: number[], dst_sqsum: number[], dst_tilted: any[]): void {
+    compute_integral_image(src: matrix_t, dst_sum: number[], dst_sqsum: number[], dst_tilted: number[]): void {
         const w0 = src.cols | 0,
             h0 = src.rows | 0,
             src_d = src.data;
@@ -1176,7 +1176,10 @@ export class imgproc extends jsfeatNext {
      * @param src RGBA image-like object (`width`, `height`, `data`).
      * @param dst Output array of per-pixel 0/255 values (length `w·h`).
      */
-    skindetector(src: { width: number; height: number; data: any[] }, dst: number[]): void {
+    skindetector(
+        src: { width: number; height: number; data: Uint8Array | Uint8ClampedArray | number[] },
+        dst: number[]
+    ): void {
         let r, g, b, j;
         let i = src.width * src.height;
         while (i--) {

--- a/src/linalg/linalg.ts
+++ b/src/linalg/linalg.ts
@@ -3,6 +3,7 @@ import { matrix_t } from "../matrix_t/matrix_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import { swap, hypot } from "./linalg_base";
 import matmath from "../matmath/matmath";
+import type { NumericArray } from "../types";
 
 /**
  * Dense linear-algebra solvers built on Jacobi rotations: LU and Cholesky
@@ -458,8 +459,8 @@ export class linalg extends jsfeatNext {
             k = 0,
             p = 1,
             astep = A.cols;
-        const ad = A.data,
-            bd = B.data;
+        const ad = A.data as NumericArray,
+            bd = B.data as NumericArray;
         let t, alpha, d, s;
 
         for (i = 0; i < astep; i++) {
@@ -602,7 +603,7 @@ export class linalg extends jsfeatNext {
      * @param options Bitmask of `SVD_U_T` / `SVD_V_T` to receive U and/or V
      *                already transposed (avoids an extra transpose).
      */
-    svd_decompose(A: any, W: matrix_t, U: matrix_t, V: matrix_t, options: number): void {
+    svd_decompose(A: matrix_t, W: matrix_t, U: matrix_t, V: matrix_t, options: number): void {
         if (typeof options === "undefined") {
             options = 0;
         }
@@ -642,7 +643,16 @@ export class linalg extends jsfeatNext {
             }
         }
 
-        this.JacobiSVDImpl(a_mt.data, m, w_mt.data, v_mt.data, n, m, n, m);
+        this.JacobiSVDImpl(
+            a_mt.data as NumericArray,
+            m,
+            w_mt.data as NumericArray,
+            v_mt.data as NumericArray,
+            n,
+            m,
+            n,
+            m
+        );
 
         if (W) {
             for (i = 0; i < n; i++) {
@@ -827,7 +837,14 @@ export class linalg extends jsfeatNext {
             a_mt.data[i] = A.data[i];
         }
 
-        this.JacobiImpl(a_mt.data, n, w_mt.data, vects ? vects.data : null, n, n);
+        this.JacobiImpl(
+            a_mt.data as NumericArray,
+            n,
+            w_mt.data as NumericArray,
+            vects ? (vects.data as NumericArray) : null,
+            n,
+            n
+        );
 
         if (vals) {
             while (--n >= 0) {

--- a/src/matrix_t/matrix_t.ts
+++ b/src/matrix_t/matrix_t.ts
@@ -1,6 +1,7 @@
 import { IData_Type, data_type } from "../data_type/data_type";
 import { data_t } from "../node_utils/data_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
+import type { TypedArray } from "../types";
 
 /**
  * Public shape of {@link matrix_t}: a 2D dense matrix (or image) backed by a
@@ -16,15 +17,15 @@ export interface IMatrix_T {
     /** Number of interleaved channels per element (1–4). */
     channel: number;
     /** The typed-array view holding the matrix elements, row-major. */
-    data: any;
+    data: TypedArray;
     /** The underlying {@link data_t} buffer that `data` is a view over. */
     buffer: data_t;
     /** (Re)allocates the backing buffer from the current cols/rows/channel/type. */
     allocate: () => void;
     /** Copies this matrix's elements into another matrix of at least equal size. */
-    copy_to: (other: any) => void;
+    copy_to: (other: IMatrix_T) => void;
     /** Changes the logical dimensions, reallocating only when the buffer is too small. */
-    resize: (c: number, r: number, ch: any) => void;
+    resize: (c: number, r: number, ch: number) => void;
 }
 
 /**
@@ -60,7 +61,7 @@ export class matrix_t implements IMatrix_T {
      * `Uint8Array`, `Int32Array`, `Float32Array` or `Float64Array`.
      * Element `(row, col, ch)` lives at index `(row * cols + col) * channel + ch`.
      */
-    public data: any;
+    public data: TypedArray;
     /** Raw backing storage; several views of it are exposed through {@link data}. */
     public buffer: data_t;
 

--- a/src/motion_estimator/motion_estimator.ts
+++ b/src/motion_estimator/motion_estimator.ts
@@ -6,6 +6,7 @@ import { ransac_params_t } from "./ransac_params_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import { homography2d } from "../motion_model/motion_model";
 import { math } from "../math/math";
+import type { MotionKernel, TypedArray } from "../types";
 
 /**
  * Robust motion-model estimation from noisy point correspondences via
@@ -35,7 +36,7 @@ export class motion_estimator extends jsfeatNext {
      * @returns `true` when a valid subset was found.
      */
     get_subset(
-        kernel: homography2d,
+        kernel: MotionKernel,
         from: point_t[],
         to: point_t[],
         need_cnt: number,
@@ -93,14 +94,14 @@ export class motion_estimator extends jsfeatNext {
      * @returns The number of inliers.
      */
     find_inliers(
-        kernel: homography2d,
+        kernel: MotionKernel,
         model: matrix_t,
         from: point_t[],
         to: point_t[],
         count: number,
         thresh: number,
         err: Int32Array | Float32Array,
-        mask: number[]
+        mask: TypedArray | number[]
     ): number {
         let numinliers: number = 0,
             i = 0,
@@ -134,7 +135,7 @@ export class motion_estimator extends jsfeatNext {
      */
     ransac(
         params: ransac_params_t,
-        kernel: any,
+        kernel: MotionKernel,
         from: point_t[],
         to: point_t[],
         count: number,
@@ -153,8 +154,8 @@ export class motion_estimator extends jsfeatNext {
             iter = 0;
         let result: boolean = false;
 
-        const subset0: any = [];
-        const subset1: any = [];
+        const subset0: point_t[] = [];
+        const subset1: point_t[] = [];
         let found = false;
 
         const mc = model.cols,
@@ -247,7 +248,7 @@ export class motion_estimator extends jsfeatNext {
      */
     lmeds(
         params: ransac_params_t,
-        kernel: any,
+        kernel: MotionKernel,
         from: point_t[],
         to: point_t[],
         count: number,
@@ -267,8 +268,8 @@ export class motion_estimator extends jsfeatNext {
         let result: boolean = false;
         const _math = new math();
 
-        const subset0: any = [];
-        const subset1: any = [];
+        const subset0: point_t[] = [];
+        const subset1: point_t[] = [];
         let found = false;
 
         const mc = model.cols,

--- a/src/motion_model/motion_model.ts
+++ b/src/motion_model/motion_model.ts
@@ -1,6 +1,7 @@
 import jsfeatNext from "../core/core";
 import { matrix_t } from "../matrix_t/matrix_t";
 import { point_t } from "../point_t/point_t";
+import type { TypedArray } from "../types";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import matmath from "../matmath/matmath";
 import { linalg } from "../linalg/linalg";
@@ -46,7 +47,7 @@ export class motion_model extends jsfeatNext {
      * @param T1    Output 3×3 transform (row-major array) for `to`.
      * @param count Number of points.
      */
-    iso_normalize_points(from: point_t[], to: point_t[], T0: number[], T1: number[], count: number): void {
+    iso_normalize_points(from: point_t[], to: point_t[], T0: TypedArray, T1: TypedArray, count: number): void {
         let i = 0;
         let cx0 = 0.0,
             cy0 = 0.0,

--- a/src/node_utils/_pool_node_t.ts
+++ b/src/node_utils/_pool_node_t.ts
@@ -13,13 +13,13 @@ export interface IPool_Node_T {
  */
 export default class _pool_node_t implements IPool_Node_T {
     /** Next node in the pool's linked list (`null` at the tail). */
-    public next: any;
+    public next: _pool_node_t | null;
     /** The wrapped storage object. */
     public data?: IData_T;
     /** Byte size of the current storage (aligned to a multiple of 8). */
     public size: number;
     /** The underlying `ArrayBuffer` (mirror of `data.buffer`). */
-    public buffer: any;
+    public buffer: ArrayBuffer;
     /** Unsigned 8-bit view (mirror of `data.u8`). */
     public u8: Uint8Array;
     /** Signed 32-bit integer view (mirror of `data.i32`). */

--- a/src/node_utils/data_t.ts
+++ b/src/node_utils/data_t.ts
@@ -41,14 +41,14 @@ export class data_t implements IData_T {
      * @param buffer        Optional existing buffer to wrap instead of
      *                      allocating (its length becomes {@link size}).
      */
-    constructor(size_in_bytes: number, buffer?: any) {
+    constructor(size_in_bytes: number, buffer?: ArrayBuffer) {
         // we need align size to multiple of 8
         this.size = ((size_in_bytes + 7) | 0) & -8;
         if (typeof buffer === "undefined") {
             this.buffer = new ArrayBuffer(this.size);
         } else {
             this.buffer = buffer;
-            this.size = buffer.length;
+            this.size = buffer.byteLength;
         }
         this.u8 = new Uint8Array(this.buffer);
         this.i32 = new Int32Array(this.buffer);

--- a/src/optical_flow_lk/optical_flow_lk.ts
+++ b/src/optical_flow_lk/optical_flow_lk.ts
@@ -15,7 +15,7 @@ import { imgproc } from "../imgproc/imgproc";
  */
 export class optical_flow_lk extends jsfeatNext {
     /** Bound `imgproc.scharr_derivatives`, used to build the gradient maps. */
-    public scharr_deriv: any;
+    public scharr_deriv: (src: matrix_t, dst: matrix_t) => void;
 
     constructor() {
         super();

--- a/src/pyramid_t/pyramid_t.ts
+++ b/src/pyramid_t/pyramid_t.ts
@@ -14,9 +14,9 @@ export class pyramid_t extends jsfeatNext {
     /** Number of pyramid levels. */
     public levels: number;
     /** The level images: `data[i]` is a {@link matrix_t} of size `w>>i` × `h>>i`. */
-    public data: any;
+    public data: matrix_t[];
     /** Bound `imgproc.pyrdown` used to build the levels. */
-    private pyrdown: any;
+    private pyrdown: (src: matrix_t, dst: matrix_t) => void;
 
     constructor(levels: number) {
         super();
@@ -56,7 +56,7 @@ export class pyramid_t extends jsfeatNext {
         // just copy data to first level
         let i = 2,
             a = input,
-            b: any = this.data[0];
+            b: matrix_t = this.data[0];
         if (!skip_first_level) {
             let j = input.cols * input.rows;
             while (--j >= 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,33 @@
+
+import type { matrix_t } from "./matrix_t/matrix_t";
+import type { point_t } from "./point_t/point_t";
+
+/**
+ * Every typed-array element storage the library uses. `matrix_t.data`, the
+ * cache-pool node views and the pyramid level buffers are always one of these
+ * four, selected by the packed type signature (`U8_t`/`S32_t`/`F32_t`/`F64_t`).
+ * Introduced for issue #85 to replace the scattered `any` on buffer payloads.
+ */
+export type TypedArray = Uint8Array | Int32Array | Float32Array | Float64Array;
+
+/**
+ * The non-`U8` numeric typed arrays. Used by the linear-algebra kernels, whose
+ * matrices are always `S32`/`F32`/`F64` — never `U8` — so their helpers accept
+ * this narrower union rather than the full {@link TypedArray}.
+ */
+export type NumericArray = Int32Array | Float32Array | Float64Array;
+
+/**
+ * The contract a motion-model kernel must satisfy to be used by
+ * `motion_estimator.ransac` / `.lmeds`. Implemented by {@link affine2d} and
+ * {@link homography2d} (both via their `motion_model` base). Introduced for
+ * issue #85 to replace `kernel: any` in `motion_estimator`.
+ */
+export interface MotionKernel {
+    /** Fits the model to `count` correspondences; returns the number of models produced (>0 on success). */
+    run(from: point_t[], to: point_t[], model: matrix_t, count: number): number;
+    /** Fills `err` with the per-correspondence transfer error under `model`. */
+    error(from: point_t[], to: point_t[], model: matrix_t, err: Int32Array | Float32Array, count: number): void;
+    /** Rejects degenerate minimal samples (e.g. collinear points); returns `true` when the subset is usable. */
+    check_subset(from: point_t[], to: point_t[], count: number): boolean;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,3 @@
-
 import type { matrix_t } from "./matrix_t/matrix_t";
 import type { point_t } from "./point_t/point_t";
 

--- a/src/yape/yape_utils.ts
+++ b/src/yape/yape_utils.ts
@@ -1,3 +1,5 @@
+import type { TypedArray } from "../types";
+
 /**
  * Precomputes the flat pixel offsets of a Bresenham-style circle of radius
  * `R` for an image with row stride `step`, walking the circle once around.
@@ -122,12 +124,12 @@ export function is_local_maxima(p: Int32Array, off: number, v: number, step: num
  * @param dirs_nb  Number of circle samples.
  */
 export function perform_one_point(
-    I: { [x: string]: number },
+    I: TypedArray,
     x: number,
     Scores: Int32Array,
     Im: number,
     Ip: number,
-    dirs: any[] | Int32Array,
+    dirs: number[] | Int32Array,
     opposite: number,
     dirs_nb: number
 ) {

--- a/src/yape06/yape06_utils.ts
+++ b/src/yape06/yape06_utils.ts
@@ -1,3 +1,5 @@
+import type { TypedArray } from "../types";
+
 /**
  * Computes a discrete Laplacian response map over a region of interest:
  * `dst[p] = -4·src[p] + src[p±Dxx] + src[p±Dyy]`. Out-of-bounds samples
@@ -12,7 +14,7 @@
  * @param ex  Region end x (exclusive). @param ey Region end y (exclusive).
  */
 export function compute_laplacian(
-    src: Int32Array | Float32Array,
+    src: TypedArray,
     dst: Int32Array | Float32Array,
     w: number,
     Dxx: number,
@@ -52,7 +54,7 @@ export function compute_laplacian(
  * @returns The smaller absolute eigenvalue of the local Hessian.
  */
 export function hessian_min_eigen_value(
-    src: number[],
+    src: TypedArray,
     off: number,
     tr: number,
     Dxx: number,


### PR DESCRIPTION
Closes #85. Removes every explicit `any` from `src/` (25 usages across ~9 modules), per the `AGENTS.md` convention. **Types-only — no runtime/behavioral change; the 63-test parity suite is unchanged.**

## New shared types (`src/types.ts`)
- **`TypedArray`** = `Uint8Array | Int32Array | Float32Array | Float64Array` — the buffer-payload union; replaces `any` on `matrix_t.data`, `pyramid_t` levels, and the convol/yape/yape06 helpers.
- **`NumericArray`** = `Int32Array | Float32Array | Float64Array` — the non-U8 union the linalg kernels use (they never operate on U8 matrices).
- **`MotionKernel`** interface (`run`/`error`/`check_subset`) — replaces `kernel: any` in `motion_estimator`, implemented by `affine2d`/`homography2d`. `get_subset`/`find_inliers` were over-narrowed to the concrete `homography2d`; widened to `MotionKernel` (they only use the interface).

## Other real types
- `_pool_node_t.next` → `_pool_node_t | null`, `.buffer` → `ArrayBuffer`; `cache.put_buffer(node: _pool_node_t)`, `cache.allocate(capacity: number)`.
- `matrix_t.copy_to(other: IMatrix_T)`, `resize(…, ch: number)`.
- `linalg.svd_decompose(A: matrix_t)`; `pyramid_t.data: matrix_t[]`; bound `pyrdown`/`scharr_deriv` typed as `(src: matrix_t, dst: matrix_t) => void`.
- `imgproc.compute_integral_image(dst_tilted: number[])`, `skindetector(src.data: Uint8Array | Uint8ClampedArray | number[])`.

## Notes for the reviewer
- Where widening `matrix_t.data` to `TypedArray` met linalg helpers that legitimately exclude U8, the fix is a **localized narrowing cast `… as NumericArray`** at 3 sites (lu_solve's `ad`/`bd`, the two Jacobi calls) — never `as any`.
- **Incidental latent-bug fix:** `data_t`'s optional 2nd `buffer` param was `any` and did `buffer.length` (an `ArrayBuffer` has `byteLength`, not `length` → the branch would set `size = undefined`). Typed as `ArrayBuffer`, corrected to `byteLength`. The branch is **provably unreachable** (no caller passes the 2nd arg), so zero behavioral effect — flagging explicitly.
- Design note: a couple of detector helpers (e.g. `_cmp_score_16`) were widened from a correct-narrow `Uint8Array` to the union rather than kept-narrow-plus-cast-at-callsite. Discussed and accepted as-is for now; revisit if it bites.

## Verification
`tsc --noEmit` clean · 0 remaining `any` in `src/` · `npm test` 63/63 · `npm run build-ts` succeeds · `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)