### PR TITLE
fix(linalg): reject non-square input in svd_invert instead of returning garbage (refs #102)

### DIFF
--- a/examples/linalg_example.html
+++ b/examples/linalg_example.html
@@ -35,9 +35,10 @@
         }
 
         // --- Matrix inverse via SVD -------------------------------------------
-        // NOTE: use a SQUARE matrix here. `svd_invert` is exercised by the parity
-        // test suite for square matrices only; for non-square (pseudo-inverse)
-        // input its output is currently not trustworthy — see issue #102.
+        // NOTE: `svd_invert` supports SQUARE matrices only, and throws on
+        // anything else. The rectangular (Moore-Penrose) pseudo-inverse
+        // inherited from jsfeat returns wrong numbers, so jsfeatNext refuses
+        // the input rather than hand you a bad answer — see issue #102.
         const A = new jsfeatNext.matrix_t(3, 3, jsfeatNext.F32C1_t);
         A.data.set([4, 7, 2,
                     2, 6, 1,

--- a/src/linalg/linalg.ts
+++ b/src/linalg/linalg.ts
@@ -764,13 +764,31 @@ export class linalg extends jsfeatNext {
     }
 
     /**
-     * Moore–Penrose pseudo-inverse via SVD: `Ai = V · diag(1/w) · Uᵀ`,
-     * with tiny singular values zeroed. Valid for any matrix shape/rank.
+     * Matrix inverse via SVD: `Ai = V · diag(1/w) · Uᵀ`, with tiny singular
+     * values zeroed.
      *
-     * @param Ai Output pseudo-inverse (n×m).
-     * @param A  Input m×n matrix (not modified).
+     * **Square matrices only.** The implementation inherited from jsfeat does
+     * not produce a correct Moore–Penrose pseudo-inverse for non-square input —
+     * only the first column of the result is right (see issue #102). Rather
+     * than return wrong numbers silently, as original jsfeat does, this method
+     * now throws on a non-square `A`. Support for the true rectangular
+     * pseudo-inverse is tracked in #102.
+     *
+     * @param Ai Output inverse, same n×n shape as `A`.
+     * @param A  Input n×n matrix (not modified).
+     * @throws {Error} if `A` is not square.
      */
     svd_invert(Ai: matrix_t, A: matrix_t): void {
+        // Guard the documented limitation: a wrong answer is worse than an
+        // error. Deliberate divergence from jsfeat, which computes garbage here.
+        if (A.cols !== A.rows) {
+            throw new Error(
+                `jsfeatNext.linalg.svd_invert: only square matrices are supported, ` +
+                    `got ${A.rows}x${A.cols} (rows x cols). The rectangular ` +
+                    `pseudo-inverse is not implemented correctly yet — see issue #102.`
+            );
+        }
+
         let i = 0,
             j = 0,
             k = 0;

--- a/tests/divergences.test.ts
+++ b/tests/divergences.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../src/jsfeatNext";
+import jsfeat from "./vendor/oracle.cjs";
+
+/**
+ * Registry of INTENTIONAL divergences from original jsfeat.
+ *
+ * The suite in `tests/parity/` pins the places where jsfeatNext must match the
+ * jsfeat oracle bit-for-bit. This file is its counterpart: every case here is a
+ * place where we have deliberately decided NOT to match, with the reason and
+ * the tracking issue recorded alongside the assertion.
+ *
+ * Keeping these separate matters. A divergence buried in the parity suite looks
+ * like a broken test; here it reads as a decision. Anything added to this file
+ * should cite an issue explaining why differing is the right call.
+ */
+
+const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
+const OF32C1 = jsfeat.F32_t | jsfeat.C1_t;
+
+describe("intentional divergences from jsfeat", () => {
+    describe("linalg.svd_invert rejects non-square input (#102)", () => {
+        /**
+         * jsfeat's svd_invert silently returns a WRONG result for a non-square
+         * matrix — only the first column of the pseudo-inverse is correct. Since
+         * upstream jsfeat is frozen we cannot fix it there, and returning wrong
+         * numbers quietly is worse than failing. jsfeatNext therefore throws.
+         *
+         * The correct rectangular pseudo-inverse is still tracked in #102.
+         */
+        it("throws instead of returning a wrong pseudo-inverse", () => {
+            // A is 2 rows x 3 cols -> new matrix_t(cols, rows, type)
+            const A = new jsfeatNext.matrix_t(3, 2, F32C1);
+            A.data.set([1, 0, 2, 0, 1, 3]);
+            const dst = new jsfeatNext.matrix_t(2, 3, F32C1);
+
+            expect(() => jsfeatNext.linalg.svd_invert(dst, A)).toThrow(/square/i);
+        });
+
+        it("original jsfeat silently returns a wrong answer for the same input", () => {
+            // Documents WHY we diverge: the oracle produces numbers that are not
+            // the Moore-Penrose pseudo-inverse, with no error of any kind.
+            const Ao = new jsfeat.matrix_t(3, 2, OF32C1);
+            Ao.data.set([1, 0, 2, 0, 1, 3]);
+            const dstO = new jsfeat.matrix_t(2, 3, OF32C1);
+
+            expect(() => jsfeat.linalg.svd_invert(dstO, Ao)).not.toThrow();
+
+            // The true pseudo-inverse of [[1,0,2],[0,1,3]] is
+            //   [ 0.7143 -0.4286 ]
+            //   [-0.4286  0.3571 ]
+            //   [ 0.1429  0.2143 ]
+            // jsfeat's second column does not match it.
+            const truthSecondColumn = [-0.4286, 0.3571, 0.2143];
+            const actualSecondColumn = [dstO.data[1], dstO.data[3], dstO.data[5]];
+            const matches = truthSecondColumn.every((want, i) => Math.abs(actualSecondColumn[i] - want) < 1e-3);
+            expect(matches).toBe(false);
+        });
+
+        it("still matches jsfeat exactly for square input (parity preserved)", () => {
+            // The divergence is scoped to the broken path only: square inversion
+            // remains bit-compatible, which is what tests/parity/linalg.test.ts pins.
+            const A = new jsfeatNext.matrix_t(2, 2, F32C1);
+            A.data.set([4, 7, 2, 6]);
+            const Ai = new jsfeatNext.matrix_t(2, 2, F32C1);
+            jsfeatNext.linalg.svd_invert(Ai, A);
+
+            const Ao = new jsfeat.matrix_t(2, 2, OF32C1);
+            Ao.data.set([4, 7, 2, 6]);
+            const Aio = new jsfeat.matrix_t(2, 2, OF32C1);
+            jsfeat.linalg.svd_invert(Aio, Ao);
+
+            for (let i = 0; i < 4; i++) {
+                expect(Ai.data[i]).toBeCloseTo(Aio.data[i], 6);
+            }
+            // ...and it is genuinely correct: A * A^-1 = I
+            const P = new jsfeatNext.matrix_t(2, 2, F32C1);
+            jsfeatNext.matmath.multiply(P, A, Ai);
+            for (const [i, want] of [1, 0, 0, 1].entries()) {
+                expect(P.data[i]).toBeCloseTo(want, 5);
+            }
+        });
+    });
+});


### PR DESCRIPTION
Implements **option (c)** of #102. Does **not** close it — the correct rectangular pseudo-inverse (option b) stays open.

## The problem
`svd_invert` inherited a defect from jsfeat: for a **non-square** matrix it silently returns a **wrong** pseudo-inverse (only the first column is correct), with no error at all. Its TSDoc even claimed *"Valid for any matrix shape/rank"* — promising precisely what it fails to deliver.

## The decision
It now **throws** on non-square input. The reasoning:
- **Upstream jsfeat is frozen** — the bug can't be fixed there, so "bug-for-bug compatible" can't be an absolute principle.
- Handing a caller **wrong numbers quietly is worse than failing**.
- *"We raise an error where jsfeat returned garbage"* is a far easier divergence to justify than *"we return different numbers than jsfeat."*

**Why throw rather than a `0` failure code:** a wrong input *shape* is a programmer error, whereas `lu_solve` returning `0` signals a *singular matrix* — a legitimate numerical outcome. Different situations, different mechanisms. Throwing also avoids changing the signature `void → number`, which would itself be a typed-API break.

## Scope is narrow
- **Square inversion is untouched** and stays bit-compatible with jsfeat → `tests/parity/linalg.test.ts` (a 4×4) is unaffected.
- **Nothing inside the library calls `svd_invert`** — it's purely public API — so there's no internal regression risk.

## New: `tests/divergences.test.ts`
A deliberate counterpart to `tests/parity/` — a **registry of places where jsfeatNext intentionally does not match jsfeat**, each with its reason and tracking issue.

Keeping these separate matters: a divergence buried in the parity suite looks like a *broken test*; here it reads as a *decision*. The three cases assert that (1) we throw, (2) jsfeat does **not** throw and really is wrong for the same input, and (3) square input still matches jsfeat exactly **and** satisfies `A · A⁻¹ = I`.

## Also
- Corrected the misleading TSDoc.
- Updated `examples/linalg_example.html`, whose comment said the non-square result was "not trustworthy" — it now throws, so the wording had to change.

## Verification
`tsc --noEmit` clean · `npm test` **66/66** (63 existing + 3 new), parity suite unchanged · square inversion still exact (`0.6, -0.7, -0.2, 0.4` for `[[4,7],[2,6]]`) while non-square throws · all five API-demo examples still run clean · prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)