### PR TITLE
test: edge cases, data structures and buffer-pool coverage (refs #87, categories B + D)

### DIFF
--- a/tests/properties/cache.test.ts
+++ b/tests/properties/cache.test.ts
@@ -38,7 +38,7 @@
 
 import { describe, it, expect } from "vitest";
 import jsfeatNext from "../../src/jsfeatNext";
-import { U8C1, F32C1, uniformImage, dstImage, cornerScene, keypointPool } from "./helpers";
+import { U8C1, F32C1, uniformImage, dstImage, cornerScene, keypointPool, rng } from "./helpers";
 
 /**
  * Tests for the shared buffer pool (issue #87, category D).
@@ -50,8 +50,19 @@ import { U8C1, F32C1, uniformImage, dstImage, cornerScene, keypointPool } from "
  * It deserves better: AGENTS.md makes "balance every `get_buffer` with a
  * `put_buffer`" a standing rule, every algorithm in the library borrows from
  * this one pool, and an imbalance is invisible until the pool drains and an
- * unrelated module starts reading someone else's scratch memory. The last test
- * here is the real prize — it holds every module to that rule at once.
+ * unrelated module starts reading someone else's scratch memory.
+ *
+ * The second block below is the real prize. It exercises real algorithm calls,
+ * but it is NOT testing those algorithms — nothing about their output is
+ * asserted. They are the subject matter: the only assertion is that the pool's
+ * free count is identical before and after. The rule belongs to the pool
+ * rather than to any one module, so it is checked in one place where the
+ * coverage is visible and a newly added module is obviously missing.
+ *
+ * Every module that calls `get_buffer` is represented — verified against
+ * `grep -rl get_buffer src/`, which is the list to re-check when adding one:
+ * imgproc (incl. resample), fast_corners, yape06, orb, optical_flow_lk,
+ * linalg, math, motion_estimator and motion_model.
  */
 
 const pool = jsfeatNext.cache;
@@ -176,6 +187,68 @@ describe("every module returns what it borrows", () => {
                 0.0001
             );
         });
