### PR TITLE
refactor(examples): convert the two ORB examples to ESM, restructure README (refs #79)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,32 +74,58 @@ npm install @webarkit/jsfeat-next
 
 ## Examples 🧪
 
-Go in the `examples` folder to test some of them (build first, then open the `.html` files in a browser).
+The `examples` folder demonstrates **both ways of consuming the library**. Build first (`npm run build-ts`), then open the examples in a browser.
 
-working = ✔️ not working = ⚠️
+### ESM examples — `import` from `dist/jsfeatNext.mjs`
 
-- browser.html ✔️
-- grayscale.html ✔️
-- linalg_example.html ✔️
-- mat_math_example.html ✔️
-- matrix_t_example.html ✔️
-- orb_test.html ✔️
-- sample_boxblur.html ✔️
-- sample_canny_edge.html ✔️
-- sample_equalize_hist.html ✔️
-- sample_fast_corners.html ✔️
-- sample_gaussblur.html ✔️
-- sample_oflow_lk.html ✔️
-- sample_orb.html ✔️
-- sample_orb_pinball.html ✔️
-- sample_pyrdown.html ✔️
-- sample_scharr.html ✔️
-- sample_sobel_edge.html ✔️
-- sample_sobel.html ✔️
-- sample_warp_affine.html ✔️
-- sample_warp_perspective.html ✔️
-- sample_yape.html ✔️
-- sample_yape06.html ✔️
+The camera demos use the modern ES-module entry point:
+
+```html
+<script type="module">
+    import jsfeatNext from '../dist/jsfeatNext.mjs';
+    jsfeatNext.imgproc.grayscale(...);
+</script>
+```
+
+> ⚠️ **These must be served over HTTP** — ES modules don't load from `file://`. Run a static server from the repo root, e.g. `npx serve .`, then browse to `http://localhost:3000/examples/…`.
+
+They share the helpers in [`examples/js/demo-utils.mjs`](examples/js/demo-utils.mjs) (webcam setup and canvas drawing) instead of repeating that boilerplate in every file.
+
+| Example | Demonstrates |
+|---|---|
+| `grayscale.html` | color → grayscale conversion |
+| `sample_boxblur.html` | box blur |
+| `sample_gaussblur.html` | gaussian blur |
+| `sample_equalize_hist.html` | histogram equalization |
+| `sample_canny_edge.html` | Canny edge detector |
+| `sample_sobel.html` / `sample_sobel_edge.html` | Sobel derivatives / edges |
+| `sample_scharr.html` | Scharr derivatives |
+| `sample_pyrdown.html` | image pyramid downsampling |
+| `sample_fast_corners.html` | FAST corner detector |
+| `sample_yape.html` / `sample_yape06.html` | YAPE / YAPE06 detectors |
+| `sample_oflow_lk.html` | Lucas–Kanade optical flow (click to add points) |
+| `sample_orb.html` | ORB descriptors + matching + homography |
+| `sample_orb_pinball.html` | ORB pattern tracking on a reference image |
+| `sample_warp_affine.html` / `sample_warp_perspective.html` | affine / perspective warps |
+
+### UMD examples — global `<script>` tag
+
+These small API demos load the UMD bundle and use the `jsfeatNext` global. They need no server and **open directly from the filesystem**:
+
+```html
+<script src="../dist/jsfeatNext.js"></script>
+<script>
+    const m = new jsfeatNext.matrix_t(320, 240, jsfeatNext.U8_t | jsfeatNext.C1_t);
+</script>
+```
+
+| Example | Demonstrates |
+|---|---|
+| `browser.html` | version, constants, `matrix_t`, `keypoint_t`, the shared `cache` |
+| `matrix_t_example.html` | constructing a `matrix_t` |
+| `mat_math_example.html` | `matmath` (3×3 identity) |
+| `linalg_example.html` | `linalg` (SVD pseudo-inverse) |
+| `orb_test.html` | `orb.describe` |
 
 ## TypeScript examples 📝
 

--- a/examples/sample_orb.html
+++ b/examples/sample_orb.html
@@ -23,76 +23,29 @@
         <div id="log" class="alert alert-info"></div>
     </div>
 
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-    <script src="../dist/jsfeatNext.js"></script>
-    <script type="text/javascript" src="js/compatibility.js"></script>
-    <script type="text/javascript" src="js/profiler.js"></script>
     <script type="text/javascript" src="js/dat.gui.min.js"></script>
-    <script>
-        $(window).on('load', function () {
-            "use strict";
+    <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+    <script type="module">
+        import jsfeatNext from '../dist/jsfeatNext.mjs';
+        import { loadCamera, stopCamera, renderCorners, renderMonoImage, showCameraError } from './js/demo-utils.mjs';
+        import { profiler } from './js/profiler.mjs';
 
-            // lets do some fun
-            var video = document.getElementById('webcam');
-            var canvas = document.getElementById('canvas');
-            var jsfeat = jsfeatNext;
-            var imgproc = jsfeat.imgproc;
-            var orb = jsfeat.orb;
-            var math = jsfeat.math;
-            var yape06 = jsfeat.yape06;
-            var motion_estimator = jsfeat.motion_estimator;
-            var homography2d = jsfeat.homography2d;
-            var matmath = jsfeat.matmath;
-            try {
-                var attempts = 0;
-                var readyListener = function (event) {
-                    findVideoSize();
-                };
-                var findVideoSize = function () {
-                    if (video.videoWidth > 0 && video.videoHeight > 0) {
-                        video.removeEventListener('loadeddata', readyListener);
-                        onDimensionsReady(video.videoWidth, video.videoHeight);
-                    } else {
-                        if (attempts < 10) {
-                            attempts++;
-                            setTimeout(findVideoSize, 200);
-                        } else {
-                            onDimensionsReady(640, 480);
-                        }
-                    }
-                };
-                var onDimensionsReady = function (width, height) {
-                    demo_app(width, height);
-                    compatibility.requestAnimationFrame(tick);
-                };
+        const WIDTH = 640, HEIGHT = 480;
 
-                video.addEventListener('loadeddata', readyListener);
+        const video = document.getElementById('webcam');
+        const canvas = document.getElementById('canvas');
+        const log = document.getElementById('log');
+        const ctx = canvas.getContext('2d', { willReadFrequently: true });
 
-                compatibility.getUserMedia({ video: true }, function (stream) {
-                    if (video.srcObject !== undefined) {
-                        video.srcObject = stream
-                    } else {
-                        try {
-                            video.src = compatibility.URL.createObjectURL(stream);
-                        } catch (error) {
-                            video.src = stream;
-                        }
-                    }
-                    setTimeout(function () {
-                        video.play();
-                    }, 500);
-                }, function (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                    $('#no_rtc').show();
-                });
-            } catch (error) {
-                $('#canvas').hide();
-                $('#log').hide();
-                $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                $('#no_rtc').show();
-            }
+        // module aliases kept so the algorithm code below reads unchanged
+        const jsfeat = jsfeatNext;
+        const imgproc = jsfeat.imgproc;
+        const orb = jsfeat.orb;
+        const math = jsfeat.math;
+        const yape06 = jsfeat.yape06;
+        const motion_estimator = jsfeat.motion_estimator;
+        const homography2d = jsfeat.homography2d;
+        const matmath = jsfeat.matmath;
 
             var stat = new profiler();
 
@@ -111,8 +64,7 @@
                 }
                 return match_t;
             })();
