### PR TITLE
refactor(examples): give the API demos real data, verifiable output and docs (closes #99)

### DIFF
--- a/examples/browser.html
+++ b/examples/browser.html
@@ -10,27 +10,49 @@
 
 <body>
     <script src="../dist/jsfeatNext.js"></script>
-    <script>    
-        var jsfeat = jsfeatNext       
-        console.log("jsfeatNext version: ", jsfeat.VERSION);
-        console.log(jsfeat.EPSILON);
-        console.log(jsfeat.FLT_MIN);
-        console.log(jsfeatNext);
-        var count = 12;
-        var mat = new jsfeat.matrix_t(count, 1, jsfeat.U8_t | jsfeat.C1_t);
-        console.log(mat);
-        var keypoint = new jsfeat.keypoint_t();
-        console.log(keypoint);
-        // jsfeat.cache is the library-wide shared buffer pool (a singleton,
-        // like original jsfeat's) — borrow with get_buffer, return with put_buffer.
-        console.log(jsfeat.cache);
-        var bf = jsfeat.cache.get_buffer((2) << 2);
-        console.log(bf);
-        jsfeat.cache.put_buffer(bf);
-        var math = jsfeat.math
-        jsfeat.yape06.laplacian_threshold = 0;
-        var yape06 = jsfeat.yape06;
-        console.log(yape06.laplacian_threshold);
+    <script>
+        // A guided tour of the jsfeatNext namespace, loaded here as the UMD
+        // bundle (plain <script> tag -> the global `jsfeatNext`).
+        // Open the browser console to see the output.
+
+        console.log("jsfeatNext version:", jsfeatNext.VERSION);
+        console.log("the whole namespace:", jsfeatNext);
+
+        // --- Constants --------------------------------------------------------
+        // Numeric tolerances used throughout the algorithms.
+        console.log("EPSILON =", jsfeatNext.EPSILON, " FLT_MIN =", jsfeatNext.FLT_MIN);
+
+        // Type flags are combined with a bitwise OR: element type | channels.
+        console.log("U8_t | C1_t =", jsfeatNext.U8_t | jsfeatNext.C1_t,
+                    " (same as the U8C1_t shorthand:", jsfeatNext.U8C1_t + ")");
+
+        // --- Data structures: these ARE constructors, so they need `new` ------
+        const mat = new jsfeatNext.matrix_t(12, 1, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        console.log("matrix_t(12, 1):", mat.cols, "x", mat.rows,
+                    "-> data length", mat.data.length);
+
+        // keypoint_t(x, y, score, level, angle)
+        const keypoint = new jsfeatNext.keypoint_t(10, 20, 0.5, 0, -1);
+        console.log("keypoint_t:", `x=${keypoint.x} y=${keypoint.y} score=${keypoint.score}`);
+
+        // --- Algorithm modules: these are SINGLETONS, called without `new` ----
+        // (Since 0.9.0 — see docs/migration-0.9.md.)
+        console.log("imgproc.grayscale is a", typeof jsfeatNext.imgproc.grayscale);
+
+        // Module state lives on the singleton, so setting it is global:
+        jsfeatNext.yape06.laplacian_threshold = 30;
+        console.log("yape06.laplacian_threshold =", jsfeatNext.yape06.laplacian_threshold);
+
+        // --- The shared buffer pool ------------------------------------------
+        // `jsfeatNext.cache` is the ONE library-wide scratch pool (a singleton,
+        // like original jsfeat's global cache) that every module borrows from.
+        // Always balance a get_buffer() with a put_buffer().
+        const node = jsfeatNext.cache.get_buffer(8 << 2); // request 32 bytes
+        console.log("borrowed a pool buffer of", node.size, "bytes;",
+                    "views: u8 =", node.u8.length, " i32 =", node.i32.length,
+                    " f32 =", node.f32.length);
+        jsfeatNext.cache.put_buffer(node); // hand it back
+        console.log("buffer returned to the pool");
     </script>
 
 </body>

--- a/examples/linalg_example.html
+++ b/examples/linalg_example.html
@@ -11,11 +11,77 @@
 <body>
     <script src="../dist/jsfeatNext.js"></script>
     <script>
-        console.log(jsfeatNext.linalg);
-        var m3x4 = new jsfeatNext.matrix_t(3,4,jsfeatNext.F32C1_t);
-        var m4x3 = new jsfeatNext.matrix_t(4,3,jsfeatNext.F32C1_t);
-        var res = jsfeatNext.linalg.svd_invert(m3x4, m4x3);
-        console.log(res);
+        // linalg — dense linear algebra (LU / Cholesky solvers, SVD, eigen).
+        // Open the browser console to see the output.
+        //
+        // Two things to know before reading the code:
+        //
+        //  1. These methods write into a DESTINATION matrix you pass in and
+        //     return nothing (`void`). Log the destination, not the call.
+        //  2. `svd_invert(Ai, A)` takes the DESTINATION FIRST:
+        //        Ai <- pseudo-inverse of A
+        //     Also remember `new matrix_t(cols, rows, type)` is COLUMNS FIRST,
+        //     so a matrix with 3 columns and 2 rows is `new matrix_t(3, 2, …)`.
+
+        /** Pretty-print a matrix_t as rows. */
+        function show(label, m) {
+            let out = label + `  (${m.rows}x${m.cols})\n`;
+            for (let r = 0; r < m.rows; r++) {
+                const row = [];
+                for (let c = 0; c < m.cols; c++) row.push(m.data[r * m.cols + c].toFixed(4));
+                out += "  [ " + row.join("  ") + " ]\n";
+            }
+            console.log(out);
+        }
+
+        // --- Matrix inverse via SVD -------------------------------------------
+        // NOTE: use a SQUARE matrix here. `svd_invert` is exercised by the parity
+        // test suite for square matrices only; for non-square (pseudo-inverse)
+        // input its output is currently not trustworthy — see issue #102.
+        const A = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+        A.data.set([4, 7, 2,
+                    2, 6, 1,
+                    1, 1, 3]);
+        show("A =", A);
+
+        // svd_invert(Ai, A): DESTINATION FIRST — Ai receives the inverse of A.
+        // It returns nothing, so read `Ai` rather than the call's result.
+        const Ainv = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+        jsfeatNext.linalg.svd_invert(Ainv, A);
+        show("inverse of A =", Ainv);
+
+        // Verification anyone can check by hand: A · A⁻¹ must be the identity.
+        const P = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+        jsfeatNext.matmath.multiply(P, A, Ainv);
+        show("A · A⁻¹ = (should be the 3x3 identity)", P);
+
+        const isIdentity = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+            .every((expected, i) => Math.abs(P.data[i] - expected) < 1e-4);
+        console.assert(isIdentity, "A · A⁻¹ should be the identity");
+        console.log("A · A⁻¹ is the identity:", isIdentity);
+
+        // --- Solving a linear system with LU ----------------------------------
+        // Solve  M x = b  for the 2x2 system
+        //     4x + 7y = 1
+        //     2x + 6y = 1
+        // whose exact solution is x = -0.1, y = 0.2.
+        const M = new jsfeatNext.matrix_t(2, 2, jsfeatNext.F32C1_t);
+        M.data.set([4, 7,
+                    2, 6]);
+        // b is a single COLUMN: 1 column x 2 rows.
+        const b = new jsfeatNext.matrix_t(1, 2, jsfeatNext.F32C1_t);
+        b.data.set([1, 1]);
+
+        // lu_solve(A, B) solves in place: B is overwritten with the solution x.
+        // It returns 1 on success, 0 if the matrix is singular.
+        const ok = jsfeatNext.linalg.lu_solve(M, b);
+        console.log("lu_solve returned:", ok, "(1 = success)");
+        console.log("solution x =", b.data[0].toFixed(4), " y =", b.data[1].toFixed(4),
+                    " (expected -0.1 and 0.2)");
+        console.assert(
+            Math.abs(b.data[0] + 0.1) < 1e-4 && Math.abs(b.data[1] - 0.2) < 1e-4,
+            "expected x = -0.1, y = 0.2"
+        );
     </script>
 
 </body>

--- a/examples/mat_math_example.html
+++ b/examples/mat_math_example.html
@@ -11,13 +11,60 @@
 <body>
     <script src="../dist/jsfeatNext.js"></script>
     <script>
-        var columns = 320, rows = 240, data_type = jsfeatNext.U8_t | jsfeatNext.C1_t;
-        console.log("data_type is:", data_type);
-        console.assert(data_type === 257, "Wrong data_type");
-        var homo3x3 = new jsfeatNext.matrix_t(3,3,jsfeatNext.F32C1_t);
-        console.log(homo3x3);
-        jsfeatNext.matmath.identity_3x3(homo3x3, 1.0);
-        console.log(homo3x3);
+        // matmath — small fixed-size matrix arithmetic (3x3 here).
+        // Open the browser console to see the output.
+        //
+        // `matmath` is a singleton on the namespace: call its methods directly,
+        // no `new` (since 0.9.0). Results are written into a DESTINATION matrix
+        // you pass in, rather than returned.
+
+        /** Pretty-print a 3x3 matrix_t as three rows. */
+        function show(label, m) {
+            const d = m.data;
+            console.log(
+                label + "\n" +
+                `  [ ${d[0].toFixed(3)}  ${d[1].toFixed(3)}  ${d[2].toFixed(3)} ]\n` +
+                `  [ ${d[3].toFixed(3)}  ${d[4].toFixed(3)}  ${d[5].toFixed(3)} ]\n` +
+                `  [ ${d[6].toFixed(3)}  ${d[7].toFixed(3)}  ${d[8].toFixed(3)} ]`
+            );
+        }
+
+        // F32C1_t = 32-bit float, 1 channel — the type used for transforms.
+        const A = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+
+        // identity_3x3(M, value) fills M with `value` on the diagonal.
+        // With 1.0 that is the identity matrix.
+        jsfeatNext.matmath.identity_3x3(A, 1.0);
+        show("identity_3x3(A, 1.0) =", A);
+        console.assert(A.data[0] === 1 && A.data[1] === 0 && A.data[4] === 1, "expected identity");
+
+        // Now a real transform: scale by 2 in x, 3 in y, then translate by (5, 7).
+        // A 2D affine transform in homogeneous coordinates looks like
+        //   [ sx  0  tx ]
+        //   [  0 sy  ty ]
+        //   [  0  0   1 ]
+        const T = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+        T.data.set([2, 0, 5,
+                    0, 3, 7,
+                    0, 0, 1]);
+        show("T (scale 2x,3y + translate 5,7) =", T);
+
+        // invert_3x3(from, to) — NOTE the argument order: source first,
+        // destination second. The inverse undoes the transform.
+        const Tinv = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+        jsfeatNext.matmath.invert_3x3(T, Tinv);
+        show("inverse of T =", Tinv);
+
+        // multiply_3x3(C, A, B) computes C = A * B (destination FIRST).
+        // T * T⁻¹ must be the identity — a self-check anyone can verify.
+        const P = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
+        jsfeatNext.matmath.multiply_3x3(P, T, Tinv);
+        show("T * inverse(T) = (should be the identity)", P);
+
+        const isIdentity = [1, 0, 0, 0, 1, 0, 0, 0, 1]
+            .every((expected, i) => Math.abs(P.data[i] - expected) < 1e-5);
+        console.assert(isIdentity, "T * T^-1 should be the identity matrix");
+        console.log("T * T^-1 is the identity:", isIdentity);
     </script>
 
 </body>

--- a/examples/matrix_t_example.html
+++ b/examples/matrix_t_example.html
@@ -11,11 +11,56 @@
 <body>
     <script src="../dist/jsfeatNext.js"></script>
     <script>
-        var columns = 320, rows = 240, data_type = jsfeatNext.U8_t | jsfeatNext.C1_t;
-        console.log("data_type is:", data_type);
-        console.assert(data_type === 257, "Wrong data_type");
-        var matrix = new jsfeatNext.matrix_t(columns, rows, data_type);
-        console.log("matrix infos: ", matrix);
+        // matrix_t — the fundamental data container of jsfeatNext.
+        // Open the browser console to see the output.
+        //
+        // new matrix_t(columns, rows, data_type)
+        //   NOTE the argument order: COLUMNS (width) first, then ROWS (height).
+        //   `data_type` packs the element type and the channel count into one
+        //   number, combined with a bitwise OR.
+
+        // U8_t = 8-bit unsigned elements, C1_t = 1 channel (i.e. grayscale).
+        const data_type = jsfeatNext.U8_t | jsfeatNext.C1_t;
+        console.log("data_type =", data_type, "(U8_t | C1_t)"); // 257
+
+        // A tiny 4x3 matrix so the layout is easy to follow by hand.
+        const cols = 4, rows = 3;
+        const matrix = new jsfeatNext.matrix_t(cols, rows, data_type);
+
+        console.log("cols =", matrix.cols, " rows =", matrix.rows, " channels =", matrix.channel);
+        // `data` is a typed array view over the backing buffer. It holds
+        // cols * rows * channels = 12 useful elements, but note the view can be
+        // LONGER than that: the buffer is padded up to a multiple of 8 bytes, so
+        // here length is 16. Always iterate with cols/rows, never data.length.
+        console.log("data is a", matrix.data.constructor.name, "of length", matrix.data.length,
+                    "(12 used +", matrix.data.length - 12, "padding)");
+
+        // Elements are stored ROW-MAJOR: the element at (row r, column c)
+        // lives at index  r * cols + c.  Fill it with a recognisable pattern:
+        // each element gets the value  10 * row + col.
+        for (let r = 0; r < rows; r++) {
+            for (let c = 0; c < cols; c++) {
+                matrix.data[r * cols + c] = 10 * r + c;
+            }
+        }
+
+        // Reading back the flat buffer shows the rows laid out end to end:
+        //   [0, 1, 2, 3,  10, 11, 12, 13,  20, 21, 22, 23]
+        console.log("flat data:", Array.from(matrix.data).join(", "));
+
+        // ...and indexing row 1, column 2 gives 12, as the pattern predicts.
+        const r = 1, c = 2;
+        const value = matrix.data[r * matrix.cols + c];
+        console.log(`element at (row ${r}, col ${c}) =`, value);
+        console.assert(value === 12, "expected 12 at (1, 2)");
+
+        // The same bytes are also reachable through the other typed-array views
+        // of the shared buffer (u8 / i32 / f32 / f64) — that is how the library
+        // reinterprets scratch memory without reallocating.
+        console.log("views on the same buffer:",
+                    "u8 =", matrix.buffer.u8.length,
+                    " i32 =", matrix.buffer.i32.length,
+                    " f32 =", matrix.buffer.f32.length);
     </script>
 
 </body>

--- a/examples/orb_test.html
+++ b/examples/orb_test.html
@@ -11,15 +11,88 @@
 <body>
     <script src="../dist/jsfeatNext.js"></script>
     <script>
-        var screen_corners = [];
-        var num_corners = 20;
-        var img_u8_smooth = new jsfeatNext.matrix_t(640, 480, jsfeatNext.U8_t | jsfeatNext.C1_t);
-        var screen_descriptors = new jsfeatNext.matrix_t(32, 500, jsfeatNext.U8_t | jsfeatNext.C1_t);
-        var i = 640 * 480;
-        while (--i >= 0) {
-            screen_corners[i] = new jsfeatNext.keypoint_t(0, 0, 0, 0, -1);
+        // orb — ORB binary feature descriptors.
+        // Open the browser console to see the output.
+        //
+        // ORB describes the neighbourhood of a keypoint as 32 bytes (256 bits).
+        // Two descriptors are compared with the HAMMING DISTANCE: the number of
+        // differing bits. Similar patches -> small distance.
+        //
+        // orb.describe(src, corners, count, descriptors)
+        //   src         : grayscale matrix_t to sample from
+        //   corners     : array of keypoint_t (only the first `count` are used)
+        //   count       : how many keypoints to describe
+        //   descriptors : DESTINATION matrix_t, 32 columns x (>= count) rows;
+        //                 row i receives the 32-byte descriptor of corners[i].
+        // It returns nothing — read the destination matrix.
+
+        const WIDTH = 128, HEIGHT = 128;
+
+        // A blank image gives meaningless (all-zero) descriptors, so build a
+        // textured one. Random noise guarantees every neighbourhood is distinct.
+        // (A regular checkerboard is a poor choice here: its patches repeat, so
+        // different points can produce identical descriptors.)
+        let seed = 12345;
+        const rand = () => { seed = (seed * 1103515245 + 12345) & 0x7fffffff; return (seed >> 16) & 0xff; };
+
+        const img = new jsfeatNext.matrix_t(WIDTH, HEIGHT, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        for (let i = 0; i < WIDTH * HEIGHT; i++) img.data[i] = rand();
+
+        // A copy of the SAME image, 30 grey levels brighter. ORB compares the
+        // relative order of pixel pairs, so it should be largely unaffected.
+        const brighter = new jsfeatNext.matrix_t(WIDTH, HEIGHT, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        for (let i = 0; i < WIDTH * HEIGHT; i++) brighter.data[i] = Math.min(255, img.data[i] + 30);
+
+        // ORB samples pairs of individual pixels, so blur first to tame noise.
+        const smooth = new jsfeatNext.matrix_t(WIDTH, HEIGHT, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        const smoothBright = new jsfeatNext.matrix_t(WIDTH, HEIGHT, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        jsfeatNext.imgproc.gaussian_blur(img, smooth, 5);
+        jsfeatNext.imgproc.gaussian_blur(brighter, smoothBright, 5);
+
+        // keypoint_t(x, y, score, level, angle) — angle in radians, or -1 to let
+        // ORB work out the patch orientation itself.
+        const pointP = [new jsfeatNext.keypoint_t(40, 40, 0, 0, -1)];
+        const pointQ = [new jsfeatNext.keypoint_t(80, 70, 0, 0, -1)];
+
+        // Destination matrices: 32 columns (bytes per descriptor) x rows = count.
+        const descP = new jsfeatNext.matrix_t(32, 1, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        const descPbright = new jsfeatNext.matrix_t(32, 1, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        const descQ = new jsfeatNext.matrix_t(32, 1, jsfeatNext.U8_t | jsfeatNext.C1_t);
+
+        jsfeatNext.orb.describe(smooth, pointP, 1, descP);              // P in the original
+        jsfeatNext.orb.describe(smoothBright, pointP, 1, descPbright);  // P in the brighter copy
+        jsfeatNext.orb.describe(smooth, pointQ, 1, descQ);              // a different point
+
+        const hex = (m) => Array.from(m.data.subarray(0, 8))
+            .map((b) => b.toString(16).padStart(2, "0")).join(" ");
+        console.log("descriptor P  (40,40)          first 8 of 32 bytes:", hex(descP));
+        console.log("descriptor P' (same pt, +30)   first 8 of 32 bytes:", hex(descPbright));
+        console.log("descriptor Q  (80,70)          first 8 of 32 bytes:", hex(descQ));
+
+        /** Hamming distance: how many of the 256 bits differ. */
+        function hamming(a, b) {
+            let dist = 0;
+            for (let k = 0; k < 32; k++) {
+                let xor = a.data[k] ^ b.data[k];
+                while (xor) { dist += xor & 1; xor >>= 1; } // count differing bits
+            }
+            return dist;
         }
-        jsfeatNext.orb.describe(img_u8_smooth, screen_corners, num_corners, screen_descriptors);
+
+        // This is the whole point of a descriptor: the SAME feature stays close
+        // even when the image changes, while a DIFFERENT feature is far away.
+        const dSame = hamming(descP, descPbright);
+        const dDiff = hamming(descP, descQ);
+        console.log(`same point, brighter image -> hamming = ${dSame}  (small: ORB ignores brightness)`);
+        console.log(`different point            -> hamming = ${dDiff}  (large: ~128 = unrelated)`);
+        console.log("a descriptor vs itself     -> hamming =", hamming(descP, descP));
+
+        console.assert(hamming(descP, descP) === 0, "a descriptor must match itself exactly");
+        console.assert(dSame < dDiff, "the same feature should be closer than a different one");
+        console.assert(
+            Array.from(descP.data).some((b) => b !== 0),
+            "descriptors should not be all zero on a textured image"
+        );
     </script>
 
 </body>


### PR DESCRIPTION
Closes #99. The five UMD API-demo examples ran on **all-zero matrices** and mostly printed nothing checkable. They now use small hand-verifiable input, print results a reader can confirm, **assert their own invariants**, and carry inline comments as documentation.

## Per file
- **`matrix_t_example`** — fills a 4×3 matrix with `10*row + col` so the **row-major layout is visible** in the flat buffer, then reads back `(1,2) == 12`. Documents that `matrix_t(cols, rows, type)` is **columns-first**, and that `data` can be **longer** than `cols*rows*channels` because the buffer pads to a multiple of 8 bytes (12 used + 4 padding) — so iterate with `cols`/`rows`, never `data.length`.
- **`mat_math_example`** — keeps `identity_3x3`, then builds a real affine transform (scale 2×,3y + translate 5,7), inverts it and multiplies back, asserting **T · T⁻¹ = I**. Documents the destination-first argument order of `invert_3x3(from, to)` and `multiply_3x3(C, A, B)`. Drops the dead `columns`/`rows` vars.
- **`linalg_example`** — fixes **two real bugs**: `svd_invert` returns `void`, so the old `var res = …; console.log(res)` printed **`undefined`**; and its args are `(destination, source)`, which the old call obscured. Now inverts a square 3×3 asserting **A · A⁻¹ = I**, plus an `lu_solve` example whose exact solution `(-0.1, 0.2)` is stated and asserted.
- **`orb_test`** — previously described a **blank** image at 20 keypoints all at **(0,0)**, logged **nothing**, and allocated **307,200** `keypoint_t` objects to use 20. Now uses seeded-noise texture and demonstrates what a descriptor is *for*: the same point in a **brightened** copy gives Hamming distance **6**, a different point gives **124** (~128 = unrelated). Asserts self-distance 0 and same < different.
- **`browser.html`** — reorganised into a guided tour (constants → data-structure constructors vs algorithm **singletons** → the shared cache pool), explaining the 0.9.0 no-`new` convention and `get_buffer`/`put_buffer` balance.

## Two findings from actually running them
1. My first `orb_test` draft used a checkerboard and claimed same-phase points would be closer. Running it showed **all three descriptors were identical** — a periodic pattern plus ORB's orientation normalisation makes phases indistinguishable. Replaced with random texture, where brightness-invariance is genuinely demonstrable.
2. My first `linalg_example` draft asserted `A · A⁺ = I` for a **non-square** matrix. **It failed** — `svd_invert` returns a wrong pseudo-inverse for non-square input (only the first column is right). Verified against the vendored oracle that **original jsfeat produces byte-identical wrong output**, so parity holds and the suite cannot see it — a concrete instance of the ceiling described in **#87**. Filed as **#102**; the example now uses a square matrix and points there.

## Verification
Executed **every example's inline script against the real UMD bundle in Node** (they're pure computation, no DOM): all five run with **no throws and no failed assertions**. Prettier clean.

> With this merged, **#79 can also be closed** — this was its last open sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)