### PR TITLE
ci(release): support prerelease tags (alpha/beta/rc) (closes #81)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,14 +3,20 @@ name: Release
 # Triggers on a bare X.Y.Z tag push (jsfeatNext's tag convention -- never
 # vX.Y.Z, see MAINTAINERS.md), or manually via workflow_dispatch to retry a
 # failed publish without re-tagging.
+#
+# Prerelease tags (X.Y.Z-alpha.1, -beta.2, -rc.1) are supported too and are
+# handled differently: the GitHub Release is marked as a prerelease and npm
+# publishes under a dist-tag derived from the identifier (beta -> `beta`), so
+# a prerelease never becomes `latest` for `npm install`. See #81.
 on:
     push:
         tags:
-            - "[0-9]+.[0-9]+.[0-9]+"
+            - "[0-9]+.[0-9]+.[0-9]+" # stable, e.g. 0.10.0
+            - "[0-9]+.[0-9]+.[0-9]+-*" # prerelease, e.g. 1.0.0-beta.1
     workflow_dispatch:
         inputs:
             tag:
-                description: "Existing tag to (re-)publish, e.g. 0.8.0"
+                description: "Existing tag to (re-)publish, e.g. 0.8.0 or 1.0.0-beta.1"
                 required: true
 
 permissions:
@@ -24,7 +30,25 @@ jobs:
         steps:
             - name: Resolve tag
               id: tag
-              run: echo "name=${{ github.event.inputs.tag || github.ref_name }}" >> "$GITHUB_OUTPUT"
+              run: |
+                  NAME="${{ github.event.inputs.tag || github.ref_name }}"
+                  echo "name=$NAME" >> "$GITHUB_OUTPUT"
+
+                  # A prerelease is any semver tag carrying a `-<identifier>`
+                  # suffix, e.g. 1.0.0-beta.1. The npm dist-tag is taken from
+                  # that identifier so `npm install @webarkit/jsfeat-next`
+                  # (which resolves `latest`) never picks up a prerelease.
+                  if [[ "$NAME" == *-* ]]; then
+                      IDENT="${NAME#*-}"   # 1.0.0-beta.1 -> beta.1
+                      IDENT="${IDENT%%.*}" # beta.1       -> beta
+                      echo "prerelease=true" >> "$GITHUB_OUTPUT"
+                      echo "npm_tag=${IDENT:-next}" >> "$GITHUB_OUTPUT"
+                      echo "::notice::$NAME is a PRERELEASE -> npm dist-tag '${IDENT:-next}', GitHub Release marked prerelease"
+                  else
+                      echo "prerelease=false" >> "$GITHUB_OUTPUT"
+                      echo "npm_tag=latest" >> "$GITHUB_OUTPUT"
+                      echo "::notice::$NAME is a STABLE release -> npm dist-tag 'latest'"
+                  fi
 
             - name: Checkout repository
               uses: actions/checkout@v7
@@ -37,6 +61,18 @@ jobs:
               with:
                   node-version-file: ".nvmrc"
                   registry-url: "https://registry.npmjs.org"
+
+            - name: Verify the tag matches package.json version
+              run: |
+                  PKG=$(node -p "require('./package.json').version")
+                  TAG="${{ steps.tag.outputs.name }}"
+                  if [ "$PKG" != "$TAG" ]; then
+                      echo "::error::tag '$TAG' does not match package.json version '$PKG'."
+                      echo "npm would publish '$PKG', not '$TAG'. Bump package.json (and for a"
+                      echo "prerelease include the suffix, e.g. \"version\": \"1.0.0-beta.1\")."
+                      exit 1
+                  fi
+                  echo "tag and package.json agree: $TAG"
 
             - name: Install
               run: npm ci
@@ -76,12 +112,19 @@ jobs:
             - name: Create GitHub Release
               env:
                   GH_TOKEN: ${{ github.token }}
+                  # --prerelease keeps the release out of the "Latest" slot on
+                  # the releases page; empty for a stable release.
+                  PRERELEASE_FLAG: ${{ steps.tag.outputs.prerelease == 'true' && '--prerelease' || '' }}
               run: |
                   gh release create "${{ steps.tag.outputs.name }}" \
                     --title "${{ steps.tag.outputs.name }}" \
-                    --notes-file release-notes.md
+                    --notes-file release-notes.md \
+                    $PRERELEASE_FLAG
 
             - name: Publish to npm
-              run: npm publish --provenance --access public
+              # --tag controls the npm dist-tag: `latest` for a stable release,
+              # or the prerelease identifier (beta / rc / alpha) otherwise, so a
+              # prerelease is installable via @beta but never becomes the default.
+              run: npm publish --provenance --access public --tag "${{ steps.tag.outputs.npm_tag }}"
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,7 +15,7 @@ When reviewing Pull Requests, maintainers must ensure the following (see [`AGENT
 - **Numeric/behavioral parity:** algorithm code must preserve parity with the original [jsfeat](https://github.com/inspirit/jsfeat). Any change touching `src/**` (excluding `tests/`) should keep `npm test` green (57+ characterization tests assert parity against a vendored jsfeat oracle).
 - **Typing:** avoid `any` in new code; the project runs `noImplicitAny: true`.
 - **No `.idea/`** (JetBrains IDE files) ever committed.
-- **Tag format:** release tags are bare `X.Y.Z` (e.g. `0.8.0`) — **never** `vX.Y.Z`. This has caused a real mixup before (see the 0.7.6 release) and the automated release workflow (below) only triggers on the bare pattern.
+- **Tag format:** release tags are bare `X.Y.Z` (e.g. `0.8.0`) — **never** `vX.Y.Z`. This has caused a real mixup before (see the 0.7.6 release) and the automated release workflow (below) only triggers on the bare pattern. Prerelease tags follow semver and are also supported: `X.Y.Z-beta.1`, `-alpha.2`, `-rc.1` (see [Prereleases](#prereleases-alpha--beta--rc)).
 
 ## 2. Release Process
 
@@ -56,18 +56,41 @@ Publishing a new version is a two-phase process: a **manual** phase you control 
    git push origin X.Y.Z
    ```
    Pushing this tag triggers [`.github/workflows/release.yml`](.github/workflows/release.yml), which automatically:
+   - **checks the tag matches `package.json`'s `version`** and fails loudly if not (otherwise npm would publish a different version than the one you tagged)
    - runs `npm ci`, `npm test`, `npm run build-ts` (rebuilds `dist/`/`types/` fresh from the tagged commit as a safety check — the workflow does **not** trust whatever happens to be committed)
    - runs `npm pack --dry-run` and logs the resulting tarball contents/size (informational; see the packaging trim in #60)
    - generates release notes from Conventional Commits with **[git-cliff](https://git-cliff.org/)** (config: [`cliff.toml`](cliff.toml)), covering everything since the previous tag
    - creates the **GitHub Release** for the tag with those generated notes as the body
-   - runs `npm publish --provenance --access public`
+   - runs `npm publish --provenance --access public --tag <dist-tag>`
 
    You can watch it under the repo's **Actions** tab. If a step fails (e.g. a transient npm registry error during publish), you do **not** need to re-tag — re-run it manually via **Actions → Release → Run workflow**, entering the existing tag.
 
+#### Prereleases (alpha / beta / rc)
+
+The same flow handles prereleases — just tag with a semver prerelease suffix (still no `v` prefix):
+
+```bash
+git tag -a 1.0.0-beta.1 -m "1.0.0-beta.1"
+git push origin 1.0.0-beta.1
+```
+
+**Set `package.json`'s version to the same string** (`"version": "1.0.0-beta.1"`) in Phase A — the workflow's tag/version check enforces this.
+
+The workflow detects the `-` suffix and adapts:
+
+| | stable `0.10.0` | prerelease `1.0.0-beta.1` |
+|---|---|---|
+| GitHub Release | normal (shows as **Latest**) | marked **`--prerelease`** (stays out of the Latest slot) |
+| npm dist-tag | `latest` | the identifier — `beta` (or `alpha` / `rc`) |
+| `npm install @webarkit/jsfeat-next` | gets it | **does not** get it |
+| how users opt in | — | `npm install @webarkit/jsfeat-next@beta` |
+
+This means a prerelease can never hijack `latest` for existing users. To promote one to stable afterwards, tag the final `1.0.0` normally.
+
 8. **Verify.** Check:
-   - the new [GitHub Release](https://github.com/webarkit/jsfeatNext/releases) has sensible notes
+   - the new [GitHub Release](https://github.com/webarkit/jsfeatNext/releases) has sensible notes (and is flagged *Pre-release* if it was one)
    - `npm view @webarkit/jsfeat-next version` shows the new version
-   - `npm view @webarkit/jsfeat-next dist-tags` shows `latest` pointing at it
+   - `npm view @webarkit/jsfeat-next dist-tags` — `latest` should point at the newest **stable**, with any prerelease under its own tag (`beta`, `rc`, …)
 
 ### Notes
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -35,7 +35,9 @@ filter_unconventional = true
 split_commits = false
 protect_breaking_commits = false
 filter_commits = false
-tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
+# Bare X.Y.Z, plus optional semver prerelease suffix (1.0.0-beta.1) so the
+# changelog range resolves correctly for prereleases too -- see #81.
+tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+(-[0-9A-Za-z.-]+)?$"
 sort_commits = "oldest"
 
 commit_parsers = [


### PR DESCRIPTION
Closes #81. The release pipeline could only handle stable `X.Y.Z` tags — a prerelease tag wouldn't have triggered the workflow at all, and even if it had, it would have published **incorrectly**. All three gaps fixed.

## The three fixes

**1. Tag trigger.** The glob `[0-9]+.[0-9]+.[0-9]+` is a *whole-ref* match, so `1.0.0-beta.1` never matched — pushing it did nothing. Added `[0-9]+.[0-9]+.[0-9]+-*`. The two don't overlap (the stable glob can't match a `-` suffix), so no double-firing.

**2. `cliff.toml` `tag_pattern`** was anchored `^X.Y.Z$` and skipped prerelease tags → wrong changelog range. Widened to `^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$` — still rejects `vX.Y.Z` (our bare-tag convention), `1.0`, `1.0.0.0`.

**3. Publication semantics — the dangerous one.** Previously `gh release create` never passed `--prerelease` and `npm publish` never set a dist-tag. An alpha would have shown as **"Latest"** on GitHub *and* taken over npm's **`latest`** — pushing an unstable build to every existing `npm install`. Now both are derived from the tag:

| | stable `0.10.0` | prerelease `1.0.0-beta.1` |
|---|---|---|
| GitHub Release | normal (**Latest**) | **`--prerelease`** |
| npm dist-tag | `latest` | `beta` (or `alpha`/`rc`) |
| `npm install …` | gets it | **does not** |
| opt in via | — | `npm install @webarkit/jsfeat-next@beta` |

## Bonus guard: tag ↔ `package.json` must agree
Added a step that fails the run with a clear message if the tag doesn't match `package.json`'s `version`. Not cosmetic — **npm publishes whatever package.json says**, so a mismatched tag would silently ship the wrong version. Prereleases make this easy to hit, since package.json must carry the suffix too (`"version": "1.0.0-beta.1"`).

## Docs
`MAINTAINERS.md` gains a **Prereleases** section with the comparison table above, and the tag-format rule now mentions the supported prerelease shapes.

## Verification
Valid YAML · prerelease-detection logic exercised against `0.10.0` / `1.0.0-beta.1` / `1.0.0-alpha.2` / `1.0.0-rc.1` / `2.0.0`, producing the right flag + dist-tag for each · new regex accepts all prerelease shapes while still rejecting `v`-prefixed and malformed tags · `git-cliff --tag 1.0.0-beta.1` generates a correct header · `npm test` 63/63 · prettier clean.

> Note: this only *enables* prereleases — it changes nothing about a normal stable release, so the small release you're planning next is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)