### PR TITLE
refactor(examples): convert 13 camera examples to ESM helpers (refs #79)

### DIFF
--- a/examples/sample_boxblur.html
+++ b/examples/sample_boxblur.html
@@ -21,135 +21,73 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
         <script type="text/javascript" src="js/dat.gui.min.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, renderMonoImage, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
+        const stat = new profiler();
+        const options = { radius: 3 };
+
+        const img_u8 = new jsfeatNext.matrix_t(WIDTH, HEIGHT, jsfeatNext.U8_t | jsfeatNext.C1_t);
+
+        function demo_app() {
+            ctx.fillStyle = 'rgb(0,255,0)';
+            ctx.strokeStyle = 'rgb(0,255,0)';
+
+            const gui = new dat.GUI();
+            gui.add(options, 'radius', 1, 21).step(1);
+
+            stat.add('grayscale');
+            stat.add('box blur');
+        }
+
+        function tick() {
+            requestAnimationFrame(tick);
+            stat.new_frame();
+
+            if (video.readyState === video.HAVE_ENOUGH_DATA) {
+                ctx.drawImage(video, 0, 0, WIDTH, HEIGHT);
+                const imageData = ctx.getImageData(0, 0, WIDTH, HEIGHT);
+
+                stat.start('grayscale');
+                jsfeatNext.imgproc.grayscale(imageData.data, WIDTH, HEIGHT, img_u8);
+                stat.stop('grayscale');
+
+                stat.start('box blur');
+                jsfeatNext.imgproc.box_blur_gray(img_u8, img_u8, options.radius | 0, 0);
+                stat.stop('box blur');
+
+                // render result back to canvas
+                const data_u32 = new Uint32Array(imageData.data.buffer);
+                renderMonoImage(img_u8.data, data_u32, WIDTH, HEIGHT, WIDTH);
+
+                ctx.putImageData(imageData, 0, 0);
+
+                log.innerHTML = stat.log();
             }
+        }
 
-            var stat = new profiler();
+        try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
 
-            var gui,options,ctx,canvasWidth,canvasHeight;
-            var img_u8;
-
-            var demo_opt = function(){
-                this.radius = 3;
-            }
-
-            function demo_app() {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
-                ctx.fillStyle = "rgb(0,255,0)";
-                ctx.strokeStyle = "rgb(0,255,0)";
-
-                img_u8 = new jsfeatNext.matrix_t(640, 480, jsfeatNext.U8_t | jsfeatNext.C1_t);
-
-                options = new demo_opt();
-                gui = new dat.GUI();
-
-                gui.add(options, 'radius', 1, 21).step(1);
-
-                stat.add("grayscale");
-                stat.add("box blur");
-            }
-
-            function tick(videoWidth, videoHeight) {
-                compatibility.requestAnimationFrame(tick);
-                stat.new_frame();
-                if (video.readyState === video.HAVE_ENOUGH_DATA) {
-                    ctx.drawImage(video, 0, 0, 640, 480);
-                    var imageData = ctx.getImageData(0, 0, 640, 480);
-
-                    stat.start("grayscale");
-                    jsfeatNext.imgproc.grayscale(imageData.data, 640, 480, img_u8);
-                    stat.stop("grayscale");
-
-                    var r = options.radius|0;
-
-                    stat.start("box blur");
-                    jsfeatNext.imgproc.box_blur_gray(img_u8, img_u8, r, 0);
-                    stat.stop("box blur");
-
-                    // render result back to canvas
-                    var data_u32 = new Uint32Array(imageData.data.buffer);
-                    var alpha = (0xff << 24);
-                    var i = img_u8.cols*img_u8.rows, pix = 0;
-                    while(--i >= 0) {
-                        pix = img_u8.data[i];
-                        data_u32[i] = alpha | (pix << 16) | (pix << 8) | pix;
-                    }
-
-                    ctx.putImageData(imageData, 0, 0);
-
-                    $('#log').html(stat.log());
-                }
-            }
-
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_canny_edge.html
+++ b/examples/sample_canny_edge.html
@@ -20,73 +20,24 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
         <script type="text/javascript" src="js/dat.gui.min.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var gui,options,ctx,canvasWidth,canvasHeight;
+            let gui, options;
             var img_u8;
 
             var demo_opt = function(){
@@ -96,10 +47,6 @@
             }
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -118,7 +65,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -150,15 +97,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_equalize_hist.html
+++ b/examples/sample_equalize_hist.html
@@ -20,79 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -103,7 +49,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -128,15 +74,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_gaussblur.html
+++ b/examples/sample_gaussblur.html
@@ -20,73 +20,24 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
         <script type="text/javascript" src="js/dat.gui.min.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var gui,options,ctx,canvasWidth,canvasHeight;
+            let gui, options;
             var img_u8;
 
             var demo_opt = function(){
@@ -95,10 +46,6 @@
             }
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -115,7 +62,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -143,15 +90,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_oflow_lk.html
+++ b/examples/sample_oflow_lk.html
@@ -23,73 +23,24 @@
         <div id="log" class="alert alert-info"></div>
     </div>
 
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <script src="../dist/jsfeatNext.js"></script>
-    <script type="text/javascript" src="js/compatibility.js"></script>
-    <script type="text/javascript" src="js/profiler.js"></script>
     <script type="text/javascript" src="js/dat.gui.min.js"></script>
-    <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function (event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function () {
-                    if (video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if (attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function (width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({ video: true }, function (stream) {
-                    if (video.srcObject !== undefined) {
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function () {
-                        video.play();
-                    }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var gui, options, ctx, canvasWidth, canvasHeight;
+            let gui, options;
             var curr_img_pyr, prev_img_pyr, point_count, point_status, prev_xy, curr_xy;
 
             var demo_opt = function () {
@@ -100,10 +51,6 @@
             }
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -131,7 +78,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -159,13 +106,13 @@
 
                     prune_oflow_points(ctx);
 
-                    $('#log').html(stat.log() + '<br/>click to add tracking points: ' + point_count);
+                    log.innerHTML = stat.log() + '<br/>click to add tracking points: ' + point_count;
                 }
             }
 
             function on_canvas_click(e) {
                 var coords = canvas.relMouseCoords(e);
-                if (coords.x > 0 & coords.y > 0 & coords.x < canvasWidth & coords.y < canvasHeight) {
+                if (coords.x > 0 & coords.y > 0 & coords.x < WIDTH & coords.y < HEIGHT) {
                     curr_xy[point_count << 1] = coords.x;
                     curr_xy[(point_count << 1) + 1] = coords.y;
                     point_count++;
@@ -213,11 +160,16 @@
             }
             HTMLCanvasElement.prototype.relMouseCoords = relMouseCoords;
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
     </script>
 </body>
 

--- a/examples/sample_pyrdown.html
+++ b/examples/sample_pyrdown.html
@@ -20,79 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-            $(window).on('load', function () {
-            "use strict";
+            import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, renderMonoImage, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_pyr;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -104,7 +50,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -128,30 +74,26 @@
                     // render result back to canvas
                     var data_u32 = new Uint32Array(imageData.data.buffer);
                     for(i=0; i < img_pyr.levels; ++i){
-                        render_mono_image(img_pyr.data[i].data, data_u32, img_pyr.data[i].cols, img_pyr.data[i].rows, 640);
+                        renderMonoImage(img_pyr.data[i].data, data_u32, img_pyr.data[i].cols, img_pyr.data[i].rows, 640);
                     }
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            function render_mono_image(src, dst, sw, sh, dw) {
-                var alpha = (0xff << 24);
-                for(var i = 0; i < sh; ++i) {
-                    for(var j = 0; j < sw; ++j) {
-                        var pix = src[i*sw+j];
-                        dst[i*dw+j] = alpha | (pix << 16) | (pix << 8) | pix;
-                    }
-                }
-            }
+            
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_scharr.html
+++ b/examples/sample_scharr.html
@@ -20,79 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8,img_gxgy;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -104,7 +50,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -131,15 +77,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_sobel.html
+++ b/examples/sample_sobel.html
@@ -21,79 +21,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-            <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-            <script src="../dist/jsfeatNext.js"></script>
-            <script type="text/javascript" src="js/compatibility.js"></script>
-            <script type="text/javascript" src="js/profiler.js"></script>
-            <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8,img_gxgy;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -105,7 +51,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -132,15 +78,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_sobel_edge.html
+++ b/examples/sample_sobel_edge.html
@@ -20,81 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-            <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-            <script src="../dist/jsfeatNext.js"></script>
-            <script type="text/javascript" src="js/compatibility.js"></script>
-            <script type="text/javascript" src="js/profiler.js"></script>
-            <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            var jsfeat = jsfeatNext;
-            var imgproc = jsfeat.imgproc;
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8,img_gxgy,img_mag;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -109,7 +53,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -204,15 +148,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_warp_affine.html
+++ b/examples/sample_warp_affine.html
@@ -20,78 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8, img_u8_warp,mat_affine;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -111,7 +58,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -136,15 +83,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_warp_perspective.html
+++ b/examples/sample_warp_perspective.html
@@ -20,79 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8, img_u8_warp, transform;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -111,7 +57,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -136,15 +82,20 @@
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
+
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_yape.html
+++ b/examples/sample_yape.html
@@ -20,79 +20,25 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-        $(window).on('load', function () {
-            "use strict";
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, renderCorners, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var ctx,canvasWidth,canvasHeight;
             var img_u8, corners;
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -105,7 +51,7 @@
                 }
 
                 // YAPE detector needs init first
-                jsfeatNext.yape.init(canvasWidth, canvasHeight, 5, 1);
+                jsfeatNext.yape.init(WIDTH, HEIGHT, 5, 1);
 
                 stat.add("grayscale");
                 stat.add("box blur");
@@ -113,7 +59,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -133,34 +79,25 @@
 
                     // render result back to canvas
                     var data_u32 = new Uint32Array(imageData.data.buffer);
-                    render_corners(corners, count, data_u32, 640);
+                    renderCorners(corners, count, data_u32, 640);
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            function render_corners(corners, count, img, step) {
-                var pix = (0xff << 24) | (0x00 << 16) | (0xff << 8) | 0x00;
-                for(var i=0; i < count; ++i)
-                {
-                    var x = corners[i].x;
-                    var y = corners[i].y;
-                    var off = (x + y * step);
-                    img[off] = pix;
-                    img[off-1] = pix;
-                    img[off+1] = pix;
-                    img[off-step] = pix;
-                    img[off+step] = pix;
-                }
-            }
+            
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>

--- a/examples/sample_yape06.html
+++ b/examples/sample_yape06.html
@@ -20,73 +20,24 @@
                 <div id="log" class="alert alert-info"></div>
             </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
         <script type="text/javascript" src="js/dat.gui.min.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
 
-    $(window).on('load', function () {
-            "use strict";
+    import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, renderCorners, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            try {
-                var attempts = 0;
-                var readyListener = function(event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function() {
-                    if(video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if(attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function(width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({video: true}, function(stream) {
-                    if(video.srcObject !== undefined){
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function() {
-                            video.play();
-                        }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        const stat = new profiler();
 
-            var stat = new profiler();
-
-            var gui,options,ctx,canvasWidth,canvasHeight;
+            let gui, options;
             var img_u8, corners;
 
             var demo_opt = function(){
@@ -95,10 +46,6 @@
             }
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth  = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -122,7 +69,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -145,34 +92,25 @@
 
                     // render result back to canvas
                     var data_u32 = new Uint32Array(imageData.data.buffer);
-                    render_corners(corners, count, data_u32, 640);
+                    renderCorners(corners, count, data_u32, 640);
 
                     ctx.putImageData(imageData, 0, 0);
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
-            function render_corners(corners, count, img, step) {
-                var pix = (0xff << 24) | (0x00 << 16) | (0xff << 8) | 0x00;
-                for(var i=0; i < count; ++i)
-                {
-                    var x = corners[i].x;
-                    var y = corners[i].y;
-                    var off = (x + y * step);
-                    img[off] = pix;
-                    img[off-1] = pix;
-                    img[off+1] = pix;
-                    img[off-step] = pix;
-                    img[off+step] = pix;
-                }
-            }
+            
+            try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
 
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+        window.addEventListener('unload', () => stopCamera(video));
         </script>
     </body>
 </html>


### PR DESCRIPTION
**Phase 2 of #79** — applies the helper API validated in phase 1 (#98) to the simple and medium tiers: **13 of the remaining 15** camera examples.

## Converted
| Tier | Files |
|---|---|
| simple | `boxblur`, `canny_edge`, `equalize_hist`, `gaussblur`, `scharr`, `sobel`, `warp_affine`, `warp_perspective` |
| medium | `oflow_lk`, `pyrdown`, `sobel_edge`, `yape`, `yape06` |

Each now uses `<script type="module">` + `import jsfeatNext from '../dist/jsfeatNext.mjs'`, with `loadCamera()` / `stopCamera()` / `showCameraError()` from `demo-utils.mjs` and the profiler via `profiler.mjs`. **jQuery and `js/compatibility.js` are gone from all of them**, and the inline grayscale→RGBA loops plus the duplicated `render_corners` / `render_mono_image` functions are replaced by the shared `renderMonoImage()` / `renderCorners()`.

### **−684 net lines** (364 insertions, 1048 deletions) — all boilerplate.

## ⚠️ A bug caught during conversion
The mechanical pass initially left `var ctx, canvasWidth, canvasHeight;` in 10 files. That would have **shadowed the module-level `ctx` with `undefined`** and left `canvasWidth`/`canvasHeight` undefined — and `sample_yape.html` passes those straight into `jsfeatNext.yape.init(...)`, while `sample_oflow_lk.html` uses them for its click bounds-check (clicking would have silently added no tracking points). Fixed by removing the stale declarations and mapping the two variables to the `WIDTH`/`HEIGHT` constants (the canvas is 640×480, so they're identical).

## Not in this batch — deliberately
`sample_orb.html` (556 lines) and `sample_orb_pinball.html` (586) have four render helpers each plus pattern-training logic — a different risk profile. They get their own focused PR to finish #79.

## Verification
- Built a temporary iframe harness that loaded **all 15 ESM examples** (these 13 + the 2 pilots) and collected errors: every one has a module script, **zero jQuery, zero compatibility shim, zero non-camera errors**. Harness removed afterwards.
- Prettier clean.
- **All 13 confirmed working with a real webcam by @kalwalt**, including `oflow_lk`'s click-to-add-points and its custom log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)