-
-            var gui, options, ctx, canvasWidth, canvasHeight;
+            var gui, options;
             var img_u8, img_u8_smooth, screen_corners, num_corners, screen_descriptors;
             var pattern_corners, pattern_descriptors, pattern_preview;
             var matches, homo3x3, match_mask;
@@ -200,10 +152,6 @@
             }
 
             function demo_app(videoWidth, videoHeight) {
-                canvasWidth = canvas.width;
-                canvasHeight = canvas.height;
-                ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                 ctx.fillStyle = "rgb(0,255,0)";
                 ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -245,7 +193,7 @@
             }
 
             function tick() {
-                compatibility.requestAnimationFrame(tick);
+                requestAnimationFrame(tick);
                 stat.new_frame();
                 if (video.readyState === video.HAVE_ENOUGH_DATA) {
                     ctx.drawImage(video, 0, 0, 640, 480);
@@ -272,13 +220,13 @@
 
                     // render result back to canvas
                     var data_u32 = new Uint32Array(imageData.data.buffer);
-                    render_corners(screen_corners, num_corners, data_u32, 640);
+                    renderCorners(screen_corners, num_corners, data_u32, 640);
 
                     // render pattern and matches
                     var num_matches = 0;
                     var good_matches = 0;
                     if (pattern_preview) {
-                        render_mono_image(pattern_preview.data, data_u32, pattern_preview.cols, pattern_preview.rows, 640);
+                        renderMonoImage(pattern_preview.data, data_u32, pattern_preview.cols, pattern_preview.rows, 640);
                         stat.start("matching");
                         num_matches = match_pattern();
                         good_matches = find_transform(matches, num_matches);
@@ -293,7 +241,7 @@
                             render_pattern_shape(ctx);
                     }
 
-                    $('#log').html(stat.log());
+                    log.innerHTML = stat.log();
                 }
             }
 
