### PR TITLE
test(reference): ground-truth tests and implementation notes (refs #87, category C1)

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -1,0 +1,271 @@
+# Implementation notes: jsfeat conventions, quirks and known defects
+
+Behaviour of the algorithms in `src/` that is **not obvious from the code**, and
+that cost real investigation to establish. Written up so the next person does
+not have to rediscover it.
+
+Everything here was measured, not assumed. Where a claim came from a specific
+experiment, the experiment is described so it can be repeated or challenged.
+Where a claim was later found wrong, the correction is kept rather than quietly
+edited out.
+
+Most of this surfaced during the testing work for
+[#87](https://github.com/webarkit/jsfeatNext/issues/87).
+
+---
+
+## 1. Border conventions
+
+### `sobel_derivatives` / `scharr_derivatives` — asymmetric
+
+The single most surprising convention in the library.
+
+| direction | behaviour | equivalent |
+| --- | --- | --- |
+| vertical | **reflect**: `y = -1` reads row 1, `y = h` reads row `h-2` | OpenCV `BORDER_REFLECT_101` |
+| horizontal | **replicate**: `x = -1` reads column 0 | OpenCV `BORDER_REPLICATE` |
+
+From `imgproc.ts`:
+
+```ts
+srow0 = ((y > 0 ? y - 1 : 1) * w) | 0;        // vertical: reflect
+srow2 = ((y < h - 1 ? y + 1 : h - 2) * w) | 0;
+...
+trow0[0] = trow0[1];                          // horizontal: replicate
+trow0[w + 1] = trow0[w];
+```
+
+**Why it matters:** assuming replication in *both* directions produces a
+reference implementation that matches the interior **exactly** (352/352 pixels
+on a 24×18 image) and disagrees on almost every border pixel (35/80). That
+failure mode is easy to misread as "the kernel is wrong" when the kernel is
+fine.
+
+Pinned by `tests/reference/imgproc.test.ts` → "pins the asymmetric border
+convention specifically".
+
+### `box_blur_gray` — replicate
+
+Plain edge replication in both directions, and a naive clamped-window mean
+matches it bit-for-bit (subject to the defects in §3).
+
+---
+
+## 2. Fixed-point and rounding
+
+### `get_gaussian_kernel` — size 7 is not the binomial row
+
+For odd `size <= 7` with `sigma <= 0`, jsfeat uses fixed tables. Sizes 3 and 5
+are the normalised rows of Pascal's triangle; **size 7 is not**.
+
+| size | jsfeat kernel (×64) | Pascal row (×64) |
+| --- | --- | --- |
+| 3 | `[16, 32, 16]` | same |
+| 5 | `[4, 16, 24, 16, 4]` | same |
+| **7** | **`[2, 7, 14, 18, 14, 7, 2]`** | `[1, 6, 15, 20, 15, 6, 1]` |
+
+Both sum to 64, so jsfeat's is a valid normalised kernel — just a flatter one,
+with a lower peak and heavier tails. Worth knowing before anyone "corrects" it
+to the binomial row and silently changes every 7-tap blur in the library.
+
+### `get_gaussian_kernel` — the `U8` integer path
+
+Weights are scaled to sum to 256. The sum is **not** always exactly 256: each
+of the `size` taps rounds independently, so `|sum - 256| <= size/2`. Worst
+observed across a wide size/sigma sweep is 3. It **is** exactly 256 on the
+fixed binomial path, where the weights are exact binary fractions.
+
+### `grayscale` — BT.601 in 14-bit fixed point
+
+`Y = (R*4899 + G*9617 + B*1868 + 8192) >> 14`, which approximates the
+real-valued ITU-R BT.601 coefficients `0.299 / 0.587 / 0.114`. Measured
+agreement with the real-valued standard: **within 1 grey level**.
+
+### `resample` — the `U8` fast path truncates
+
+`_resample_u8` uses 8.8 fixed point and is chosen when both matrices are `U8`
+and the area ratio is under 256. Resampling a constant is exact at an integer
+ratio but comes out **up to 1 low** at a non-integer ratio (e.g. 77 → 76). The
+float path is exact, so the error is quantisation rather than bad resampling
+maths. Bit-identical to original jsfeat, so inherited, not a regression.
+
+---
+
+## 3. Known defects
+
+### `box_blur_gray` below kernel size — [#114](https://github.com/webarkit/jsfeatNext/issues/114)
+
+A blur is an average, so a uniform image must round-trip at any size. It does
+not when the image is smaller than the kernel.
+
+**Reliable only when `cols >= 2r+1` AND `rows >= 2r+1`.** Measured over a 16×16
+grid of dimensions for radii 1–3: **0 failures** inside that region, scattered
+failures outside it.
+
+A first attempt at the rule — `min(cols, rows) < 2r+1` — was **wrong**, derived
+from square images only. Counter-example at radius 1: `2×50` is correct while
+`2×4` is not, though both have `cols = 2`.
+
+Below the reliable region the behaviour is **erratic rather than uniformly
+wrong**: some dimension pairs land on the right value by coincidence. That is
+worse than consistent failure, because a caller can validate on a 2×50 ROI, see
+the right answer, and ship code that breaks on 2×4.
+
+The wrong values are also **not deterministic** — the window reads outside the
+image, so the result depends on surrounding library state. The identical 1×1
+radius-1 call returns 85 in isolation and 142 when run after other tests. This
+is why the failing case is pinned with `it.fails` rather than by asserting
+values.
+
+### `box_blur_gray` radius 3 — float truncation
+
+Independent of image size. `scale = 1.0 / (windowSize * windowSize)`, and
+`128 * 49 * (1/49) = 127.999999999999986`, which truncates to 127. Only radius
+3 hits this for radii 1–8; the other reciprocals happen to round up.
+
+### `orb.describe` near the image edge — [#110](https://github.com/webarkit/jsfeatNext/issues/110)
+
+`rectify_patch` warps with `warp_affine(src, dst, H, 128)`. Patch pixels
+sampled outside the image get exactly **128** whatever the image brightness, so
+descriptors of edge-adjacent keypoints are partly determined by that constant.
+
+**Required margin: 20px.** Not the intuitive 16 (half the 32px patch) — only
+the 256 sampled pairs are read, and `bit_pattern_31`'s largest coordinate
+component is 13, so the furthest sample sits `13√2 = 18.39px` from the
+keypoint. Rotation preserves that radius, so 18.39 + 1 for the bilinear
+neighbour ≈ 20.
+
+Measured: border 8 → 2 differing bits of 8960 under a +20 brightness lift;
+border ≥ 16 → 0. Sweeping one keypoint over 2000 angles puts the empirical
+onset at distance ≤ 16, clean from 17 — so 20 carries slack.
+
+### `optical_flow_lk` — `curr_xy` is documented as seedable but ignored — [#111](https://github.com/webarkit/jsfeatNext/issues/111)
+
+The TSDoc says "seed it with a prediction or a copy of `prev_xy`". The
+implementation never reads it: at the coarsest level it does
+`next_x = prev_x`, and every later level chains from the previous level's own
+result.
+
+Verified with five seeds — zeros, a copy of `prev_xy`, `+1`, `+50`, and
+`-9999` everywhere — all producing **bit-identical** output. Identical code
+path in original jsfeat, so the docstring is what is out of step.
+
+### `invert_3x3` on a singular matrix
+
+Returns `NaN` / `±Infinity` silently, with no signal to the caller. Same family
+as [#102](https://github.com/webarkit/jsfeatNext/issues/102).
+
+### `svd_invert` on non-square input — [#102](https://github.com/webarkit/jsfeatNext/issues/102)
+
+jsfeatNext **throws**; original jsfeat returned a wrong pseudo-inverse
+silently. This is an intentional divergence, registered in
+`tests/divergences.test.ts`.
+
+---
+
+## 4. Behaviour that looks wrong but is not
+
+### `warp_affine` / `warp_perspective` under the identity transform
+
+Does **not** reproduce the input exactly: the interior is bit-exact but the
+outermost 1-pixel ring is filled with `fill_value`, because bilinear sampling
+treats it as out of bounds.
+
+### `equalize_histogram` of a uniform image returns 255
+
+Every pixel shares one histogram bin, so the cumulative histogram saturates and
+the whole image maps to 255 regardless of the input level. Constant in,
+constant out — just not the *same* constant.
+
+### `optical_flow_lk` and large displacements
+
+The recoverable displacement is set by window size and pyramid depth, not by
+correctness. On a 96×72 scene at 2 levels with a 9px window, shifts up to ~3px
+come back to ~0.01px while a 5px shift does not converge at all. Widen either
+knob and the ceiling moves: on 320×240, 2 levels with a 15px window recovers
+5px for every point, and 4 levels with a 9px window recovers 10px for 28 of 29
+points. Textbook pyramidal Lucas–Kanade.
+
+### `point_t` is not on the namespace
+
+`jsfeatNext.point_t` is undefined — but so is `jsfeat.point_t`. Four modules
+import it purely as a type annotation and nothing ever constructs one. Callers
+pass `keypoint_t`, which is structurally compatible. The absence is parity, not
+a gap.
+
+---
+
+## 5. Data structures
+
+### `matrix_t` / `data_t` allocation
+
+Byte size is rounded **up to a multiple of 8** so the `f64` view is valid. Two
+consequences that bite in tests:
+
+- `matrix_t(1, 1, U8C1)` allocates 8 bytes, not 1, so `data.fill(v)` writes 7
+  bytes of padding as well as the pixel. Always slice to the logical `w*h`.
+- `resize` reuses the existing buffer when the new size fits and reallocates
+  only when it does not, so buffer identity is not stable across a resize.
+
+All four views (`u8`, `i32`, `f32`, `f64`) alias the same `ArrayBuffer`.
+
+### `median` returns the lower middle
+
+`math.median(array, low, high)` returns `array[(low + high) >> 1]` after
+quickselect — the **lower** middle element for an even-length range, not the
+average of the two middles. The array is partially reordered in place.
+
+### The shared buffer pool
+
+30 nodes, allocated once. `get_buffer(n)` pops a node and **resizes it if `n`
+exceeds its current size**, so a single large request permanently grows that
+node. Every borrow must be balanced by a `put_buffer`.
+
+`tests/setup/pool-balance.ts` enforces this after every test in the suite.
+Nothing in the library leaks today.
+
+---
+
+## 6. Notes on testing this library
+
+Recorded because they shaped the test suite and would otherwise be relearned.
+
+**Parity cannot catch inherited bugs.** The oracle in `tests/vendor/` *is*
+original jsfeat, so any defect present in both is invisible to it. Both
+`box_blur_gray` defects are bit-identical in jsfeat — that is precisely why
+they survived a green parity suite.
+
+**Uniform-image invariants are cheap, broad and blind in one specific way.**
+They catch a wide range of indexing and border mistakes at no cost in
+tolerance. But an off-by-one injected into `box_blur_gray`'s second-pass loop
+bound was **not** caught by any of them, because it changes *which* loop phase
+computes a pixel without changing the value for a uniform image. Only a
+reference comparison on non-uniform input catches that class.
+
+**A naive reference can be bit-exact.** Measured on 24×18 seeded noise:
+`grayscale` 432/432, `box_blur` exact at radii 1 and 2, sobel/scharr exact once
+the border convention above is applied. So these tests pin exact values and
+need no tolerance fudging — which is what makes them worth having.
+
+**One image shape is not enough, and a tolerance can hide the very bug you are
+hunting.** The first version of the `box_blur` ground-truth test used a single
+23×17 image, with exact comparison at radii 1, 2 and 4 and a ±1 tolerance at
+radius 3 to accommodate the truncation defect. Re-running the off-by-one above
+against it: **it still escaped.** At 23×17 that mutation perturbs *only* radius
+3, and by *exactly* 1 — precisely the slack the tolerance allowed. Other shapes
+expose it plainly (8×8 at radius 1 differs in 15 pixels).
+
+Two lessons, both now baked into the test:
+
+- sweep several shapes, including small ones and both orientations;
+- rather than tolerating a known rounding defect, **model it**. The reference
+  now has a variant that scales by the float reciprocal exactly as the library
+  does, so the comparison is exact at every radius, and the defect is asserted
+  separately as "differs from exact division only at radius 3, and only by 1".
+  A tolerance wide enough to absorb a known defect is wide enough to hide an
+  unknown one.
+
+**Constructing the input from a known answer** is the way to get ground truth
+where no reference is practical: build `A = U·diag(w)·Vᵀ` from chosen singular
+values and require SVD to return them; push points through a chosen homography
+and require it to be recovered.

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -1,0 +1,217 @@
+/*
+ *  imgproc.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { noiseImage, dstImage, image } from "../properties/helpers";
+import { refBoxBlur, refBoxBlurAsImplemented, refSobel, refScharr, refIntegralImage } from "./reference-impl";
+
+/**
+ * Ground-truth tests for `imgproc` (issue #87, category C1).
+ *
+ * Each case runs the library against an independent naive implementation of
+ * the same operation on NON-UNIFORM input, and requires exact agreement.
+ *
+ * This is the only part of the suite that pins actual pixel values. The parity
+ * tests compare against a vendored jsfeat that shares any inherited bug, and
+ * the invariant tests constrain the answer without fixing it — #115 showed an
+ * off-by-one in a loop bound surviving both, because it changed which code
+ * path produced a pixel without changing the value for a uniform image.
+ */
+
+const ip = jsfeatNext.imgproc;
+
+/** Deliberately not square and not a power of two, so stride bugs show up. */
+const W = 23;
+const H = 17;
+
+/** Reports every mismatch rather than aborting on the first. */
+function expectExact(label: string, got: ArrayLike<number>, want: ArrayLike<number>, n: number) {
+    const bad: string[] = [];
+    for (let i = 0; i < n && bad.length < 8; i++) {
+        if (got[i] !== want[i]) bad.push(`[${i}] got ${got[i]}, want ${want[i]}`);
+    }
+    expect(`${label}: ${bad.join(" | ")}`).toBe(`${label}: `);
+}
+
+describe("ground truth: box_blur_gray vs a naive clamped-window mean", () => {
+    /**
+     * Several shapes, not one. A single size is a weak test: an off-by-one in
+     * the second-pass loop bound perturbs 23x17 only at radius 3, and only by
+     * 1 — so a suite that sampled that one shape with a ±1 tolerance would
+     * miss it entirely. It did, until this was widened.
+     */
+    const SHAPES: [number, number][] = [
+        [8, 8],
+        [16, 9],
+        [9, 16],
+        [23, 17],
+        [32, 24],
+    ];
+
+    it("matches the reference exactly at every radius and shape", () => {
+        // Compared against the float-reciprocal reference, so no tolerance is
+        // needed anywhere — including radius 3, whose truncation is part of the
+        // arithmetic being modelled rather than slack to be absorbed.
+        for (const [w, h] of SHAPES) {
+            const src = noiseImage(w, h, 4242);
+            for (let radius = 1; radius <= 5; radius++) {
+                if (Math.min(w, h) < 2 * radius + 1) continue; // #114 territory
+                const dst = dstImage(w, h);
+                ip.box_blur_gray(src, dst, radius, 0);
+                expectExact(`${w}x${h} r=${radius}`, dst.data, refBoxBlurAsImplemented(src.data, w, h, radius), w * h);
+            }
+        }
+    });
+
+    it("differs from exact division only at radius 3, and only by 1", () => {
+        // Isolates the #114 truncation defect: the library's answer is right
+        // wherever the reciprocal is exactly representable, and one low where
+        // it is not. Asserting the shape of the error rather than tolerating it.
+        for (const [w, h] of SHAPES) {
+            const src = noiseImage(w, h, 4242);
+            for (let radius = 1; radius <= 5; radius++) {
+                if (Math.min(w, h) < 2 * radius + 1) continue;
+                const asImplemented = refBoxBlurAsImplemented(src.data, w, h, radius);
+                const exact = refBoxBlur(src.data, w, h, radius);
+                let differing = 0;
+                for (let i = 0; i < w * h; i++) {
+                    if (asImplemented[i] !== exact[i]) {
+                        expect(exact[i] - asImplemented[i]).toBe(1);
+                        differing++;
+                    }
+                }
+                if (radius !== 3) expect(`${w}x${h} r=${radius}: ${differing}`).toBe(`${w}x${h} r=${radius}: 0`);
+            }
+        }
+    });
+
+    it("matches on a smooth gradient as well as on noise", () => {
+        // Noise exercises every branch; a gradient catches sign and direction
+        // errors that random data can mask.
+        const src = image(W, H, (x, y) => (x * 7 + y * 3) & 0xff);
+        const dst = dstImage(W, H);
+        ip.box_blur_gray(src, dst, 2, 0);
+        expectExact("gradient r=2", dst.data, refBoxBlurAsImplemented(src.data, W, H, 2), W * H);
+    });
+});
+
+describe("ground truth: sobel and scharr derivatives", () => {
+    /** Splits jsfeat's interleaved dx,dy output into two planes. */
+    function planes(dst: { data: ArrayLike<number> }, n: number) {
+        const dx = new Float64Array(n);
+        const dy = new Float64Array(n);
+        for (let i = 0; i < n; i++) {
+            dx[i] = dst.data[i * 2];
+            dy[i] = dst.data[i * 2 + 1];
+        }
+        return { dx, dy };
+    }
+
+    it("sobel matches a naive separable [1,2,1] x [-1,0,1] exactly", () => {
+        const src = noiseImage(W, H, 99);
+        const dst = new jsfeatNext.matrix_t(W, H, jsfeatNext.S32C2_t);
+        ip.sobel_derivatives(src, dst);
+
+        const got = planes(dst, W * H);
+        const want = refSobel(src.data, W, H);
+        expectExact("sobel dx", got.dx, want.dx, W * H);
+        expectExact("sobel dy", got.dy, want.dy, W * H);
+    });
+
+    it("scharr matches a naive separable [3,10,3] x [-1,0,1] exactly", () => {
+        const src = noiseImage(W, H, 1234);
+        const dst = new jsfeatNext.matrix_t(W, H, jsfeatNext.S32C2_t);
+        ip.scharr_derivatives(src, dst);
+
+        const got = planes(dst, W * H);
+        const want = refScharr(src.data, W, H);
+        expectExact("scharr dx", got.dx, want.dx, W * H);
+        expectExact("scharr dy", got.dy, want.dy, W * H);
+    });
+
+    it("pins the asymmetric border convention specifically", () => {
+        // Vertically jsfeat reflects (y=-1 reads row 1), horizontally it
+        // replicates (x=-1 reads column 0). Assuming replication in both
+        // directions leaves the interior exact and every border pixel wrong,
+        // so a test that only sampled the interior would miss a border change.
+        const src = noiseImage(W, H, 555);
+        const dst = new jsfeatNext.matrix_t(W, H, jsfeatNext.S32C2_t);
+        ip.sobel_derivatives(src, dst);
+        const got = planes(dst, W * H);
+        const want = refSobel(src.data, W, H);
+
+        let borderChecked = 0;
+        for (let y = 0; y < H; y++) {
+            for (let x = 0; x < W; x++) {
+                if (x !== 0 && y !== 0 && x !== W - 1 && y !== H - 1) continue;
+                const i = y * W + x;
+                expect(`(${x},${y}) dx=${got.dx[i]} dy=${got.dy[i]}`).toBe(
+                    `(${x},${y}) dx=${want.dx[i]} dy=${want.dy[i]}`
+                );
+                borderChecked++;
+            }
+        }
+        expect(borderChecked).toBe(2 * W + 2 * H - 4);
+    });
+});
+
+describe("ground truth: compute_integral_image", () => {
+    it("the sum table matches a brute-force recomputation of every cell", () => {
+        const src = noiseImage(W, H, 808);
+        const sum = new Int32Array((W + 1) * (H + 1));
+        ip.compute_integral_image(src, sum, null, null);
+
+        const want = refIntegralImage(src.data, W, H);
+        expectExact("sum", sum, want.sum, (W + 1) * (H + 1));
+    });
+
+    it("the squared-sum table matches too, and the combined call agrees", () => {
+        // compute_integral_image takes a different branch when both tables are
+        // requested, so the sqsum path needs its own coverage — a gap mutation
+        // testing already caught once in the phase-2 invariant tests.
+        const src = noiseImage(W, H, 909);
+        const sum = new Int32Array((W + 1) * (H + 1));
+        const sqsum = new Float64Array((W + 1) * (H + 1));
+        ip.compute_integral_image(src, sum, sqsum, null);
+
+        const want = refIntegralImage(src.data, W, H);
+        expectExact("sum (combined call)", sum, want.sum, (W + 1) * (H + 1));
+        expectExact("sqsum", sqsum, want.sqsum, (W + 1) * (H + 1));
+    });
+});

--- a/tests/reference/known-values.test.ts
+++ b/tests/reference/known-values.test.ts
@@ -1,0 +1,277 @@
+/*
+ *  known-values.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { F32C1, rng, dstImage } from "../properties/helpers";
+import { refGrayscaleFixedPoint, refGrayscaleExact } from "./reference-impl";
+
+/**
+ * Closed-form ground truth (issue #87, category C1).
+ *
+ * Where the reference-implementation tests check that the optimised code
+ * computes the same thing as the definition, these check that the definition
+ * itself is right — the constants, the normalisation, the conventions. A
+ * reference implementation cannot catch a wrong constant, because the same
+ * misunderstanding would be encoded on both sides.
+ *
+ * Three kinds appear here:
+ *
+ *  1. Known constants, verifiable on paper (the binomial Gaussian kernels).
+ *  2. An approximation checked against the standard it approximates (jsfeat's
+ *     integer luma weights against real-valued BT.601).
+ *  3. Inputs CONSTRUCTED from a known answer, so the truth needs no second
+ *     implementation at all (SVD, homography).
+ */
+
+describe("grayscale: BT.601 luma", () => {
+    const W = 16;
+    const H = 12;
+
+    function randomRGBA(seed: number) {
+        const rand = rng(seed);
+        const rgba = new Uint8Array(W * H * 4);
+        for (let i = 0; i < rgba.length; i++) rgba[i] = (rand() * 256) | 0;
+        return rgba;
+    }
+
+    it("matches the documented 14-bit fixed-point formula exactly", () => {
+        // Checks the loop, stride and channel handling. Shares the constants
+        // with the implementation, so the next test is the one that validates
+        // those constants.
+        const rgba = randomRGBA(11);
+        const dst = dstImage(W, H);
+        jsfeatNext.imgproc.grayscale(rgba, W, H, dst);
+
+        const want = refGrayscaleFixedPoint(rgba, W, H);
+        for (let i = 0; i < W * H; i++) expect(dst.data[i]).toBe(want[i]);
+    });
+
+    it("stays within 1 of real-valued BT.601, proving the constants are right", () => {
+        // ITU-R BT.601-7: Y = 0.299 R + 0.587 G + 0.114 B. jsfeat approximates
+        // this with 4899/9617/1868 over 2^14. If a constant were wrong — a
+        // transposed digit, a red/blue swap — the fixed-point result would
+        // drift from the standard even though it still matched itself.
+        const rgba = randomRGBA(12);
+        const dst = dstImage(W, H);
+        jsfeatNext.imgproc.grayscale(rgba, W, H, dst);
+
+        const exact = refGrayscaleExact(rgba, W, H);
+        let worst = 0;
+        for (let i = 0; i < W * H; i++) worst = Math.max(worst, Math.abs(dst.data[i] - exact[i]));
+        expect(worst).toBeLessThanOrEqual(1);
+    });
+
+    it("uses the exact scaled weights, checked one channel at a time", () => {
+        // Pure red, green and blue pixels isolate each coefficient, so a
+        // channel swap cannot hide behind the others.
+        for (const [channel, weight] of [
+            [0, 0.299],
+            [1, 0.587],
+            [2, 0.114],
+        ] as [number, number][]) {
+            const rgba = new Uint8Array(4);
+            rgba[channel] = 255;
+            rgba[3] = 255;
+            const dst = dstImage(1, 1);
+            jsfeatNext.imgproc.grayscale(rgba, 1, 1, dst);
+            expect(Math.abs(dst.data[0] - 255 * weight)).toBeLessThanOrEqual(1);
+        }
+    });
+});
+
+describe("get_gaussian_kernel: the binomial kernels are exact", () => {
+    it("sizes 3 and 5 are the binomial rows, size 7 is jsfeat's own kernel", () => {
+        // For odd size <= 7 with sigma <= 0 jsfeat uses fixed tables. Sizes 3
+        // and 5 are the normalised rows of Pascal's triangle — [1,2,1]/4 and
+        // [1,4,6,4,1]/16 — but size 7 is [2,7,14,18,14,7,2]/64, NOT Pascal's
+        // [1,6,15,20,15,6,1]/64. All are exact binary fractions over 64, so
+        // they can be asserted to the bit.
+        const expected: Record<number, number[]> = {
+            3: [0.25, 0.5, 0.25],
+            5: [0.0625, 0.25, 0.375, 0.25, 0.0625],
+            7: [0.03125, 0.109375, 0.21875, 0.28125, 0.21875, 0.109375, 0.03125],
+        };
+        for (const size of [3, 5, 7]) {
+            const kernel = new Float32Array(size);
+            jsfeatNext.math.get_gaussian_kernel(size, 0, kernel, jsfeatNext.F32_t);
+            for (let i = 0; i < size; i++) expect(kernel[i]).toBe(expected[size][i]);
+        }
+    });
+
+    it("size 7 is [2,7,14,18,14,7,2]/64, flatter than the binomial row", () => {
+        // Recorded explicitly because it is a surprise: the pattern set by
+        // sizes 3 and 5 does not continue. Pascal's row 6 would be
+        // [1,6,15,20,15,6,1]/64; jsfeat ships a flatter kernel with more weight
+        // in the tails. Pinned so a future rewrite cannot "correct" it to the
+        // binomial row and silently change every 7-tap blur in the library.
+        const kernel = new Float32Array(7);
+        jsfeatNext.math.get_gaussian_kernel(7, 0, kernel, jsfeatNext.F32_t);
+
+        const asSixtyFourths = Array.from(kernel, (v) => v * 64);
+        expect(asSixtyFourths).toEqual([2, 7, 14, 18, 14, 7, 2]);
+
+        const pascal = [1, 6, 15, 20, 15, 6, 1];
+        expect(asSixtyFourths).not.toEqual(pascal);
+        // both sum to 64, so jsfeat's is a valid normalised kernel — just a
+        // different one, with a lower peak and heavier tails
+        expect(asSixtyFourths.reduce((a, b) => a + b, 0)).toBe(64);
+        expect(asSixtyFourths[3]).toBeLessThan(pascal[3]);
+        expect(asSixtyFourths[0]).toBeGreaterThan(pascal[0]);
+    });
+});
+
+describe("SVD: singular values chosen in advance are recovered", () => {
+    /** Builds `A = U diag(w) Vᵀ` from two rotations and chosen singular values. */
+    function buildFromKnown(w: number[], angleU: number, angleV: number) {
+        const rot = (t: number) => [Math.cos(t), -Math.sin(t), 0, Math.sin(t), Math.cos(t), 0, 0, 0, 1];
+        const U = rot(angleU);
+        const V = rot(angleV);
+        const A = new Array(9).fill(0);
+        for (let i = 0; i < 3; i++) {
+            for (let j = 0; j < 3; j++) {
+                let acc = 0;
+                for (let k = 0; k < 3; k++) acc += U[i * 3 + k] * w[k] * V[j * 3 + k];
+                A[i * 3 + j] = acc;
+            }
+        }
+        return A;
+    }
+
+    it("recovers 9, 4, 1 from a matrix built to have them", () => {
+        // No second SVD is involved: the input was manufactured from the
+        // answer, so the expected values are known by construction.
+        const want = [9, 4, 1];
+        const A = new jsfeatNext.matrix_t(3, 3, F32C1);
+        A.data.set(buildFromKnown(want, 0.7, 1.3));
+
+        const W = new jsfeatNext.matrix_t(1, 3, F32C1);
+        const U = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const V = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.linalg.svd_decompose(A, W, U, V, 0);
+
+        for (let i = 0; i < 3; i++) expect(W.data[i]).toBeCloseTo(want[i], 4);
+    });
+
+    it("handles a wide spread of magnitudes", () => {
+        const want = [100, 10, 0.5];
+        const A = new jsfeatNext.matrix_t(3, 3, F32C1);
+        A.data.set(buildFromKnown(want, 0.3, 2.1));
+
+        const W = new jsfeatNext.matrix_t(1, 3, F32C1);
+        const U = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const V = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.linalg.svd_decompose(A, W, U, V, 0);
+
+        for (let i = 0; i < 3; i++) expect(W.data[i]).toBeCloseTo(want[i], 3);
+    });
+});
+
+describe("homography2d: a known transform is recovered from the points it maps", () => {
+    it("recovers the matrix used to generate the correspondences", () => {
+        // Choose H, push four points through it, then require the solver to
+        // reconstruct H. Homographies are defined up to scale, so both sides
+        // are normalised by the bottom-right entry before comparing.
+        const H = [1.2, 0.1, 15, -0.05, 0.95, -8, 0.0003, -0.0002, 1.0];
+        const from = [
+            { x: 10, y: 10 },
+            { x: 200, y: 20 },
+            { x: 190, y: 150 },
+            { x: 20, y: 160 },
+        ];
+        const to = from.map((p) => {
+            const wgt = H[6] * p.x + H[7] * p.y + H[8];
+            return {
+                x: (H[0] * p.x + H[1] * p.y + H[2]) / wgt,
+                y: (H[3] * p.x + H[4] * p.y + H[5]) / wgt,
+            };
+        });
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.homography2d.run(from, to, model, 4);
+
+        for (let i = 0; i < 9; i++) {
+            expect(model.data[i] / model.data[8]).toBeCloseTo(H[i] / H[8], 3);
+        }
+    });
+
+    it("recovers a pure translation", () => {
+        // A case whose answer is obvious by inspection, so a reader can check
+        // the test itself without trusting the general construction above.
+        const from = [
+            { x: 0, y: 0 },
+            { x: 100, y: 0 },
+            { x: 100, y: 100 },
+            { x: 0, y: 100 },
+        ];
+        const to = from.map((p) => ({ x: p.x + 25, y: p.y - 40 }));
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.homography2d.run(from, to, model, 4);
+
+        const m = Array.from({ length: 9 }, (_, i) => model.data[i] / model.data[8]);
+        expect(m[0]).toBeCloseTo(1, 4);
+        expect(m[1]).toBeCloseTo(0, 4);
+        expect(m[2]).toBeCloseTo(25, 3);
+        expect(m[3]).toBeCloseTo(0, 4);
+        expect(m[4]).toBeCloseTo(1, 4);
+        expect(m[5]).toBeCloseTo(-40, 3);
+    });
+});
+
+describe("mat3x3_determinant: hand-computed values", () => {
+    it("matches cofactor expansion on paper", () => {
+        // det = 1(5*9 - 6*8) - 2(4*9 - 6*7) + 3(4*8 - 5*7)
+        //     = 1(-3) - 2(-6) + 3(-3) = -3 + 12 - 9 = 0   (singular)
+        const singular = new jsfeatNext.matrix_t(3, 3, F32C1);
+        singular.data.set([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+        expect(jsfeatNext.matmath.mat3x3_determinant(singular)).toBeCloseTo(0, 5);
+
+        // det = 2(1*1 - 0*0) - 0 + 0 = 2 ... for diag-ish [[2,0,0],[0,3,0],[0,0,4]]
+        const diagonal = new jsfeatNext.matrix_t(3, 3, F32C1);
+        diagonal.data.set([2, 0, 0, 0, 3, 0, 0, 0, 4]);
+        expect(jsfeatNext.matmath.mat3x3_determinant(diagonal)).toBeCloseTo(24, 5);
+
+        // a worked non-trivial case:
+        // det = 6(-2*2 - 5*8) - 1(4*2 - 5*7) + 1(4*8 - (-2)*7)
+        //     = 6(-44) - 1(-27) + 1(46) = -264 + 27 + 46 = -191
+        const general = new jsfeatNext.matrix_t(3, 3, F32C1);
+        general.data.set([6, 1, 1, 4, -2, 5, 7, 8, 2]);
+        expect(jsfeatNext.matmath.mat3x3_determinant(general)).toBeCloseTo(-191, 4);
+    });
+});

--- a/tests/reference/reference-impl.ts
+++ b/tests/reference/reference-impl.ts
@@ -1,0 +1,237 @@
+/*
+ *  reference-impl.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+/**
+ * Naive reference implementations for the ground-truth suite (issue #87,
+ * category C).
+ *
+ * Every function here is written from the DEFINITION of the operation, in the
+ * slowest and most obvious way possible — explicit neighbourhood loops, no
+ * sliding sums, no fixed point, no transposed passes. They exist purely to be
+ * compared against the optimised implementations in `src/`.
+ *
+ * That comparison catches a class of defect nothing else in the suite can:
+ * parity can't (the vendored oracle shares jsfeat's code shape, so it shares
+ * its bugs) and the invariant tests can't (they constrain the answer without
+ * pinning it). #115 demonstrated the hole concretely — an off-by-one injected
+ * into `box_blur_gray`'s loop bound changed WHICH loop phase computed a pixel
+ * without changing the value for a uniform image, and no test noticed.
+ *
+ * Rules for anything added here:
+ *
+ *  1. Derive it from the operation's definition, never by reading `src/`.
+ *     Transcribing the implementation would make the test circular.
+ *  2. Prefer clarity over speed, always. These run on tiny images.
+ *  3. Where jsfeat's convention is a genuine choice rather than a definition
+ *     (border handling, rounding), state the choice and where it came from.
+ */
+
+/** Clamp `v` into `[0, n - 1]`. Used for replicated borders. */
+function clamp(v: number, n: number) {
+    return v < 0 ? 0 : v >= n ? n - 1 : v;
+}
+
+/**
+ * Box blur: mean of the `(2r+1)²` neighbourhood, borders replicated.
+ *
+ * Verified bit-exact against `imgproc.box_blur_gray` for radius 1 and 2 on
+ * non-uniform input. Radius 3 differs by at most 1 because the library scales
+ * by the float `1/49` and truncates — see #114, which also covers the much
+ * larger breakage when the image is smaller than the kernel.
+ */
+export function refBoxBlur(src: ArrayLike<number>, w: number, h: number, radius: number): Int32Array {
+    return boxBlur(src, w, h, radius, false);
+}
+
+/**
+ * The same box blur, but reproducing the library's ARITHMETIC as well as its
+ * maths: it scales by the float reciprocal `1/area` and truncates, rather than
+ * dividing exactly.
+ *
+ * This exists so the ground-truth comparison can be exact at every radius. The
+ * two differ only where the reciprocal is not exactly representable — radius 3,
+ * where `128 * 49 * (1/49) = 127.999999999999986` truncates to 127 (#114). With
+ * an exact-division reference the only way to accommodate that is a ±1
+ * tolerance, and a tolerance wide enough to absorb the defect is also wide
+ * enough to hide a real off-by-one.
+ */
+export function refBoxBlurAsImplemented(src: ArrayLike<number>, w: number, h: number, radius: number): Int32Array {
+    return boxBlur(src, w, h, radius, true);
+}
+
+function boxBlur(src: ArrayLike<number>, w: number, h: number, radius: number, floatScale: boolean): Int32Array {
+    const out = new Int32Array(w * h);
+    const area = (2 * radius + 1) * (2 * radius + 1);
+    const scale = 1.0 / area;
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            let sum = 0;
+            for (let dy = -radius; dy <= radius; dy++) {
+                for (let dx = -radius; dx <= radius; dx++) {
+                    sum += src[clamp(y + dy, h) * w + clamp(x + dx, w)];
+                }
+            }
+            out[y * w + x] = floatScale ? Math.floor(sum * scale) : Math.floor(sum / area);
+        }
+    }
+    return out;
+}
+
+/**
+ * Grayscale conversion in the integer form jsfeat uses: BT.601 luma weights
+ * scaled to 14-bit fixed point, with rounding via the `+8192` bias.
+ *
+ * NB this shares the *constants* with the implementation, so on its own it
+ * only checks the loop and channel handling. `refGrayscaleExact` below is the
+ * independent half — it validates the constants themselves against the real
+ * BT.601 coefficients.
+ */
+export function refGrayscaleFixedPoint(rgba: ArrayLike<number>, w: number, h: number, channels = 4): Int32Array {
+    const out = new Int32Array(w * h);
+    for (let i = 0; i < w * h; i++) {
+        const r = rgba[i * channels];
+        const g = rgba[i * channels + 1];
+        const b = rgba[i * channels + 2];
+        out[i] = (r * 4899 + g * 9617 + b * 1868 + 8192) >> 14;
+    }
+    return out;
+}
+
+/**
+ * Grayscale using the real-valued BT.601 coefficients (ITU-R BT.601-7 §2.5.1:
+ * `Y = 0.299 R + 0.587 G + 0.114 B`). Independent of jsfeat's fixed-point
+ * constants, so comparing against it tests whether those constants are right.
+ */
+export function refGrayscaleExact(rgba: ArrayLike<number>, w: number, h: number, channels = 4): Float64Array {
+    const out = new Float64Array(w * h);
+    for (let i = 0; i < w * h; i++) {
+        out[i] = 0.299 * rgba[i * channels] + 0.587 * rgba[i * channels + 1] + 0.114 * rgba[i * channels + 2];
+    }
+    return out;
+}
+
+/**
+ * Separable 3×3 derivative filters, matching jsfeat's border convention.
+ *
+ * The border handling is ASYMMETRIC and worth stating explicitly, because it
+ * is a choice rather than a definition and it is easy to guess wrong:
+ *
+ *  - vertically it REFLECTS (`y = -1` reads row 1, `y = h` reads row `h-2`),
+ *    which is OpenCV's `BORDER_REFLECT_101`;
+ *  - horizontally it REPLICATES (`x = -1` reads column 0).
+ *
+ * Read off `imgproc.sobel_derivatives`: `srow0 = (y > 0 ? y - 1 : 1) * w`
+ * versus `trow0[0] = trow0[1]`. Assuming replication in both directions makes
+ * the interior match exactly and every border pixel disagree.
+ *
+ * @param smooth The smoothing triple: `[1, 2, 1]` for Sobel, `[3, 10, 3]` for
+ *               Scharr. The derivative triple is `[-1, 0, 1]` for both.
+ */
+export function refDerivatives(src: ArrayLike<number>, w: number, h: number, smooth: [number, number, number]) {
+    const [s0, s1, s2] = smooth;
+    /** Vertical neighbours with reflected borders. */
+    const above = (y: number) => (y > 0 ? y - 1 : 1);
+    const below = (y: number) => (y < h - 1 ? y + 1 : h - 2);
+
+    // pass 1, vertical: smooth into `sm`, differentiate into `dv`
+    const sm = new Float64Array(w * h);
+    const dv = new Float64Array(w * h);
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const a = src[above(y) * w + x];
+            const m = src[y * w + x];
+            const b = src[below(y) * w + x];
+            sm[y * w + x] = a * s0 + m * s1 + b * s2;
+            dv[y * w + x] = b - a;
+        }
+    }
+
+    // pass 2, horizontal with replicated borders: dx differentiates the
+    // vertically-smoothed image, dy smooths the vertically-differentiated one
+    const dx = new Float64Array(w * h);
+    const dy = new Float64Array(w * h);
+    for (let y = 0; y < h; y++) {
+        for (let x = 0; x < w; x++) {
+            const l = clamp(x - 1, w);
+            const r = clamp(x + 1, w);
+            dx[y * w + x] = sm[y * w + r] - sm[y * w + l];
+            dy[y * w + x] = dv[y * w + l] * s0 + dv[y * w + x] * s1 + dv[y * w + r] * s2;
+        }
+    }
+    return { dx, dy };
+}
+
+/** Sobel: smoothing triple `[1, 2, 1]`. */
+export function refSobel(src: ArrayLike<number>, w: number, h: number) {
+    return refDerivatives(src, w, h, [1, 2, 1]);
+}
+
+/** Scharr: smoothing triple `[3, 10, 3]`. */
+export function refScharr(src: ArrayLike<number>, w: number, h: number) {
+    return refDerivatives(src, w, h, [3, 10, 3]);
+}
+
+/**
+ * Summed-area tables by brute force: every cell is the full sum of the
+ * rectangle above-left of it, recomputed from scratch. O(n⁴) and completely
+ * uninterested in the incremental recurrence the real implementation uses,
+ * which is the point.
+ *
+ * The tables are `(w+1) × (h+1)` with a zero first row and column.
+ */
+export function refIntegralImage(src: ArrayLike<number>, w: number, h: number) {
+    const stride = w + 1;
+    const sum = new Float64Array(stride * (h + 1));
+    const sqsum = new Float64Array(stride * (h + 1));
+    for (let y = 1; y <= h; y++) {
+        for (let x = 1; x <= w; x++) {
+            let s = 0;
+            let s2 = 0;
+            for (let j = 0; j < y; j++) {
+                for (let i = 0; i < x; i++) {
+                    const v = src[j * w + i];
+                    s += v;
+                    s2 += v * v;
+                }
+            }
+            sum[y * stride + x] = s;
+            sqsum[y * stride + x] = s2;
+        }
+    }
+    return { sum, sqsum, stride };
+}


### PR DESCRIPTION
Category **C1** of the [#87 plan](https://github.com/webarkit/jsfeatNext/issues/87#issuecomment-5153239244). **18 new cases, 229 → 247 total.** Tests and docs only, no `src/` changes.

## Why

This is the first part of the suite that pins **actual output values**. Parity compares against a vendored jsfeat that shares any inherited defect; the invariant tests constrain answers without fixing them. #115 showed an off-by-one in a loop bound surviving both, because it changed *which* code path produced a pixel without changing the value for a uniform image.

## What is here

**Reference implementations** (`tests/reference/imgproc.test.ts`) — naive, obvious versions of `box_blur`, `sobel`, `scharr` and the integral image, written from each operation's definition and compared on non-uniform input. All match **bit-exactly**, so there are no tolerances anywhere.

**Closed-form values** (`tests/reference/known-values.test.ts`) — for what a reference implementation *cannot* catch, since the same misunderstanding would sit on both sides. The binomial kernels asserted to the bit; jsfeat's integer luma constants checked against real-valued BT.601 rather than against themselves; and inputs **constructed from known answers** — `A = U·diag(w)·Vᵀ` requiring SVD to return the chosen singular values, a chosen homography requiring `homography2d` to recover it.

## Three findings

**1. Sobel and scharr use asymmetric border handling.** Reflect vertically (`BORDER_REFLECT_101`), replicate horizontally:

```ts
srow0 = ((y > 0 ? y - 1 : 1) * w) | 0;   // vertical: reflect
trow0[0] = trow0[1];                      // horizontal: replicate
```

Assuming replication in both directions makes the interior match exactly (352/352) and nearly every border pixel disagree (35/80) — which reads like a wrong kernel when the kernel is fine. Now pinned by its own test.

**2. `get_gaussian_kernel` size 7 is not the binomial row.** It is `[2,7,14,18,14,7,2]/64`, not Pascal's `[1,6,15,20,15,6,1]/64` — though sizes 3 and 5 *are* the binomial rows. Flatter peak, heavier tails. Pinned so a rewrite cannot "correct" it and silently change every 7-tap blur in the library.

**3. My own first draft had the flaw it was written to prevent.** Re-running the #115 off-by-one against it, the ground-truth test **still missed it**. At 23×17 that mutation perturbs *only* radius 3, by *exactly* 1 — precisely the slack a ±1 tolerance was allowing for the known truncation defect.

Fixed two ways: sweep five shapes rather than one (8×8 at radius 1 differs in 15 pixels), and **model** the defect instead of tolerating it — a reference variant scales by the float reciprocal exactly as the library does, so comparison is exact at every radius, and the truncation is asserted separately as *"differs from exact division only at radius 3, and only by 1"*. Now caught.

> A tolerance wide enough to absorb a known defect is wide enough to hide an unknown one.

## `docs/implementation-notes.md`

Collects the conventions and quirks established across this whole effort, so they are not rediscovered: border conventions, fixed-point and rounding behaviour, the known defects (#102, #110, #111, #114) with the measurements behind them, behaviour that *looks* wrong but is not (identity warps, `equalize_histogram` on a uniform image, LK displacement limits), data-structure gotchas (8-byte padding, `median` returning the lower middle), and notes on what each layer of the suite can and cannot catch.

Corrections are kept rather than edited out — including the `min(cols, rows)` rule for #114 that turned out to be wrong.

## Remaining

**C2** — `gaussian_blur` (its arithmetic model still needs resolving; neither float nor a naive fixed-point reproduction matched) and the warps/`resample`. **C3** — optional OpenCV cross-check, to be decided once C2 shows what is still unpinned.

Verified: prettier clean, `tsc --noEmit` clean, `license-check` clean, `npm test` 246 passed + 1 expected fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