+    });
+
+    it("math.get_gaussian_kernel is balanced", () => {
+        // Borrows a scratch node directly, not only via the blur paths above.
+        expectBalanced("get_gaussian_kernel f32", () =>
+            jsfeatNext.math.get_gaussian_kernel(7, 0, new Float32Array(7), jsfeatNext.F32_t)
+        );
+        expectBalanced("get_gaussian_kernel u8", () =>
+            jsfeatNext.math.get_gaussian_kernel(9, 1.5, new Int32Array(9), jsfeatNext.U8_t)
+        );
+    });
+
+    it("motion_estimator and its kernels are balanced", () => {
+        // ransac/lmeds each borrow three nodes, and the motion models borrow
+        // two more inside run(). None of it is reached by the paths above.
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const rand = rng(1234);
+        const from: { x: number; y: number }[] = [];
+        const to: { x: number; y: number }[] = [];
+        for (let i = 0; i < 40; i++) {
+            const x = 10 + rand() * 300;
+            const y = 10 + rand() * 220;
+            const w = 1.0 / (GT[6] * x + GT[7] * y + GT[8]);
+            from.push({ x, y });
+            to.push({ x: (GT[0] * x + GT[1] * y + GT[2]) * w, y: (GT[3] * x + GT[4] * y + GT[5]) * w });
+        }
+
+        const me = jsfeatNext.motion_estimator;
+        for (const kernel of [jsfeatNext.homography2d, jsfeatNext.affine2d]) {
+            expectBalanced("motion_model.run", () => {
+                const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+                kernel.run(from, to, model, from.length);
+            });
+            expectBalanced("motion_estimator.ransac", () => {
+                const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+                const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+                me.ransac(
+                    params,
+                    kernel,
+                    from,
+                    to,
+                    from.length,
+                    model,
+                    new jsfeatNext.matrix_t(from.length, 1, U8C1),
+                    100
+                );
+            });
+            expectBalanced("motion_estimator.lmeds", () => {
+                const params = new jsfeatNext.ransac_params_t(4, 0, 0.45, 0.99);
+                const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+                me.lmeds(
+                    params,
+                    kernel,
+                    from,
+                    to,
+                    from.length,
+                    model,
+                    new jsfeatNext.matrix_t(from.length, 1, U8C1),
+                    100
+                );
+            });
+        }
     });
 
     it("linalg solvers are balanced", () => {

--- a/tests/properties/cache.test.ts
+++ b/tests/properties/cache.test.ts
@@ -1,0 +1,212 @@
+/*
+ *  cache.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { U8C1, F32C1, uniformImage, dstImage, cornerScene, keypointPool } from "./helpers";
+
+/**
+ * Tests for the shared buffer pool (issue #87, category D).
+ *
+ * The pool had no behavioural coverage at all — `tests/api-shape` only checked
+ * that `jsfeatNext.cache.get_buffer` is a function and that every module points
+ * at the same object.
+ *
+ * It deserves better: AGENTS.md makes "balance every `get_buffer` with a
+ * `put_buffer`" a standing rule, every algorithm in the library borrows from
+ * this one pool, and an imbalance is invisible until the pool drains and an
+ * unrelated module starts reading someone else's scratch memory. The last test
+ * here is the real prize — it holds every module to that rule at once.
+ */
+
+const pool = jsfeatNext.cache;
+
+/** The pool's free-node count. Private, but it is the thing under test. */
+const freeCount = () => (pool as unknown as { _pool_size: number })._pool_size;
+
+describe("shared buffer pool mechanics", () => {
+    it("hands out a node and takes it back", () => {
+        const before = freeCount();
+        const node = pool.get_buffer(64);
+        expect(freeCount()).toBe(before - 1);
+        pool.put_buffer(node);
+        expect(freeCount()).toBe(before);
+    });
+
+    it("returns a node at least as large as requested", () => {
+        const node = pool.get_buffer(64);
+        expect(node.size).toBeGreaterThanOrEqual(64);
+        pool.put_buffer(node);
+    });
+
+    it("grows a node on demand for an oversized request", () => {
+        // Nodes start small; asking for more than the node holds must resize it
+        // rather than hand back something too short to write into.
+        const huge = 1 << 20;
+        const node = pool.get_buffer(huge);
+        expect(node.size).toBeGreaterThanOrEqual(huge);
+        expect(node.u8.length).toBeGreaterThanOrEqual(huge);
+        pool.put_buffer(node);
+    });
+
+    it("keeps the node's views consistent after a resize", () => {
+        const node = pool.get_buffer(4096);
+        expect(node.u8.buffer).toBe(node.buffer);
+        expect(node.i32.buffer).toBe(node.buffer);
+        expect(node.f32.buffer).toBe(node.buffer);
+        expect(node.f64.buffer).toBe(node.buffer);
+        node.i32[0] = 123456;
+        expect(node.i32[0]).toBe(123456);
+        pool.put_buffer(node);
+    });
+
+    it("restores the free count after borrowing several at once", () => {
+        const before = freeCount();
+        const nodes = [pool.get_buffer(32), pool.get_buffer(64), pool.get_buffer(128)];
+        expect(freeCount()).toBe(before - 3);
+        for (const n of nodes) pool.put_buffer(n);
+        expect(freeCount()).toBe(before);
+    });
+});
+
+describe("every module returns what it borrows", () => {
+    /** Asserts `run` leaves the pool exactly as it found it. */
+    function expectBalanced(label: string, run: () => void) {
+        const before = freeCount();
+        run();
+        expect(`${label}: ${freeCount()}`).toBe(`${label}: ${before}`);
+    }
+
+    const ip = jsfeatNext.imgproc;
+    const W = 96;
+    const H = 72;
+
+    it("imgproc operations are balanced", () => {
+        expectBalanced("gaussian_blur", () => ip.gaussian_blur(uniformImage(32, 32, 90), dstImage(32, 32), 5, 0));
+        expectBalanced("box_blur_gray", () => ip.box_blur_gray(uniformImage(32, 32, 90), dstImage(32, 32), 3, 0));
+        expectBalanced("sobel_derivatives", () =>
+            ip.sobel_derivatives(uniformImage(32, 32, 90), new jsfeatNext.matrix_t(32, 32, jsfeatNext.S32C2_t))
+        );
+        expectBalanced("scharr_derivatives", () =>
+            ip.scharr_derivatives(uniformImage(32, 32, 90), new jsfeatNext.matrix_t(32, 32, jsfeatNext.S32C2_t))
+        );
+        expectBalanced("canny", () => ip.canny(cornerScene(32, 32), dstImage(32, 32), 20, 50));
+        expectBalanced("equalize_histogram", () => ip.equalize_histogram(cornerScene(32, 32), dstImage(32, 32)));
+        expectBalanced("pyrdown", () => ip.pyrdown(cornerScene(32, 32), dstImage(16, 16)));
+        expectBalanced("resample", () => ip.resample(cornerScene(32, 32), dstImage(16, 16), 16, 16));
+        expectBalanced("compute_integral_image", () =>
+            ip.compute_integral_image(cornerScene(32, 32), new Int32Array(33 * 33), null, null)
+        );
+    });
+
+    it("detectors and the descriptor are balanced", () => {
+        const fc = jsfeatNext.fast_corners;
+        fc.set_threshold(20);
+
+        expectBalanced("fast_corners.detect", () => fc.detect(cornerScene(W, H), keypointPool(1024), 5));
+        expectBalanced("yape06.detect", () => jsfeatNext.yape06.detect(cornerScene(W, H), keypointPool(1024), 5));
+        expectBalanced("yape.detect", () => {
+            const y = jsfeatNext.yape;
+            y.init(W, H, 5, 1);
+            y.detect(cornerScene(W, H), keypointPool(1024), 4);
+        });
+        expectBalanced("orb.describe", () => {
+            const corners = keypointPool(1024);
+            const n = fc.detect(cornerScene(W, H), corners, 24);
+            for (let i = 0; i < n; i++) corners[i].angle = 0;
+            jsfeatNext.orb.describe(cornerScene(W, H), corners, n, new jsfeatNext.matrix_t(32, n, U8C1));
+        });
+    });
+
+    it("optical_flow_lk is balanced", () => {
+        const img = cornerScene(W, H);
+        const pyramid = () => {
+            const p = new jsfeatNext.pyramid_t(2);
+            p.allocate(W, H, U8C1);
+            p.build(img, false);
+            return p;
+        };
+        expectBalanced("optical_flow_lk.track", () => {
+            const xy = Float32Array.from([30, 30, 50, 40]);
+            jsfeatNext.optical_flow_lk.track(
+                pyramid(),
+                pyramid(),
+                xy,
+                new Float32Array(4),
+                2,
+                9,
+                30,
+                new Uint8Array(2),
+                0.01,
+                0.0001
+            );
+        });
+    });
+
+    it("linalg solvers are balanced", () => {
+        const spd = () => {
+            const m = new jsfeatNext.matrix_t(3, 3, F32C1);
+            m.data.set([4, 1, 2, 1, 5, 3, 2, 3, 6]);
+            return m;
+        };
+
+        expectBalanced("svd_decompose", () =>
+            jsfeatNext.linalg.svd_decompose(
+                spd(),
+                new jsfeatNext.matrix_t(1, 3, F32C1),
+                new jsfeatNext.matrix_t(3, 3, F32C1),
+                new jsfeatNext.matrix_t(3, 3, F32C1),
+                0
+            )
+        );
+        expectBalanced("svd_invert", () => jsfeatNext.linalg.svd_invert(new jsfeatNext.matrix_t(3, 3, F32C1), spd()));
+        expectBalanced("eigenVV", () =>
+            jsfeatNext.linalg.eigenVV(spd(), new jsfeatNext.matrix_t(3, 3, F32C1), new jsfeatNext.matrix_t(1, 3, F32C1))
+        );
+        expectBalanced("lu_solve", () => {
+            const b = new jsfeatNext.matrix_t(1, 3, F32C1);
+            b.data.set([1, 2, 3]);
+            jsfeatNext.linalg.lu_solve(spd(), b);
+        });
+        expectBalanced("cholesky_solve", () => {
+            const b = new jsfeatNext.matrix_t(1, 3, F32C1);
+            b.data.set([1, 2, 3]);
+            jsfeatNext.linalg.cholesky_solve(spd(), b);
+        });
+    });
+});

--- a/tests/properties/data-structures.test.ts
+++ b/tests/properties/data-structures.test.ts
@@ -1,0 +1,327 @@
+/*
+ *  data-structures.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { data_t } from "../../src/node_utils/data_t";
+import { point_t } from "../../src/point_t/point_t";
+import { U8C1, F32C1, cornerScene } from "./helpers";
+
+/**
+ * Tests for the data structures and `node_utils` (issue #87, category D).
+ *
+ * These were the coverage holes the issue asks about: `data_t` and
+ * `_pool_node_t` had no tests at all, `point_t` was never referenced by any
+ * test, and `pyramid_t`/`keypoint_t`/`ransac_params_t` were only ever
+ * constructed as scaffolding for algorithm tests — never asserted on.
+ *
+ * `matrix_t` is already pinned against the oracle in `tests/parity/structs`,
+ * so what follows deliberately covers what parity does NOT: the typed-array
+ * view selection, zero-initialisation, and the reallocate-vs-reuse rule in
+ * `resize`.
+ */
+
+describe("data_t (node_utils)", () => {
+    it("rounds the byte size up to a multiple of 8", () => {
+        // The f64 view needs 8-byte alignment, so an unaligned request must be
+        // padded — otherwise constructing the Float64Array would throw.
+        for (const [requested, expected] of [
+            [1, 8],
+            [7, 8],
+            [8, 8],
+            [9, 16],
+            [15, 16],
+            [16, 16],
+            [100, 104],
+        ]) {
+            expect(new data_t(requested).size).toBe(expected);
+        }
+    });
+
+    it("exposes four views over the SAME buffer", () => {
+        // The whole point of data_t: algorithms reinterpret one allocation as
+        // bytes, ints or floats without copying. If the views ever stopped
+        // aliasing, scratch buffers would silently decouple.
+        const d = new data_t(32);
+        expect(d.u8.buffer).toBe(d.buffer);
+        expect(d.i32.buffer).toBe(d.buffer);
+        expect(d.f32.buffer).toBe(d.buffer);
+        expect(d.f64.buffer).toBe(d.buffer);
+
+        d.i32[0] = 0x01020304;
+        // little-endian: the low byte lands first
+        expect(d.u8[0]).toBe(0x04);
+        expect(d.u8[3]).toBe(0x01);
+
+        // 1.5 as a double is 0x3FF8000000000000; little-endian, the high word
+        // (f32[3]) carries the exponent and the low word (f32[2]) is zero.
+        d.f64[1] = 1.5;
+        expect(d.f32[2]).toBe(0);
+        expect(d.f32[3]).not.toBe(0); // the f64 write is visible through f32
+    });
+
+    it("sizes each view to the byte length", () => {
+        const d = new data_t(64);
+        expect(d.u8.length).toBe(64);
+        expect(d.i32.length).toBe(16);
+        expect(d.f32.length).toBe(16);
+        expect(d.f64.length).toBe(8);
+    });
+
+    it("adopts the length of a buffer it is handed", () => {
+        const existing = new ArrayBuffer(48);
+        const d = new data_t(8, existing);
+        expect(d.buffer).toBe(existing);
+        expect(d.size).toBe(48); // the requested 8 is ignored in favour of the real length
+    });
+
+    it("starts zeroed", () => {
+        const d = new data_t(64);
+        for (let i = 0; i < 64; i++) expect(d.u8[i]).toBe(0);
+    });
+});
+
+describe("matrix_t beyond parity", () => {
+    it("picks the typed-array view matching the type signature", () => {
+        const cases: [number, string][] = [
+            [jsfeatNext.U8_t | jsfeatNext.C1_t, "Uint8Array"],
+            [jsfeatNext.S32_t | jsfeatNext.C1_t, "Int32Array"],
+            [jsfeatNext.F32_t | jsfeatNext.C1_t, "Float32Array"],
+            [jsfeatNext.F64_t | jsfeatNext.C1_t, "Float64Array"],
+        ];
+        for (const [type, view] of cases) {
+            const m = new jsfeatNext.matrix_t(4, 4, type);
+            expect(m.data.constructor.name).toBe(view);
+        }
+    });
+
+    it("is zero-initialised", () => {
+        // Several tests depend on this — e.g. the warp fill-value checks read
+        // untouched destination pixels.
+        const m = new jsfeatNext.matrix_t(8, 8, U8C1);
+        for (let i = 0; i < 64; i++) expect(m.data[i]).toBe(0);
+    });
+
+    it("reuses the buffer when resizing down, reallocates when it will not fit", () => {
+        const m = new jsfeatNext.matrix_t(16, 16, U8C1);
+        const original = m.buffer;
+
+        m.resize(8, 8, 1);
+        expect(m.buffer).toBe(original); // still fits: no reallocation
+        expect([m.cols, m.rows]).toEqual([8, 8]);
+
+        m.resize(64, 64, 1);
+        expect(m.buffer).not.toBe(original); // too big: fresh allocation
+        expect([m.cols, m.rows]).toEqual([64, 64]);
+    });
+
+    it("keeps channel count in the size calculation", () => {
+        // NB: sizes are padded up to a multiple of 8, so the C4 buffer is not
+        // simply 4x the C1 one — 100 bytes pads to 104 while 400 already fits.
+        const align = (bytes: number) => (bytes + 7) & -8;
+        const c1 = new jsfeatNext.matrix_t(10, 10, jsfeatNext.U8_t | jsfeatNext.C1_t);
+        const c4 = new jsfeatNext.matrix_t(10, 10, jsfeatNext.U8_t | jsfeatNext.C4_t);
+
+        expect(c1.channel).toBe(1);
+        expect(c4.channel).toBe(4);
+        expect(c1.buffer.size).toBe(align(10 * 10 * 1));
+        expect(c4.buffer.size).toBe(align(10 * 10 * 4));
+    });
+
+    it("copy_to transfers every element", () => {
+        const src = new jsfeatNext.matrix_t(5, 3, U8C1);
+        for (let i = 0; i < 15; i++) src.data[i] = i * 7;
+        const dst = new jsfeatNext.matrix_t(5, 3, U8C1);
+        src.copy_to(dst);
+        for (let i = 0; i < 15; i++) expect(dst.data[i]).toBe(src.data[i]);
+    });
+});
+
+describe("point_t", () => {
+    it("is deliberately NOT on the namespace, matching jsfeat", () => {
+        // point_t is a type-only structure: four modules import it purely as an
+        // annotation and nothing ever constructs one. Original jsfeat has no
+        // runtime `jsfeat.point_t` either, so the absence is parity, not a gap.
+        // Callers pass keypoint_t instances, which are structurally compatible.
+        expect((jsfeatNext as unknown as Record<string, unknown>).point_t).toBeUndefined();
+    });
+
+    it("constructs and carries assignable coordinates when imported directly", () => {
+        // A bare struct: the constructor takes no arguments and detector code
+        // fills the fields in. Nothing else in the suite touched it before.
+        const p = new point_t();
+        p.x = 12;
+        p.y = 34;
+        p.score = 0.5;
+        expect([p.x, p.y, p.score]).toEqual([12, 34, 0.5]);
+    });
+
+    it("is a valid pool type for fast_corners.detect", () => {
+        // The signature asks for point_t[], so passing real point_t instances
+        // must work — even though callers normally hand it keypoint_t.
+        const pool = Array.from({ length: 4096 }, () => new point_t());
+        jsfeatNext.fast_corners.set_threshold(20);
+        const n = jsfeatNext.fast_corners.detect(cornerScene(96, 72), pool, 5);
+
+        expect(n).toBeGreaterThan(0);
+        for (let i = 0; i < n; i++) {
+            expect(Number.isInteger(pool[i].x)).toBe(true);
+            expect(Number.isInteger(pool[i].y)).toBe(true);
+            expect(pool[i].score).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe("keypoint_t", () => {
+    it("defaults angle to -1 and everything else to 0", () => {
+        const k = new jsfeatNext.keypoint_t();
+        expect([k.x, k.y, k.score, k.level, k.angle]).toEqual([0, 0, 0, 0, -1.0]);
+    });
+
+    it("stores explicit values", () => {
+        const k = new jsfeatNext.keypoint_t(3, 4, 0.75, 2, 1.25);
+        expect([k.x, k.y, k.score, k.level, k.angle]).toEqual([3, 4, 0.75, 2, 1.25]);
+    });
+});
+
+describe("pyramid_t", () => {
+    it("allocates each level at half the previous dimensions", () => {
+        const p = new jsfeatNext.pyramid_t(4);
+        p.allocate(64, 48, U8C1);
+        expect(p.levels).toBe(4);
+        for (let i = 0; i < 4; i++) {
+            expect([p.data[i].cols, p.data[i].rows]).toEqual([64 >> i, 48 >> i]);
+        }
+    });
+
+    it("build with skip_first_level = false copies the source into level 0", () => {
+        const src = new jsfeatNext.matrix_t(32, 32, U8C1);
+        for (let i = 0; i < 32 * 32; i++) src.data[i] = (i * 3) & 0xff;
+
+        const p = new jsfeatNext.pyramid_t(3);
+        p.allocate(32, 32, U8C1);
+        p.build(src, false);
+
+        for (let i = 0; i < 32 * 32; i++) expect(p.data[0].data[i]).toBe(src.data[i]);
+    });
+
+    it("fills the lower levels by downsampling, preserving a constant", () => {
+        // A uniform source must stay uniform all the way down — the cheapest
+        // check that every level was actually written rather than left zeroed.
+        const src = new jsfeatNext.matrix_t(32, 32, U8C1);
+        src.data.fill(120);
+
+        const p = new jsfeatNext.pyramid_t(3);
+        p.allocate(32, 32, U8C1);
+        p.build(src, false);
+
+        for (let level = 0; level < 3; level++) {
+            const m = p.data[level];
+            for (let i = 0; i < m.cols * m.rows; i++) expect(m.data[i]).toBe(120);
+        }
+    });
+});
+
+describe("ransac_params_t", () => {
+    it("applies documented defaults", () => {
+        const p = new jsfeatNext.ransac_params_t();
+        expect([p.size, p.thresh, p.eps, p.prob]).toEqual([0, 0.5, 0.5, 0.99]);
+    });
+
+    it("update_iters never exceeds the cap and stays non-negative", () => {
+        const p = new jsfeatNext.ransac_params_t(4, 0.5, 0.5, 0.99);
+        for (const eps of [0, 0.1, 0.3, 0.5, 0.7, 0.9, 1]) {
+            const iters = p.update_iters(eps, 1000);
+            expect(iters).toBeLessThanOrEqual(1000);
+            expect(iters).toBeGreaterThanOrEqual(0);
+            expect(Number.isInteger(iters)).toBe(true);
+        }
+    });
+
+    it("needs more iterations as the outlier ratio grows", () => {
+        // The whole point of the adaptive stopping rule: dirtier data demands
+        // more samples, until the cap takes over.
+        const p = new jsfeatNext.ransac_params_t(4, 0.5, 0.5, 0.99);
+        let previous = -1;
+        for (const eps of [0.1, 0.2, 0.3, 0.4, 0.5]) {
+            const iters = p.update_iters(eps, 100000);
+            expect(iters).toBeGreaterThanOrEqual(previous);
+            previous = iters;
+        }
+    });
+
+    it("demands nothing when there are no outliers", () => {
+        const p = new jsfeatNext.ransac_params_t(4, 0.5, 0.5, 0.99);
+        expect(p.update_iters(0, 1000)).toBe(0);
+    });
+});
+
+describe("data_type helpers", () => {
+    it("decode the type and channel packed into a signature", () => {
+        const types = [jsfeatNext.U8_t, jsfeatNext.S32_t, jsfeatNext.F32_t, jsfeatNext.F64_t];
+        const channels = [jsfeatNext.C1_t, jsfeatNext.C2_t, jsfeatNext.C3_t, jsfeatNext.C4_t];
+        const base = new jsfeatNext();
+
+        for (const t of types) {
+            for (const c of channels) {
+                const signature = t | c;
+                expect(base.get_data_type(signature)).toBe(t);
+                expect(base.get_channel(signature)).toBe(c);
+            }
+        }
+    });
+
+    it("report the element size in bytes", () => {
+        const base = new jsfeatNext();
+        expect(base.get_data_type_size(jsfeatNext.U8_t)).toBe(1);
+        expect(base.get_data_type_size(jsfeatNext.S32_t)).toBe(4);
+        expect(base.get_data_type_size(jsfeatNext.F32_t)).toBe(4);
+        expect(base.get_data_type_size(jsfeatNext.F64_t)).toBe(8);
+    });
+
+    it("agree with the buffer matrix_t actually allocates", () => {
+        // Ties the helpers to observable behaviour rather than to themselves.
+        const base = new jsfeatNext();
+        for (const type of [U8C1, F32C1, jsfeatNext.S32_t | jsfeatNext.C1_t]) {
+            const m = new jsfeatNext.matrix_t(10, 10, type);
+            const elementSize = base.get_data_type_size(base.get_data_type(type));
+            const expected = (10 * 10 * elementSize + 7) & -8;
+            expect(m.buffer.size).toBe(expected);
+        }
+    });
+});

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -1,0 +1,321 @@
+/*
+ *  edge-cases.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { U8C1, F32C1, uniformImage, dstImage, keypointPool, pixelRange } from "./helpers";
+
+/**
+ * Edge- and boundary-input tests (issue #87, category B).
+ *
+ * Degenerate inputs are where CV code breaks: 1x1 images, single rows and
+ * columns, kernels larger than the image, extreme intensities, singular
+ * matrices. The rest of the suite runs on comfortable 16x16 and 96x72 inputs
+ * and says nothing about any of it.
+ *
+ * Most of what follows asserts that an invariant established elsewhere still
+ * holds at the boundary. Two blocks instead CHARACTERIZE behaviour that is
+ * wrong but inherited from jsfeat — `box_blur_gray` below kernel size (#114)
+ * and `invert_3x3` on a singular matrix. Those are labelled, cite their issue,
+ * and are written to be replaced by a fix rather than kept.
+ */
+
+const ip = jsfeatNext.imgproc;
+
+/** Grayscale image of `w`x`h` filled with `value`, sized however degenerate. */
+const flat = (w: number, h: number, value = 128) => uniformImage(w, h, value);
+
+/** The degenerate shapes worth exercising: point, single row, single column, tiny squares. */
+const SHAPES: [number, number][] = [
+    [1, 1],
+    [1, 8],
+    [8, 1],
+    [2, 2],
+    [3, 3],
+    [5, 4], // odd x even
+    [4, 5], // even x odd
+];
+
+describe("edge cases: degenerate image sizes", () => {
+    it("gaussian_blur preserves a constant at every degenerate shape", () => {
+        // The invariant the 16x16 test asserts, now at the sizes where border
+        // clamping actually has to work. Holds exactly, including 1x1.
+        for (const [w, h] of SHAPES) {
+            for (const kernel of [3, 5, 7]) {
+                const dst = dstImage(w, h);
+                ip.gaussian_blur(flat(w, h, 128), dst, kernel, 0);
+                const { min, max } = pixelRange(dst, w, h);
+                expect(`${w}x${h} k=${kernel}: [${min},${max}]`).toBe(`${w}x${h} k=${kernel}: [128,128]`);
+            }
+        }
+    });
+
+    it("derivatives of a constant stay exactly zero at every degenerate shape", () => {
+        for (const [w, h] of SHAPES) {
+            for (const derive of [ip.sobel_derivatives, ip.scharr_derivatives]) {
+                const dst = new jsfeatNext.matrix_t(w, h, jsfeatNext.S32C2_t);
+                derive.call(ip, flat(w, h), dst);
+                for (let i = 0; i < w * h * 2; i++) expect(dst.data[i]).toBe(0);
+            }
+        }
+    });
+
+    it("canny finds no edges in a constant image at every degenerate shape", () => {
+        for (const [w, h] of SHAPES) {
+            const dst = dstImage(w, h);
+            ip.canny(flat(w, h), dst, 20, 50);
+            for (let i = 0; i < w * h; i++) expect(dst.data[i]).toBe(0);
+        }
+    });
+
+    it("equalize_histogram maps a constant image to a single value", () => {
+        // Every pixel shares one bin, so the cumulative histogram saturates and
+        // the whole image maps to 255. The value is incidental; what matters is
+        // that it stays CONSTANT rather than developing structure from nothing.
+        for (const [w, h] of SHAPES) {
+            const dst = dstImage(w, h);
+            ip.equalize_histogram(flat(w, h, 77), dst);
+            const { min, max } = pixelRange(dst, w, h);
+            expect(min).toBe(max);
+        }
+    });
+
+    it("grayscale handles a single-pixel RGBA buffer", () => {
+        const rgba = new Uint8Array([90, 90, 90, 255]);
+        const dst = dstImage(1, 1);
+        ip.grayscale(rgba, 1, 1, dst);
+        expect(dst.data[0]).toBe(90);
+    });
+});
+
+describe("edge cases: extreme intensities", () => {
+    it("all-black and all-white survive a blur unchanged", () => {
+        for (const level of [0, 255]) {
+            const dst = dstImage(8, 8);
+            ip.gaussian_blur(flat(8, 8, level), dst, 5, 0);
+            const { min, max } = pixelRange(dst, 8, 8);
+            expect([min, max]).toEqual([level, level]);
+        }
+    });
+
+    it("derivatives of all-black and all-white are zero", () => {
+        // Saturated input is the classic place for an overflow or a sign slip.
+        for (const level of [0, 255]) {
+            const dst = new jsfeatNext.matrix_t(8, 8, jsfeatNext.S32C2_t);
+            ip.sobel_derivatives(flat(8, 8, level), dst);
+            for (let i = 0; i < 8 * 8 * 2; i++) expect(dst.data[i]).toBe(0);
+        }
+    });
+});
+
+describe("edge cases: compute_integral_image at boundary sizes", () => {
+    it("the corner equals the total and the first row/column stay zero", () => {
+        for (const [w, h] of SHAPES) {
+            const src = new jsfeatNext.matrix_t(w, h, U8C1);
+            for (let i = 0; i < w * h; i++) src.data[i] = (i % 200) + 1;
+            const sum = new Int32Array((w + 1) * (h + 1));
+            ip.compute_integral_image(src, sum, null, null);
+
+            const stride = w + 1;
+            let total = 0;
+            for (let i = 0; i < w * h; i++) total += src.data[i];
+
+            expect(sum[h * stride + w]).toBe(total);
+            for (let x = 0; x <= w; x++) expect(sum[x]).toBe(0);
+            for (let y = 0; y <= h; y++) expect(sum[y * stride]).toBe(0);
+        }
+    });
+});
+
+describe("edge cases: box_blur_gray below kernel size — KNOWN BUG #114", () => {
+    // A blur is an average, so a uniform image must round-trip at ANY size.
+    // box_blur_gray only manages it once the image is at least as large as the
+    // kernel; below that the sliding-window sums are never correctly primed and
+    // the output is grossly wrong. Bit-identical in original jsfeat, so this is
+    // inherited rather than a jsfeatNext regression.
+    //
+    // These are CHARACTERIZATION tests pinning today's broken output. When #114
+    // is fixed they must fail — that is the point.
+
+    it("is correct once the image is at least as large as the kernel", () => {
+        // The real invariant, asserted where it actually holds.
+        for (const radius of [1, 2, 3, 4]) {
+            const size = 2 * radius + 1;
+            const dst = dstImage(size, size);
+            ip.box_blur_gray(flat(size, size, 128), dst, radius, 0);
+            const { min, max } = pixelRange(dst, size, size);
+            // radius 3 lands 1 low from float truncation — see the test below
+            expect(Math.abs(min - 128)).toBeLessThanOrEqual(1);
+            expect(Math.abs(max - 128)).toBeLessThanOrEqual(1);
+        }
+    });
+
+    it("is exact for radii whose reciprocal window area rounds up", () => {
+        for (const radius of [1, 2, 4]) {
+            const dst = dstImage(32, 32);
+            ip.box_blur_gray(flat(32, 32, 128), dst, radius, 0);
+            const { min, max } = pixelRange(dst, 32, 32);
+            expect([min, max]).toEqual([128, 128]);
+        }
+    });
+
+    it("BUG #114: radius 3 comes out 1 low even on a large image", () => {
+        // scale is the float 1/49, and 128 * 49 * (1/49) = 127.999999999999986,
+        // which truncates to 127. Only radius 3 hits this for radii 1..8.
+        const dst = dstImage(32, 32);
+        ip.box_blur_gray(flat(32, 32, 128), dst, 3, 0);
+        const { min, max } = pixelRange(dst, 32, 32);
+        expect([min, max]).toEqual([127, 127]);
+    });
+
+    // Declared with `it.fails`: the body asserts the CORRECT behaviour, and the
+    // test passes only because that assertion currently fails. Fix #114 and
+    // this flips to a failure, forcing a deliberate update.
+    //
+    // Deliberately not pinning the wrong values. They are not stable — the
+    // window reads outside the image, so the result depends on surrounding
+    // library state. The identical call returns 85 in isolation and 142 when
+    // run after the tests above it. That instability is itself part of the bug
+    // and is recorded in #114; asserting the numbers would just be flaky.
+    it.fails("BUG #114: a uniform image is NOT preserved when smaller than the kernel", () => {
+        for (const [size, radius] of [
+            [1, 1],
+            [2, 1],
+            [1, 2],
+            [4, 2],
+        ] as [number, number][]) {
+            const dst = dstImage(size, size);
+            ip.box_blur_gray(flat(size, size, 128), dst, radius, 0);
+            const { min, max } = pixelRange(dst, size, size);
+            expect([min, max]).toEqual([128, 128]);
+        }
+    });
+});
+
+describe("edge cases: detectors on tiny images and oversized borders", () => {
+    it("return zero detections instead of throwing", () => {
+        const fc = jsfeatNext.fast_corners;
+        fc.set_threshold(20);
+        for (const [w, h] of [
+            [1, 1],
+            [4, 4],
+            [7, 7],
+        ] as [number, number][]) {
+            expect(fc.detect(flat(w, h), keypointPool(64), 3)).toBe(0);
+            expect(jsfeatNext.yape06.detect(flat(w, h), keypointPool(64), 5)).toBe(0);
+        }
+    });
+
+    it("tolerate a border larger than the image", () => {
+        // The scan range collapses to nothing; it must come back empty rather
+        // than looping into negative bounds.
+        const fc = jsfeatNext.fast_corners;
+        fc.set_threshold(20);
+        for (const border of [20, 100]) {
+            expect(fc.detect(flat(16, 16), keypointPool(64), border)).toBe(0);
+            expect(jsfeatNext.yape06.detect(flat(16, 16), keypointPool(64), border)).toBe(0);
+        }
+    });
+});
+
+describe("edge cases: linalg and matmath on degenerate matrices", () => {
+    const square = (n: number, values: number[]) => {
+        const m = new jsfeatNext.matrix_t(n, n, F32C1);
+        m.data.set(values);
+        return m;
+    };
+
+    it("svd_invert handles the 1x1 case", () => {
+        const A = square(1, [4]);
+        const Ai = new jsfeatNext.matrix_t(1, 1, F32C1);
+        jsfeatNext.linalg.svd_invert(Ai, A);
+        expect(Ai.data[0]).toBeCloseTo(0.25, 6);
+    });
+
+    it("lu_solve reports failure on a singular system and success on a solvable one", () => {
+        // [[1,2],[2,4]] has linearly dependent rows: no unique solution.
+        const singular = square(2, [1, 2, 2, 4]);
+        const b = new jsfeatNext.matrix_t(1, 2, F32C1);
+        b.data.set([1, 2]);
+        expect(jsfeatNext.linalg.lu_solve(singular, b)).toBe(0);
+
+        // ...and a well-conditioned one really is solved, so the 0 above is a
+        // meaningful signal rather than "always fails".
+        const regular = square(2, [4, 7, 2, 6]);
+        const b2 = new jsfeatNext.matrix_t(1, 2, F32C1);
+        b2.data.set([1, 2]);
+        expect(jsfeatNext.linalg.lu_solve(regular, b2)).toBe(1);
+        const [x0, x1] = [b2.data[0], b2.data[1]];
+        expect(4 * x0 + 7 * x1).toBeCloseTo(1, 4);
+        expect(2 * x0 + 6 * x1).toBeCloseTo(2, 4);
+    });
+
+    it("CHARACTERIZATION: invert_3x3 of a singular matrix silently yields non-finite values", () => {
+        // Same family as #102: no error, no signal, just garbage the caller
+        // will happily use. Pinned so a future guard is a deliberate change.
+        const singular = square(3, [1, 2, 3, 2, 4, 6, 1, 1, 1]);
+        expect(jsfeatNext.matmath.mat3x3_determinant(singular)).toBe(0);
+
+        const inverse = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.matmath.invert_3x3(singular, inverse);
+        let nonFinite = 0;
+        for (let i = 0; i < 9; i++) if (!Number.isFinite(inverse.data[i])) nonFinite++;
+        expect(nonFinite).toBeGreaterThan(0);
+    });
+});
+
+describe("edge cases: gaussian kernels at minimum size", () => {
+    it("a size-1 kernel is the identity", () => {
+        const k = new Float32Array(1);
+        jsfeatNext.math.get_gaussian_kernel(1, 0, k, jsfeatNext.F32_t);
+        expect(k[0]).toBe(1);
+    });
+
+    it("even sizes are still normalized and symmetric", () => {
+        // Even kernels have no centre tap, so they take the sampled exp() path
+        // rather than the fixed binomial one.
+        for (const size of [2, 4, 6]) {
+            const k = new Float32Array(size);
+            jsfeatNext.math.get_gaussian_kernel(size, 0, k, jsfeatNext.F32_t);
+            let sum = 0;
+            for (let i = 0; i < size; i++) sum += k[i];
+            expect(sum).toBeCloseTo(1, 5);
+            for (let i = 0; i < size; i++) expect(k[i]).toBeCloseTo(k[size - 1 - i], 6);
+        }
+    });
+});

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -172,17 +172,34 @@ describe("edge cases: box_blur_gray below kernel size — KNOWN BUG #114", () =>
     // These are CHARACTERIZATION tests pinning today's broken output. When #114
     // is fixed they must fail — that is the point.
 
-    it("is correct once the image is at least as large as the kernel", () => {
-        // The real invariant, asserted where it actually holds.
+    it("is correct at every size at or above the kernel, in both dimensions", () => {
+        // The real invariant, asserted across the whole region where it holds
+        // rather than at one sampled point per radius.
+        //
+        // The reliable region is BOTH cols >= 2r+1 AND rows >= 2r+1 — not
+        // `min(cols, rows)`. The two passes run along cols and then along rows,
+        // and either being shorter than the window is enough to break it. Below
+        // the region the result is erratic rather than uniformly wrong: some
+        // dimension pairs land on the right value by coincidence, which is why
+        // the failing side is pinned with `it.fails` instead of exact values.
+        // See #114.
+        const offenders: string[] = [];
         for (const radius of [1, 2, 3, 4]) {
-            const size = 2 * radius + 1;
-            const dst = dstImage(size, size);
-            ip.box_blur_gray(flat(size, size, 128), dst, radius, 0);
-            const { min, max } = pixelRange(dst, size, size);
-            // radius 3 lands 1 low from float truncation — see the test below
-            expect(Math.abs(min - 128)).toBeLessThanOrEqual(1);
-            expect(Math.abs(max - 128)).toBeLessThanOrEqual(1);
+            const kernel = 2 * radius + 1;
+            for (let cols = kernel; cols <= kernel + 6; cols++) {
+                for (let rows = kernel; rows <= kernel + 6; rows++) {
+                    const dst = dstImage(cols, rows);
+                    ip.box_blur_gray(flat(cols, rows, 128), dst, radius, 0);
+                    const { min, max } = pixelRange(dst, cols, rows);
+                    // radius 3 lands 1 low from float truncation — a separate
+                    // defect with its own test below, so allow a single level
+                    if (Math.abs(min - 128) > 1 || Math.abs(max - 128) > 1) {
+                        offenders.push(`${cols}x${rows} r=${radius} -> [${min},${max}]`);
+                    }
+                }
+            }
         }
+        expect(offenders).toEqual([]);
     });
 
     it("is exact for radii whose reciprocal window area rounds up", () => {


### PR DESCRIPTION
Category **B** of the #87 plan (edge/boundary inputs). **19 new cases, 180 → 199 total** (198 passing + 1 expected failure). Tests only, no `src/` changes.

Follows #106 (linalg + matmath), #108 (imgproc), #109 (math + detectors + optical flow) which completed category A.

## Why

Degenerate inputs are where CV code breaks, and the rest of the suite runs on comfortable 16×16 and 96×72 images that say nothing about them. This covers 1×1, single rows and columns, odd-vs-even dimensions, kernels larger than the image, all-black/all-white, borders wider than the image, 1×1 and singular matrices, and minimum kernel sizes.

## It found a real bug — #114

**`box_blur_gray` does not preserve a uniform image when the image is smaller than the kernel.** A blur is an average, so a constant image must round-trip at any size. It doesn't:

| image | radius | output | |
| --- | --- | --- | --- |
| 1×1 | 1 | `[85, 85]` | wrong |
| 4×4 | 2 | `[51, 128]` | 60% low |
| 5×5 | 2 | `[128, 128]` | correct |

The rule is exact — output settles precisely at `size >= 2*radius + 1`, verified for radius 1–4. A **separate** float-truncation defect makes radius 3 come out 1 low even on a 32×32 image, because `128 * 49 * (1/49) = 127.999999999999986` truncates to 127.

Both are **bit-identical in original jsfeat**, so they are inherited rather than jsfeatNext regressions, and `gaussian_blur` has neither — it is correct from 1×1 upward. This is precisely the class of defect parity testing structurally cannot find, since the oracle shares it.

A follow-up posted on #114: the wrong output is **not deterministic**. The identical 1×1 radius-1 call returns `85` in isolation and `142` when run after the other cases in the same file, because the window reads outside the image and picks up unrelated state.

## How the bug is pinned

With `it.fails`, not by asserting the wrong numbers — those aren't stable, per the above. The body asserts the **correct** behaviour and the test passes only because that assertion currently fails, so fixing #114 flips it to a failure and forces a deliberate update.

Verified that guard is not a no-op: making the inner assertion trivially true turns the suite red.

## What else is covered

Everything below confirms an invariant still holds at the boundary:

- `gaussian_blur` preserves a constant at 1×1, 1×8, 8×1, 2×2, 3×3, 5×4, 4×5 for kernels 3/5/7
- sobel and scharr derivatives stay exactly zero; `canny` finds nothing
- `equalize_histogram` maps a constant to a single value rather than inventing structure
- integral-image corner equals the total, first row and column zero, at every degenerate shape
- all-black and all-white survive a blur unchanged, derivatives zero
- detectors return 0 rather than throwing on tiny images and on borders wider than the image
- `lu_solve` reports failure on a singular system **and** still solves a well-conditioned one (so the 0 is a meaningful signal, not "always fails")
- `svd_invert` handles 1×1; size-1 gaussian kernel is the identity; even-size kernels stay normalized and symmetric

Plus one more characterization: `invert_3x3` on a singular matrix silently returns `NaN`/`±Infinity` with no signal to the caller — the same family as #102.

## Verification

prettier clean · `tsc --noEmit` clean · `license-check` clean · `npm test` 198 passed + 1 expected fail.

## Remaining #87 scope

Category A and B are now done. Still open: **C** third-party ground-truth fixtures, **D** coverage gaps (`data_type` has no dedicated test). As discussed, C is the natural point to revisit the empirically-characterised bounds in the earlier phases with tighter assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