@@ -521,36 +469,16 @@
                 ctx.lineWidth = 4;
                 ctx.stroke();
             }
+        try {
+            await loadCamera(video);
+            demo_app();
+            requestAnimationFrame(tick);
+        } catch (error) {
+            showCameraError();
+            console.error(error);
+        }
 
-            function render_corners(corners, count, img, step) {
-                var pix = (0xff << 24) | (0x00 << 16) | (0xff << 8) | 0x00;
-                for (var i = 0; i < count; ++i) {
-                    var x = corners[i].x;
-                    var y = corners[i].y;
-                    var off = (x + y * step);
-                    img[off] = pix;
-                    img[off - 1] = pix;
-                    img[off + 1] = pix;
-                    img[off - step] = pix;
-                    img[off + step] = pix;
-                }
-            }
-
-            function render_mono_image(src, dst, sw, sh, dw) {
-                var alpha = (0xff << 24);
-                for (var i = 0; i < sh; ++i) {
-                    for (var j = 0; j < sw; ++j) {
-                        var pix = src[i * sw + j];
-                        dst[i * dw + j] = alpha | (pix << 16) | (pix << 8) | pix;
-                    }
-                }
-            }
-
-            $(window).on('unload', function () {
-                video.pause();
-                video.src = null;
-            });
-        });
+        window.addEventListener("unload", () => stopCamera(video));
     </script>
 </body>
 

--- a/examples/sample_orb_pinball.html
+++ b/examples/sample_orb_pinball.html
@@ -23,93 +23,53 @@
         <div id="log" class="alert alert-info"></div>
     </div>
     <canvas id="myCanvas" style="border:1px solid #d3d3d3;">
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
-        <script src="../dist/jsfeatNext.js"></script>
-        <script type="text/javascript" src="js/compatibility.js"></script>
-        <script type="text/javascript" src="js/profiler.js"></script>
         <script type="text/javascript" src="js/dat.gui.min.js"></script>
-        <script type="text/javascript">
+        <!-- ES module example: serve over http:// (e.g. `npx serve .`), not file:// -->
+        <script type="module">
+            import jsfeatNext from '../dist/jsfeatNext.mjs';
+            import { loadCamera, stopCamera, renderCorners, renderMonoImage, showCameraError } from './js/demo-utils.mjs';
+            import { profiler } from './js/profiler.mjs';
 
-            var image = new Image();
+            const WIDTH = 640, HEIGHT = 480;
+
+            const video = document.getElementById('webcam');
+            const canvas = document.getElementById('canvas');
+            const log = document.getElementById('log');
+            const ctx = canvas.getContext('2d', { willReadFrequently: true });
+
+            // The reference pattern is a static image: draw it into #myCanvas
+            // (hidden), then train on it once the camera demo is initialised.
+            const image = new Image();
             image.src = "img/pinball.jpg";
             var new_corners, options;
 
-            window.onload = function () {
+            window.addEventListener('load', function () {
                 var c = document.getElementById("myCanvas");
                 var ctxx = c.getContext("2d");
-                cols = image.width;
-                rows = image.height;
+                // NB: these were implicit globals in the old sloppy-mode script;
+                // ES modules are strict mode, so they must be declared.
+                const cols = image.width;
+                const rows = image.height;
                 c.width = cols;
                 c.height = rows;
                 ctxx.drawImage(image, 0, 0, image.width, image.height);
-                $('#myCanvas').hide();
-                setTimeout(function () { options.train_pattern(); }, 2000);
-            };
+                c.style.display = 'none';
+                // `options` is created by demo_app(), which only runs once the
+                // camera is up; guard so a denied/slow camera doesn't throw here.
+                setTimeout(function () {
+                    if (options) options.train_pattern();
+                }, 2000);
+            });
 
