### PR TITLE
test(properties): add linalg and matmath invariant tests (refs #87)

### DIFF
--- a/tests/properties/helpers.ts
+++ b/tests/properties/helpers.ts
@@ -1,0 +1,95 @@
+import { expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+
+/**
+ * Shared helpers for the property/invariant suite (issue #87).
+ *
+ * These tests assert mathematical truths that hold regardless of what original
+ * jsfeat does — the complement to `tests/parity/`, which pins compatibility.
+ * They are the only kind of test that can catch a defect present in BOTH
+ * implementations (see #102), or cover code with no oracle at all.
+ */
+
+export const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
+
+/** Deterministic PRNG so failures are always reproducible. */
+export function rng(seed: number): () => number {
+    let a = seed >>> 0;
+    return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+/** `cols`x`rows` matrix filled from `values` (row-major). */
+export function mat(cols: number, rows: number, values?: number[]) {
+    const m = new jsfeatNext.matrix_t(cols, rows, F32C1);
+    if (values) m.data.set(values);
+    return m;
+}
+
+/** Uninitialised `cols`x`rows` destination matrix. */
+export function dst(cols: number, rows: number) {
+    return new jsfeatNext.matrix_t(cols, rows, F32C1);
+}
+
+/** Random `n`x`n` matrix with entries in [-scale/2, scale/2). */
+export function randomSquare(n: number, seed: number, scale = 4) {
+    const rand = rng(seed);
+    const m = mat(n, n);
+    for (let i = 0; i < n * n; i++) m.data[i] = rand() * scale - scale / 2;
+    return m;
+}
+
+/**
+ * Random symmetric positive-definite `n`x`n` matrix (`MᵀM + nI`).
+ * Well conditioned, so the solvers have a unique stable answer — required by
+ * `cholesky_solve`, and it keeps `lu_solve`/SVD away from degenerate cases.
+ */
+export function randomSPD(n: number, seed: number) {
+    const rand = rng(seed);
+    const raw = Array.from({ length: n * n }, () => rand() * 4 - 2);
+    const m = mat(n, n);
+    for (let r = 0; r < n; r++) {
+        for (let c = 0; c < n; c++) {
+            let s = 0;
+            for (let k = 0; k < n; k++) s += raw[k * n + r] * raw[k * n + c];
+            if (r === c) s += n; // dominate the diagonal
+            m.data[r * n + c] = s;
+        }
+    }
+    return m;
+}
+
+/** Plain row-major multiply, used as an independent check of the library's own. */
+export function matmulPlain(A: ArrayLike<number>, B: ArrayLike<number>, n: number, m: number, p: number) {
+    // A is n x m, B is m x p, result is n x p
+    const out = new Float64Array(n * p);
+    for (let i = 0; i < n; i++) {
+        for (let j = 0; j < p; j++) {
+            let s = 0;
+            for (let k = 0; k < m; k++) s += A[i * m + k] * B[k * p + j];
+            out[i * p + j] = s;
+        }
+    }
+    return out;
+}
+
+/** Asserts `m` is the `n`x`n` identity within `digits` decimal places. */
+export function expectIdentity(m: { data: ArrayLike<number> }, n: number, digits = 4) {
+    for (let r = 0; r < n; r++) {
+        for (let c = 0; c < n; c++) {
+            expect(m.data[r * n + c]).toBeCloseTo(r === c ? 1 : 0, digits);
+        }
+    }
+}
+
+/** Asserts two flat numeric sequences agree element-wise. */
+export function expectClose(actual: ArrayLike<number>, expected: ArrayLike<number>, len: number, digits = 4) {
+    for (let i = 0; i < len; i++) {
+        expect(actual[i]).toBeCloseTo(expected[i], digits);
+    }
+}

--- a/tests/properties/linalg.test.ts
+++ b/tests/properties/linalg.test.ts
@@ -118,8 +118,7 @@ describe("linalg invariants", () => {
 
             const UD = matmulPlain(U.data, D, n, n, n);
             const recon = matmulPlain(UD, Vt, n, n, n);
-            for (let i = 0; i < n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
-        });
+            for (let i = 0; i < n * n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
 
         it("reconstructs the input: A = Uᵀ·diag(W)·V (SVD_U_T | SVD_V_T)", () => {
             const A = mat(n, n, values);

--- a/tests/properties/linalg.test.ts
+++ b/tests/properties/linalg.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { mat, dst, randomSquare, randomSPD, matmulPlain, expectIdentity, rng } from "./helpers";
+
+/**
+ * Property/invariant tests for `linalg` (issue #87).
+ *
+ * Every assertion here is a mathematical truth that holds regardless of the
+ * implementation, so unlike `tests/parity/linalg.test.ts` these can catch a
+ * defect that jsfeatNext and jsfeat share. #102 is exactly such a defect, and
+ * the `svd_invert` invariant below is what pins it.
+ *
+ * Convention notes established empirically against the library:
+ *  - `svd_decompose(A, W, U, V, 0)` returns the natural form, `A = U·diag(W)·Vᵀ`.
+ *  - With `SVD_U_T | SVD_V_T` the two factors come back transposed, so the
+ *    reconstruction becomes `A = Uᵀ·diag(W)·V`.
+ *  - A `matrix_t`'s `data` view can be LONGER than rows*cols (the buffer is
+ *    padded to a multiple of 8 bytes), so always slice to the logical size.
+ */
+
+const la = jsfeatNext.linalg;
+
+/** Reads the logical `n` entries of a vector matrix_t, ignoring buffer padding. */
+function vec(m: { data: ArrayLike<number> }, n: number) {
+    return Array.from({ length: n }, (_, i) => m.data[i]);
+}
+
+/** `A · x` for a row-major n×n matrix and length-n vector. */
+function apply(A: ArrayLike<number>, x: ArrayLike<number>, n: number) {
+    const out = new Float64Array(n);
+    for (let r = 0; r < n; r++) {
+        let s = 0;
+        for (let c = 0; c < n; c++) s += A[r * n + c] * x[c];
+        out[r] = s;
+    }
+    return out;
+}
+
+describe("linalg invariants", () => {
+    describe("lu_solve", () => {
+        it("returns a genuine solution: A·x ≈ b", () => {
+            const n = 4;
+            const A = randomSPD(n, 101);
+            const Aorig = Array.from(A.data.subarray(0, n * n)); // lu_solve mutates A
+            const b = mat(1, n);
+            const rand = rng(102);
+            for (let i = 0; i < n; i++) b.data[i] = rand() * 10 - 5;
+            const bOrig = vec(b, n);
+
+            const ok = la.lu_solve(A, b); // b is overwritten with x
+            expect(ok).toBe(1);
+
+            const residual = apply(Aorig, vec(b, n), n);
+            for (let i = 0; i < n; i++) expect(residual[i]).toBeCloseTo(bOrig[i], 3);
+        });
+
+        it("solves a hand-checkable 2x2 system exactly", () => {
+            // 4x + 7y = 1 ; 2x + 6y = 1  ->  x = -0.1, y = 0.2
+            const A = mat(2, 2, [4, 7, 2, 6]);
+            const b = mat(1, 2, [1, 1]);
+            expect(la.lu_solve(A, b)).toBe(1);
+            expect(b.data[0]).toBeCloseTo(-0.1, 4);
+            expect(b.data[1]).toBeCloseTo(0.2, 4);
+        });
+
+        it("reports failure (0) on a singular matrix instead of inventing an answer", () => {
+            const A = mat(3, 3, [1, 2, 3, 2, 4, 6, 1, 1, 1]); // row1 = 2*row0
+            const b = mat(1, 3, [1, 2, 3]);
+            expect(la.lu_solve(A, b)).toBe(0);
+        });
+    });
+
+    describe("cholesky_solve", () => {
+        it("returns a genuine solution for a symmetric positive-definite system", () => {
+            const n = 4;
+            const A = randomSPD(n, 111);
+            const Aorig = Array.from(A.data.subarray(0, n * n));
+            const b = mat(1, n);
+            const rand = rng(112);
+            for (let i = 0; i < n; i++) b.data[i] = rand() * 10 - 5;
+            const bOrig = vec(b, n);
+
+            expect(la.cholesky_solve(A, b)).toBe(1);
+
+            const residual = apply(Aorig, vec(b, n), n);
+            for (let i = 0; i < n; i++) expect(residual[i]).toBeCloseTo(bOrig[i], 3);
+        });
+
+        it("agrees with lu_solve on the same SPD system", () => {
+            const n = 4;
+            const A1 = randomSPD(n, 121);
+            const A2 = mat(n, n, Array.from(A1.data.subarray(0, n * n)));
+            const b1 = mat(1, n, [1, 2, 3, 4]);
+            const b2 = mat(1, n, [1, 2, 3, 4]);
+
+            la.cholesky_solve(A1, b1);
+            la.lu_solve(A2, b2);
+
+            for (let i = 0; i < n; i++) expect(b1.data[i]).toBeCloseTo(b2.data[i], 3);
+        });
+    });
+
+    describe("svd_decompose", () => {
+        const n = 3;
+        const values = [1, 2, 0, 0, 1, 3, 2, 0, 1]; // asymmetric, full rank
+
+        it("reconstructs the input: A = U·diag(W)·Vᵀ (opts = 0)", () => {
+            const A = mat(n, n, values);
+            const W = dst(1, n);
+            const U = dst(n, n);
+            const V = dst(n, n);
+            la.svd_decompose(A, W, U, V, 0);
+
+            const D = new Float64Array(n * n);
+            for (let i = 0; i < n; i++) D[i * n + i] = W.data[i];
+            const Vt = new Float64Array(n * n);
+            for (let r = 0; r < n; r++) for (let c = 0; c < n; c++) Vt[c * n + r] = V.data[r * n + c];
+
+            const UD = matmulPlain(U.data, D, n, n, n);
+            const recon = matmulPlain(UD, Vt, n, n, n);
+            for (let i = 0; i < n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
+        });
+
+        it("reconstructs the input: A = Uᵀ·diag(W)·V (SVD_U_T | SVD_V_T)", () => {
+            const A = mat(n, n, values);
+            const W = dst(1, n);
+            const U = dst(n, n);
+            const V = dst(n, n);
+            la.svd_decompose(A, W, U, V, jsfeatNext.SVD_U_T | jsfeatNext.SVD_V_T);
+
+            const D = new Float64Array(n * n);
+            for (let i = 0; i < n; i++) D[i * n + i] = W.data[i];
+            const Ut = new Float64Array(n * n);
+            for (let r = 0; r < n; r++) for (let c = 0; c < n; c++) Ut[c * n + r] = U.data[r * n + c];
+
+            const UtD = matmulPlain(Ut, D, n, n, n);
+            const recon = matmulPlain(UtD, V.data, n, n, n);
+            for (let i = 0; i < n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
+        });
+
+        it("singular values are non-negative and in descending order", () => {
+            const A = randomSquare(4, 131);
+            const W = dst(1, 4);
+            const U = dst(4, 4);
+            const V = dst(4, 4);
+            la.svd_decompose(A, W, U, V, 0);
+
+            const w = vec(W, 4);
+            for (const s of w) expect(s).toBeGreaterThanOrEqual(0);
+            for (let i = 1; i < w.length; i++) expect(w[i]).toBeLessThanOrEqual(w[i - 1] + 1e-5);
+        });
+
+        it("U and V are orthonormal: UᵀU ≈ I and VᵀV ≈ I", () => {
+            const n4 = 4;
+            const A = randomSquare(n4, 141);
+            const W = dst(1, n4);
+            const U = dst(n4, n4);
+            const V = dst(n4, n4);
+            la.svd_decompose(A, W, U, V, 0);
+
+            for (const M of [U, V]) {
+                const Mt = new Float64Array(n4 * n4);
+                for (let r = 0; r < n4; r++) for (let c = 0; c < n4; c++) Mt[c * n4 + r] = M.data[r * n4 + c];
+                const prod = matmulPlain(Mt, M.data, n4, n4, n4);
+                expectIdentity({ data: prod }, n4, 3);
+            }
+        });
+
+        it("singular values of a diagonal matrix are its |entries|, sorted", () => {
+            const A = mat(3, 3, [4, 0, 0, 0, -3, 0, 0, 0, 2]);
+            const W = dst(1, 3);
+            const U = dst(3, 3);
+            const V = dst(3, 3);
+            la.svd_decompose(A, W, U, V, 0);
+            expect(vec(W, 3).map((x) => Math.round(x * 1000) / 1000)).toEqual([4, 3, 2]);
+        });
+    });
+
+    describe("svd_solve", () => {
+        it("returns a genuine solution: A·x ≈ b", () => {
+            const n = 4;
+            const A = randomSPD(n, 151);
+            const Aorig = Array.from(A.data.subarray(0, n * n));
+            const b = mat(1, n, [1, -2, 3, 0.5]);
+            const x = dst(1, n);
+
+            la.svd_solve(A, x, b);
+
+            const residual = apply(Aorig, vec(x, n), n);
+            const bWant = [1, -2, 3, 0.5];
+            for (let i = 0; i < n; i++) expect(residual[i]).toBeCloseTo(bWant[i], 3);
+        });
+    });
+
+    describe("svd_invert", () => {
+        it("A · A⁻¹ ≈ I and A⁻¹ · A ≈ I", () => {
+            const n = 3;
+            const A = mat(n, n, [4, 7, 2, 2, 6, 1, 1, 1, 3]);
+            const Ai = dst(n, n);
+            la.svd_invert(Ai, A);
+
+            const left = matmulPlain(A.data, Ai.data, n, n, n);
+            expectIdentity({ data: left }, n, 3);
+            const right = matmulPlain(Ai.data, A.data, n, n, n);
+            expectIdentity({ data: right }, n, 3);
+        });
+
+        it("satisfies the defining Moore–Penrose property A·A⁺·A ≈ A", () => {
+            // The invariant that would have caught #102. It holds for square
+            // input today; once the rectangular pseudo-inverse is implemented
+            // (#102 option b) this same assertion should pass for non-square
+            // matrices too, with no other change.
+            const n = 3;
+            const values = [4, 7, 2, 2, 6, 1, 1, 1, 3];
+            const A = mat(n, n, values);
+            const Ap = dst(n, n);
+            la.svd_invert(Ap, A);
+
+            const AAp = matmulPlain(A.data, Ap.data, n, n, n);
+            const AApA = matmulPlain(AAp, A.data, n, n, n);
+            for (let i = 0; i < n * n; i++) expect(AApA[i]).toBeCloseTo(values[i], 3);
+        });
+
+        it("inverts the identity to the identity", () => {
+            const I = dst(3, 3);
+            jsfeatNext.matmath.identity(I, 1.0);
+            const Ii = dst(3, 3);
+            la.svd_invert(Ii, I);
+            expectIdentity(Ii, 3);
+        });
+    });
+
+    describe("eigenVV", () => {
+        it("every eigenpair satisfies A·v ≈ λ·v", () => {
+            const n = 4;
+            const A = randomSPD(n, 161);
+            const Aorig = Array.from(A.data.subarray(0, n * n));
+            const vects = dst(n, n);
+            const vals = dst(1, n);
+
+            la.eigenVV(A, vects, vals);
+
+            for (let e = 0; e < n; e++) {
+                const lambda = vals.data[e];
+                const v = Array.from({ length: n }, (_, i) => vects.data[e * n + i]); // eigenvectors are rows
+                const Av = apply(Aorig, v, n);
+                for (let i = 0; i < n; i++) expect(Av[i]).toBeCloseTo(lambda * v[i], 3);
+            }
+        });
+
+        it("eigenvalues come back in descending order", () => {
+            const A = randomSPD(4, 171);
+            const vects = dst(4, 4);
+            const vals = dst(1, 4);
+            la.eigenVV(A, vects, vals);
+
+            const w = vec(vals, 4);
+            for (let i = 1; i < w.length; i++) expect(w[i]).toBeLessThanOrEqual(w[i - 1] + 1e-5);
+        });
+
+        it("eigenvectors are unit length", () => {
+            const n = 4;
+            const A = randomSPD(n, 181);
+            const vects = dst(n, n);
+            const vals = dst(1, n);
+            la.eigenVV(A, vects, vals);
+
+            for (let e = 0; e < n; e++) {
+                let norm = 0;
+                for (let i = 0; i < n; i++) norm += vects.data[e * n + i] ** 2;
+                expect(Math.sqrt(norm)).toBeCloseTo(1, 3);
+            }
+        });
+
+        it("a symmetric positive-definite matrix has strictly positive eigenvalues", () => {
+            const A = randomSPD(4, 191);
+            const vects = dst(4, 4);
+            const vals = dst(1, 4);
+            la.eigenVV(A, vects, vals);
+            for (const lambda of vec(vals, 4)) expect(lambda).toBeGreaterThan(0);
+        });
+    });
+});

--- a/tests/properties/linalg.test.ts
+++ b/tests/properties/linalg.test.ts
@@ -119,6 +119,7 @@ describe("linalg invariants", () => {
             const UD = matmulPlain(U.data, D, n, n, n);
             const recon = matmulPlain(UD, Vt, n, n, n);
             for (let i = 0; i < n * n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
+        });
 
         it("reconstructs the input: A = Uᵀ·diag(W)·V (SVD_U_T | SVD_V_T)", () => {
             const A = mat(n, n, values);
@@ -134,7 +135,7 @@ describe("linalg invariants", () => {
 
             const UtD = matmulPlain(Ut, D, n, n, n);
             const recon = matmulPlain(UtD, V.data, n, n, n);
-            for (let i = 0; i < n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
+            for (let i = 0; i < n * n; i++) expect(recon[i]).toBeCloseTo(values[i], 3);
         });
 
         it("singular values are non-negative and in descending order", () => {

--- a/tests/properties/matmath.test.ts
+++ b/tests/properties/matmath.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { mat, dst, randomSquare, matmulPlain, expectIdentity, expectClose, rng } from "./helpers";
+
+/**
+ * Property/invariant tests for `matmath` (issue #87).
+ *
+ * Unlike `tests/parity/matmath.test.ts`, nothing here compares against the
+ * jsfeat oracle — every assertion is a mathematical truth that must hold no
+ * matter how (or by whom) the function is implemented.
+ *
+ * `multiply` is verified first against an independent plain-JS implementation,
+ * because the linalg invariants lean on it to check their own results.
+ */
+
+const mm = jsfeatNext.matmath;
+
+describe("matmath invariants", () => {
+    describe("multiply", () => {
+        it("agrees with a plain reference implementation", () => {
+            // A is 2x3 (rows x cols), B is 3x2  ->  C is 2x2
+            const A = mat(3, 2, [1, 2, 3, 4, 5, 6]);
+            const B = mat(2, 3, [7, 8, 9, 10, 11, 12]);
+            const C = dst(2, 2);
+            mm.multiply(C, A, B);
+
+            const want = matmulPlain(A.data, B.data, 2, 3, 2);
+            expectClose(C.data, want, 4);
+        });
+
+        it("is associative: (A·B)·C = A·(B·C)", () => {
+            const A = randomSquare(3, 11);
+            const B = randomSquare(3, 12);
+            const C = randomSquare(3, 13);
+
+            const AB = dst(3, 3);
+            const left = dst(3, 3);
+            mm.multiply(AB, A, B);
+            mm.multiply(left, AB, C);
+
+            const BC = dst(3, 3);
+            const right = dst(3, 3);
+            mm.multiply(BC, B, C);
+            mm.multiply(right, A, BC);
+
+            expectClose(left.data, right.data, 9, 3);
+        });
+
+        it("has the identity as a neutral element: M·I = I·M = M", () => {
+            const M = randomSquare(4, 14);
+            const I = dst(4, 4);
+            mm.identity(I, 1.0);
+
+            const right = dst(4, 4);
+            const left = dst(4, 4);
+            mm.multiply(right, M, I);
+            mm.multiply(left, I, M);
+
+            expectClose(right.data, M.data, 16);
+            expectClose(left.data, M.data, 16);
+        });
+    });
+
+    describe("transpose", () => {
+        it("is an involution: transpose(transpose(A)) = A", () => {
+            const A = mat(3, 2, [1, 2, 3, 4, 5, 6]); // 2 rows x 3 cols
+            const At = dst(2, 3);
+            const Att = dst(3, 2);
+            mm.transpose(At, A);
+            mm.transpose(Att, At);
+            expectClose(Att.data, A.data, 6);
+        });
+
+        it("moves element (r,c) to (c,r)", () => {
+            const A = mat(3, 2, [1, 2, 3, 4, 5, 6]);
+            const At = dst(2, 3);
+            mm.transpose(At, A);
+            // A is 2x3, At is 3x2
+            for (let r = 0; r < 2; r++) {
+                for (let c = 0; c < 3; c++) {
+                    expect(At.data[c * 2 + r]).toBeCloseTo(A.data[r * 3 + c], 6);
+                }
+            }
+        });
+    });
+
+    describe("identity / identity_3x3", () => {
+        it("puts `value` on the diagonal and zero elsewhere", () => {
+            const M = dst(4, 4);
+            mm.identity(M, 2.5);
+            for (let r = 0; r < 4; r++) {
+                for (let c = 0; c < 4; c++) {
+                    expect(M.data[r * 4 + c]).toBeCloseTo(r === c ? 2.5 : 0, 6);
+                }
+            }
+        });
+
+        it("identity_3x3 matches the generic identity for 3x3", () => {
+            const a = dst(3, 3);
+            const b = dst(3, 3);
+            mm.identity_3x3(a, 1.0);
+            mm.identity(b, 1.0);
+            expectClose(a.data, b.data, 9, 6);
+        });
+    });
+
+    describe("invert_3x3", () => {
+        it("M · M⁻¹ = I and M⁻¹ · M = I", () => {
+            const M = mat(3, 3, [2, 0, 5, 0, 3, 7, 0, 0, 1]);
+            const Mi = dst(3, 3);
+            mm.invert_3x3(M, Mi); // NB: (from, to)
+
+            const P = dst(3, 3);
+            mm.multiply_3x3(P, M, Mi);
+            expectIdentity(P, 3);
+
+            const Q = dst(3, 3);
+            mm.multiply_3x3(Q, Mi, M);
+            expectIdentity(Q, 3);
+        });
+
+        it("is an involution: invert(invert(M)) = M", () => {
+            const M = randomSquare(3, 21);
+            const Mi = dst(3, 3);
+            const Mii = dst(3, 3);
+            mm.invert_3x3(M, Mi);
+            mm.invert_3x3(Mi, Mii);
+            expectClose(Mii.data, M.data, 9, 3);
+        });
+
+        it("inverts the identity to the identity", () => {
+            const I = dst(3, 3);
+            mm.identity_3x3(I, 1.0);
+            const Ii = dst(3, 3);
+            mm.invert_3x3(I, Ii);
+            expectIdentity(Ii, 3);
+        });
+    });
+
+    describe("mat3x3_determinant", () => {
+        it("det(I) = 1", () => {
+            const I = dst(3, 3);
+            mm.identity_3x3(I, 1.0);
+            expect(mm.mat3x3_determinant(I)).toBeCloseTo(1, 5);
+        });
+
+        it("is multiplicative: det(A·B) = det(A)·det(B)", () => {
+            const A = randomSquare(3, 31);
+            const B = randomSquare(3, 32);
+            const AB = dst(3, 3);
+            mm.multiply_3x3(AB, A, B);
+
+            expect(mm.mat3x3_determinant(AB)).toBeCloseTo(mm.mat3x3_determinant(A) * mm.mat3x3_determinant(B), 3);
+        });
+
+        it("is zero for a singular matrix (duplicate rows)", () => {
+            const S = mat(3, 3, [1, 2, 3, 1, 2, 3, 4, 5, 7]);
+            expect(Math.abs(mm.mat3x3_determinant(S))).toBeLessThan(1e-5);
+        });
+
+        it("scaling one row by k scales the determinant by k", () => {
+            const A = randomSquare(3, 33);
+            const before = mm.mat3x3_determinant(A);
+            const B = mat(3, 3, Array.from(A.data.subarray(0, 9)));
+            for (let c = 0; c < 3; c++) B.data[c] *= 3; // scale row 0
+            expect(mm.mat3x3_determinant(B)).toBeCloseTo(before * 3, 3);
+        });
+    });
+
+    describe("the multiply_At* family agrees with explicit transpose+multiply", () => {
+        // A is 3 rows x 2 cols
+        const A = mat(2, 3, [1, 2, 3, 4, 5, 6]);
+        const B = mat(2, 3, [7, 8, 9, 10, 11, 12]);
+
+        it("multiply_AtA(C, A) = Aᵀ·A", () => {
+            const C = dst(2, 2);
+            mm.multiply_AtA(C, A);
+            const At = dst(3, 2);
+            mm.transpose(At, A);
+            const want = dst(2, 2);
+            mm.multiply(want, At, A);
+            expectClose(C.data, want.data, 4);
+        });
+
+        it("multiply_AAt(C, A) = A·Aᵀ", () => {
+            const C = dst(3, 3);
+            mm.multiply_AAt(C, A);
+            const At = dst(3, 2);
+            mm.transpose(At, A);
+            const want = dst(3, 3);
+            mm.multiply(want, A, At);
+            expectClose(C.data, want.data, 9);
+        });
+
+        it("multiply_AtB(C, A, B) = Aᵀ·B", () => {
+            const C = dst(2, 2);
+            mm.multiply_AtB(C, A, B);
+            const At = dst(3, 2);
+            mm.transpose(At, A);
+            const want = dst(2, 2);
+            mm.multiply(want, At, B);
+            expectClose(C.data, want.data, 4);
+        });
+
+        it("multiply_ABt(C, A, B) = A·Bᵀ", () => {
+            const C = dst(3, 3);
+            mm.multiply_ABt(C, A, B);
+            const Bt = dst(3, 2);
+            mm.transpose(Bt, B);
+            const want = dst(3, 3);
+            mm.multiply(want, A, Bt);
+            expectClose(C.data, want.data, 9);
+        });
+
+        it("Aᵀ·A is symmetric", () => {
+            const C = dst(2, 2);
+            mm.multiply_AtA(C, A);
+            expect(C.data[1]).toBeCloseTo(C.data[2], 5);
+        });
+    });
+
+    describe("multiply_3x3 matches the generic multiply for 3x3", () => {
+        it("produces the same product", () => {
+            const A = randomSquare(3, 41);
+            const B = randomSquare(3, 42);
+            const viaFixed = dst(3, 3);
+            const viaGeneric = dst(3, 3);
+            mm.multiply_3x3(viaFixed, A, B);
+            mm.multiply(viaGeneric, A, B);
+            expectClose(viaFixed.data, viaGeneric.data, 9, 4);
+        });
+    });
+});

--- a/tests/properties/matmath.test.ts
+++ b/tests/properties/matmath.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import jsfeatNext from "../../src/jsfeatNext";
-import { mat, dst, randomSquare, matmulPlain, expectIdentity, expectClose, rng } from "./helpers";
+import { mat, dst, randomSquare, matmulPlain, expectIdentity, expectClose } from "./helpers";
 
 /**
  * Property/invariant tests for `matmath` (issue #87).


### PR DESCRIPTION
**Phase 1 of the #87 plan.** Property/invariant tests assert mathematical truths that hold *regardless of implementation* — the only kind of test that can catch a defect jsfeatNext **shares** with jsfeat (the parity suite structurally cannot — see #102), or cover code with no oracle at all.

Tests only, **no `src/` changes**. **66 → 104 tests.**

## The suite now has a clean three-way split
| Directory | Job |
|---|---|
| `tests/parity/` | we **must match** jsfeat — refactor safety net |
| **`tests/properties/`** ← new | must be **mathematically true**, implementation-agnostic |
| `tests/divergences.test.ts` | we **deliberately don't match** jsfeat |

## What's asserted
**`matmath` (20)** — `multiply` vs an independent plain-JS reference, associativity, identity element; `transpose` is an involution and maps (r,c)→(c,r); `invert_3x3` gives `M·M⁻¹ = M⁻¹·M = I`, is an involution, fixes `I`; determinant is 1 for `I`, multiplicative, zero when singular, scales with a row; the `multiply_At*` family cross-checked against explicit transpose+multiply, and `AᵀA` symmetric.

**`linalg` (18)** — `lu_solve`/`cholesky_solve` verified **by residual** (`A·x ≈ b`) rather than by comparing numbers, plus a hand-checkable 2×2 and the singular case returning `0`; the two solvers agree; `svd_decompose` reconstructs its input in **both** flag modes, has non-negative descending singular values, orthonormal `U`/`V`, and recovers a diagonal matrix's known values; `svd_solve` by residual; `svd_invert` gives `A·A⁻¹ = I` **and** the defining `A·A⁺·A ≈ A`; `eigenVV` satisfies `A·v ≈ λ·v` per pair, descending eigenvalues, unit eigenvectors, positive eigenvalues for SPD.

## Two conventions established empirically (not assumed), recorded in the file header
- `svd_decompose(A,W,U,V,0)` → natural `A = U·diag(W)·Vᵀ`; with `SVD_U_T|SVD_V_T` both factors come back **transposed**, so it becomes `A = Uᵀ·diag(W)·V`.
- A `matrix_t` `data` view can be **longer than rows×cols** (buffer padded to a multiple of 8 bytes), so vectors must be sliced to their logical length.

## Proving the tests can actually fail
A green suite proves nothing on its own, so:

1. **Ran the Moore–Penrose invariant against the *unguarded* jsfeat oracle** with #102's non-square input. `A·A⁺·A` returned `[1, 0.3077, 2.9231, 0, 0.4615, 1.3846]` instead of `[1, 0, 2, 0, 1, 3]` — **the invariant fails, confirming it would have caught #102.** That's #87's central claim, now demonstrated rather than argued.
2. **Mutation-tested:** perturbing a term in `invert_3x3` failed **3** tests; perturbing the eigenvalue update in `eigenVV` failed the `A·v = λ·v` test. Source restored and the full suite re-verified after.

## Verification
`tsc --noEmit` clean · `npm test` **104/104** · prettier clean.

> Leaves #87 open — phases 2 (edge cases) and 3 (golden fixtures), plus `imgproc`/detectors/optical-flow invariants, still to come.

🤖 Generated with [Claude Code](https://claude.com/claude-code)