-            $(window).on('load', function () {
-                "use strict";
-
-                // lets do some fun
-                var video = document.getElementById('webcam');
-                var canvas = document.getElementById('canvas');
-                var jsfeat = jsfeatNext;
-                var imgproc = jsfeat.imgproc;
-                var orb = jsfeat.orb;
-                var math = jsfeat.math;
-                var yape06 = jsfeat.yape06;
-                var motion_estimator = jsfeat.motion_estimator;
-                var homography2d = jsfeat.homography2d;
-                var matmath = jsfeat.matmath;
-                try {
-                    var attempts = 0;
-                    var readyListener = function (event) {
-                        findVideoSize();
-                    };
-                    var findVideoSize = function () {
-                        if (video.videoWidth > 0 && video.videoHeight > 0) {
-                            video.removeEventListener('loadeddata', readyListener);
-                            onDimensionsReady(video.videoWidth, video.videoHeight);
-                        } else {
-                            if (attempts < 10) {
-                                attempts++;
-                                setTimeout(findVideoSize, 200);
-                            } else {
-                                onDimensionsReady(640, 480);
-                            }
-                        }
-                    };
-                    var onDimensionsReady = function (width, height) {
-                        demo_app(width, height);
-                        compatibility.requestAnimationFrame(tick);
-                    };
-
-                    video.addEventListener('loadeddata', readyListener);
-
-                    compatibility.getUserMedia({ video: true }, function (stream) {
-                        if (video.srcObject !== undefined) {
-                            video.srcObject = stream
-                        } else {
-                            try {
-                                video.src = compatibility.URL.createObjectURL(stream);
-                            } catch (error) {
-                                video.src = stream;
-                            }
-                        }
-                        setTimeout(function () {
-                            video.play();
-                        }, 500);
-                    }, function (error) {
-                        $('#canvas').hide();
-                        $('#log').hide();
-                        $('#no_rtc').html('<h4>WebRTC not available.</h4>');
-                        $('#no_rtc').show();
-                    });
-                } catch (error) {
-                    $('#canvas').hide();
-                    $('#log').hide();
-                    $('#no_rtc').html('<h4>Something goes wrong...</h4>');
-                    $('#no_rtc').show();
-                }
+            // module aliases kept so the algorithm code below reads unchanged
+            const jsfeat = jsfeatNext;
+            const imgproc = jsfeat.imgproc;
+            const orb = jsfeat.orb;
+            const math = jsfeat.math;
+            const yape06 = jsfeat.yape06;
+            const motion_estimator = jsfeat.motion_estimator;
+            const homography2d = jsfeat.homography2d;
+            const matmath = jsfeat.matmath;
 
                 var stat = new profiler();
 
@@ -128,8 +88,7 @@
                     }
                     return match_t;
                 })();
-
-                var gui, ctx, canvasWidth, canvasHeight;
+                var gui;
                 var img_u8, img_u8_smooth, screen_corners, num_corners, screen_descriptors;
                 var pattern_corners, pattern_descriptors, pattern_preview;
                 var matches, homo3x3, match_mask;
@@ -226,10 +185,6 @@
                 }
 
                 function demo_app(videoWidth, videoHeight) {
-                    canvasWidth = canvas.width;
-                    canvasHeight = canvas.height;
-                    ctx = canvas.getContext('2d', {"willReadFrequently": true});
-
                     ctx.fillStyle = "rgb(0,255,0)";
                     ctx.strokeStyle = "rgb(0,255,0)";
 
@@ -271,7 +226,7 @@
                 }
 
                 function tick() {
-                    compatibility.requestAnimationFrame(tick);
+                    requestAnimationFrame(tick);
                     stat.new_frame();
                     if (video.readyState === video.HAVE_ENOUGH_DATA) {
                         ctx.drawImage(video, 0, 0, 640, 480);
@@ -298,13 +253,13 @@
 
                         // render result back to canvas
                         var data_u32 = new Uint32Array(imageData.data.buffer);
-                        render_corners(screen_corners, num_corners, data_u32, 640);
+                        renderCorners(screen_corners, num_corners, data_u32, 640);
 
                         // render pattern and matches
                         var num_matches = 0;
                         var good_matches = 0;
                         if (pattern_preview) {
-                            render_mono_image(pattern_preview.data, data_u32, pattern_preview.cols, pattern_preview.rows, 640);
+                            renderMonoImage(pattern_preview.data, data_u32, pattern_preview.cols, pattern_preview.rows, 640);
                             stat.start("matching");
                             num_matches = match_pattern();
                             good_matches = find_transform(matches, num_matches);
@@ -322,7 +277,7 @@
                                 render_pattern_shape(ctx);
                         }
 
-                        $('#log').html(stat.log());
+                        log.innerHTML = stat.log();
                     }
                 }
 
@@ -551,36 +506,16 @@
                     ctx.lineWidth = 4;
                     ctx.stroke();
                 }
+            try {
+                await loadCamera(video);
+                demo_app();
+                requestAnimationFrame(tick);
+            } catch (error) {
+                showCameraError();
+                console.error(error);
+            }
 
-                function render_corners(corners, count, img, step) {
-                    var pix = (0xff << 24) | (0x00 << 16) | (0xff << 8) | 0x00;
-                    for (var i = 0; i < count; ++i) {
-                        var x = corners[i].x;
-                        var y = corners[i].y;
-                        var off = (x + y * step);
-                        img[off] = pix;
-                        img[off - 1] = pix;
-                        img[off + 1] = pix;
-                        img[off - step] = pix;
-                        img[off + step] = pix;
-                    }
-                }
-
-                function render_mono_image(src, dst, sw, sh, dw) {
-                    var alpha = (0xff << 24);
-                    for (var i = 0; i < sh; ++i) {
-                        for (var j = 0; j < sw; ++j) {
-                            var pix = src[i * sw + j];
-                            dst[i * dw + j] = alpha | (pix << 16) | (pix << 8) | pix;
-                        }
-                    }
-                }
-
-                $(window).on('unload', function () {
-                    video.pause();
-                    video.src = null;
-                });
-            });
+            window.addEventListener("unload", () => stopCamera(video));
         </script>
 </body>
 


### PR DESCRIPTION
**Phase 3 of #79** — the final two camera examples, plus the README restructure.

> ⚠️ **#79 is intentionally NOT closed by this PR.** Its core scope is complete, but sub-issue **#99** (API-demo data quality + inline docs) is still open, so #79 stays open until that lands.

## Converted
`sample_orb.html` and `sample_orb_pinball.html` now use `<script type="module">` + `import jsfeatNext from '../dist/jsfeatNext.mjs'`, the shared `loadCamera()` / `stopCamera()` / `showCameraError()` helpers, `renderCorners()` / `renderMonoImage()` from `demo-utils.mjs`, and the profiler via `profiler.mjs`. jQuery and `js/compatibility.js` are gone.

Both were converted **by hand** rather than with the batch pass from #100 — `sample_orb` uses a bare `<script>` tag (the tag-block pattern didn't match) and `orb_pinball` has an extra pattern-image `window.onload` block ahead of the main wrapper that the mechanical regex cut through.

The ORB-specific helpers (`match_pattern`, `popcnt32`, `find_transform`, `tCorners`, `render_matches`, `render_pattern_shape`) are **deliberately left inline and unchanged** — promoting those into real modules is **#83**'s job, so this stays a pure conversion.

## Two bugs fixed
1. **`cols` / `rows` were implicit globals** in `orb_pinball` (`cols = image.width`, no declaration). Legal in sloppy mode, but **ES modules are always strict**, so it threw `ReferenceError: cols is not defined` — found by @kalwalt while testing. To rule out the same class of bug elsewhere, I wrote a static checker for assignments to undeclared identifiers and ran it over the inline module script of **all 15 ESM examples**: `cols`/`rows` were the only genuine instances.
2. **`options.train_pattern()` on undefined** whenever the camera is denied or slow — `options` is created in `demo_app()` (post-camera) while the 2s training timer fires unconditionally. Verified against git that this is **pre-existing, not a conversion regression**; added a guard, happy path unchanged.

## README
The Examples section now documents **both consumption paths**:
- **ESM examples (17)** — with the "must be served over HTTP" caveat and a note about the shared `demo-utils.mjs` helpers
- **UMD examples (5)** — the small API demos that open straight from `file://`

Per @kalwalt's request the per-file ✔️/⚠️ marks are dropped, replaced by a short "demonstrates" description for each.

## Verification
Both ORB examples load with **zero non-camera errors** (iframe harness) · no jQuery/compatibility shim remains · implicit-global checker clean across all 15 ESM examples · all 22 examples referenced in the README · prettier passes · **webcam-tested by @kalwalt**.

With this, all 17 camera examples are ESM and the 5 API demos stay UMD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)