### PR TITLE
test(reference): pin gaussian_blur and warp_affine against references (refs #87, C2)

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -187,12 +187,19 @@ Practical effect: speckle along the top and left edges of a warped image, where
 `fill_value` was probably intended. Coordinates below `-1` are unaffected —
 they truncate to `-1` and fail the check correctly.
 
-Characterized in `tests/reference/imgproc.test.ts`; **not yet filed as an
-issue.**
+Identical bounds check in original jsfeat, so inherited rather than introduced
+here. Characterized in `tests/reference/imgproc.test.ts`; tracked as
+[#119](https://github.com/webarkit/jsfeatNext/issues/119).
 
-### `invert_3x3` on a singular matrix
+### `invert_3x3` on a singular matrix — [#120](https://github.com/webarkit/jsfeatNext/issues/120)
 
-Returns `NaN` / `±Infinity` silently, with no signal to the caller. Same family
+Divides by the determinant without checking it, so a singular input returns
+`NaN` / `±Infinity` silently — no return value, no exception, no flag.
+Byte-identical in original jsfeat, so inherited.
+
+Matters because `NaN` propagates: a degenerate homography or collapsed affine
+fit poisons whatever consumes the inverse, surfacing far from the cause.
+Contrast `linalg.lu_solve`, which returns 0 on a singular system. Same family
 as [#102](https://github.com/webarkit/jsfeatNext/issues/102).
 
 ### `svd_invert` on non-square input — [#102](https://github.com/webarkit/jsfeatNext/issues/102)

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -81,6 +81,26 @@ fixed binomial path, where the weights are exact binary fractions.
 real-valued ITU-R BT.601 coefficients `0.299 / 0.587 / 0.114`. Measured
 agreement with the real-valued standard: **within 1 grey level**.
 
+### `gaussian_blur` — quantises to 8 bits *between* passes
+
+The separable blur is not "accumulate both passes, then scale". On `U8` input
+it:
+
+1. uses the **integer** kernel (weights summing to ~256), not the float one;
+2. ends each pass with `Math.min(sum >> 8, 255)` — an arithmetic shift, so it
+   **truncates**, with no `+128` rounding bias;
+3. writes the horizontal result **back into the U8 destination**, so precision
+   is quantised to 8 bits before the vertical pass reads it.
+
+Point 3 is the one that catches people out. Accumulating both passes at full
+width and shifting once at the end produces a slightly *better* answer that is
+1–2 grey levels away from what the library actually returns. Reproducing all
+three details gives bit-exact agreement across every shape and kernel size
+tested.
+
+Borders **replicate** in both directions here — unlike the derivative filters
+in §1.
+
 ### `resample` — the `U8` fast path truncates
 
 `_resample_u8` uses 8.8 fixed point and is chosen when both matrices are `U8`
@@ -149,6 +169,26 @@ result.
 Verified with five seeds — zeros, a copy of `prev_xy`, `+1`, `+50`, and
 `-9999` everywhere — all producing **bit-identical** output. Identical code
 path in original jsfeat, so the docstring is what is out of step.
+
+### `warp_affine` extrapolates just outside the top-left edge
+
+The bounds check is `ixs >= 0 && iys >= 0 && ...` where `ixs = xs | 0`, and
+`| 0` truncates **toward zero**. So a source coordinate of `-0.5` yields
+`ixs = 0`, passes the check, and is treated as inside the image. The
+interpolation weight `a = xs - ixs` is then **negative**, and the "bilinear
+interpolation" becomes an extrapolation.
+
+The result can leave `[0, 255]`, and because the destination is a `Uint8Array`
+it **wraps modulo 256** rather than clamping. On a 23×17 test warp with a
+`(-0.5, -0.5)` translation: 13 pixels sampled with a negative weight, 4 of them
+out of range and wrapped.
+
+Practical effect: speckle along the top and left edges of a warped image, where
+`fill_value` was probably intended. Coordinates below `-1` are unaffected —
+they truncate to `-1` and fail the check correctly.
+
+Characterized in `tests/reference/imgproc.test.ts`; **not yet filed as an
+issue.**
 
 ### `invert_3x3` on a singular matrix
 

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -38,8 +38,16 @@
 
 import { describe, it, expect } from "vitest";
 import jsfeatNext from "../../src/jsfeatNext";
-import { noiseImage, dstImage, image } from "../properties/helpers";
-import { refBoxBlur, refBoxBlurAsImplemented, refSobel, refScharr, refIntegralImage } from "./reference-impl";
+import { noiseImage, dstImage, image, U8C1, F32C1 } from "../properties/helpers";
+import {
+    refBoxBlur,
+    refBoxBlurAsImplemented,
+    refGaussianBlurU8,
+    refSobel,
+    refScharr,
+    refIntegralImage,
+    refWarpAffine,
+} from "./reference-impl";
 
 /**
  * Ground-truth tests for `imgproc` (issue #87, category C1).
@@ -131,6 +139,63 @@ describe("ground truth: box_blur_gray vs a naive clamped-window mean", () => {
     });
 });
 
+describe("ground truth: gaussian_blur vs a naive separable convolution", () => {
+    const SHAPES: [number, number][] = [
+        [8, 8],
+        [16, 9],
+        [9, 16],
+        [23, 17],
+        [32, 24],
+    ];
+
+    it("matches exactly at every kernel size and shape", () => {
+        // Exact only once the reference reproduces jsfeat's ARITHMETIC as well
+        // as its maths: the integer kernel, a truncating `>> 8` per pass, and
+        // — the part that is easy to miss — quantisation back to 8 bits
+        // BETWEEN the two passes. Accumulating both passes at full width and
+        // shifting once at the end lands 1-2 grey levels out on most pixels.
+        for (const [w, h] of SHAPES) {
+            const src = noiseImage(w, h, 777);
+            for (const size of [3, 5, 7, 9]) {
+                const dst = dstImage(w, h);
+                ip.gaussian_blur(src, dst, size, 0);
+
+                const intKernel = new Int32Array(size);
+                jsfeatNext.math.get_gaussian_kernel(size, 0, intKernel, jsfeatNext.U8_t);
+                expectExact(`${w}x${h} k=${size}`, dst.data, refGaussianBlurU8(src.data, w, h, intKernel), w * h);
+            }
+        }
+    });
+
+    it("matches on a gradient, where a border slip cannot hide in noise", () => {
+        const src = image(W, H, (x, y) => (x * 5 + y * 11) & 0xff);
+        const dst = dstImage(W, H);
+        ip.gaussian_blur(src, dst, 5, 0);
+
+        const intKernel = new Int32Array(5);
+        jsfeatNext.math.get_gaussian_kernel(5, 0, intKernel, jsfeatNext.U8_t);
+        expectExact("gradient k=5", dst.data, refGaussianBlurU8(src.data, W, H, intKernel), W * H);
+    });
+
+    it("matches when sigma is given explicitly rather than derived", () => {
+        // sigma > 0 takes the sampled exp() path in get_gaussian_kernel instead
+        // of the fixed binomial tables, so the weights differ entirely.
+        const src = noiseImage(W, H, 314);
+        for (const [size, sigma] of [
+            [5, 1.5],
+            [7, 0.8],
+            [9, 2.5],
+        ] as [number, number][]) {
+            const dst = dstImage(W, H);
+            ip.gaussian_blur(src, dst, size, sigma);
+
+            const intKernel = new Int32Array(size);
+            jsfeatNext.math.get_gaussian_kernel(size, sigma, intKernel, jsfeatNext.U8_t);
+            expectExact(`k=${size} sigma=${sigma}`, dst.data, refGaussianBlurU8(src.data, W, H, intKernel), W * H);
+        }
+    });
+});
+
 describe("ground truth: sobel and scharr derivatives", () => {
     /** Splits jsfeat's interleaved dx,dy output into two planes. */
     function planes(dst: { data: ArrayLike<number> }, n: number) {
@@ -188,6 +253,67 @@ describe("ground truth: sobel and scharr derivatives", () => {
             }
         }
         expect(borderChecked).toBe(2 * W + 2 * H - 4);
+    });
+});
+
+describe("ground truth: warp_affine vs naive bilinear sampling", () => {
+    /** Builds an F32 3x3 affine matrix and returns its float32-rounded coefficients. */
+    function transform(values: number[]) {
+        const m = new jsfeatNext.matrix_t(3, 3, F32C1);
+        m.data.set([...values, 0, 0, 1]);
+        return { matrix: m, coefficients: Array.from({ length: 6 }, (_, i) => m.data[i]) };
+    }
+
+    const CASES: [string, number[]][] = [
+        [
+            "rotate+scale+translate",
+            [1.15 * Math.cos(0.37), -1.15 * Math.sin(0.37), 3.25, 1.15 * Math.sin(0.37), 1.15 * Math.cos(0.37), -1.75],
+        ],
+        ["pure scale", [0.5, 0, 0, 0, 0.5, 0]],
+        ["shear", [1, 0.4, -2.5, 0.15, 1, 1.25]],
+        ["translate only", [1, 0, 4.5, 0, 1, -3.5]],
+    ];
+
+    it("matches exactly for a range of transforms", () => {
+        const src = noiseImage(W, H, 2468);
+        for (const [name, values] of CASES) {
+            const { matrix, coefficients } = transform(values);
+            const dst = new jsfeatNext.matrix_t(W, H, U8C1);
+            ip.warp_affine(src, dst, matrix, 42);
+
+            const want = refWarpAffine(src.data, W, H, W, H, coefficients, 42);
+            expectExact(name, dst.data, want, W * H);
+        }
+    });
+
+    it("treats source coordinates in (-1, 0) as inside, extrapolating with a negative weight", () => {
+        // `xs | 0` truncates toward zero, so xs = -0.5 gives ixs = 0 and passes
+        // the `ixs >= 0` bounds check. The interpolation weight `a = xs - ixs`
+        // is then negative and the result is an extrapolation, which can leave
+        // [0,255] and wrap in the U8 destination. Characterizing the current
+        // behaviour, not endorsing it.
+        const src = noiseImage(W, H, 2468);
+        const { matrix, coefficients } = transform([1, 0, -0.5, 0, 1, -0.5]);
+        const dst = new jsfeatNext.matrix_t(W, H, U8C1);
+        ip.warp_affine(src, dst, matrix, 42);
+
+        // count how many sampled pixels get a negative weight
+        let negativeWeight = 0;
+        for (let y = 0; y < H; y++) {
+            for (let x = 0; x < W; x++) {
+                const xs = coefficients[0] * x + coefficients[1] * y + coefficients[2];
+                const ys = coefficients[3] * x + coefficients[4] * y + coefficients[5];
+                const ixs = xs | 0;
+                const iys = ys | 0;
+                if (ixs >= 0 && iys >= 0 && ixs < W - 1 && iys < H - 1 && (xs - ixs < 0 || ys - iys < 0)) {
+                    negativeWeight++;
+                }
+            }
+        }
+        expect(negativeWeight).toBeGreaterThan(0);
+
+        // and the reference reproduces it, wrapping included
+        expectExact("negative-weight warp", dst.data, refWarpAffine(src.data, W, H, W, H, coefficients, 42), W * H);
     });
 });
 

--- a/tests/reference/reference-impl.ts
+++ b/tests/reference/reference-impl.ts
@@ -146,6 +146,67 @@ export function refGrayscaleExact(rgba: ArrayLike<number>, w: number, h: number,
 }
 
 /**
+ * Separable Gaussian blur on `U8` data, reproducing jsfeat's arithmetic.
+ *
+ * Three details matter, and getting any of them wrong puts the result 1–2 grey
+ * levels out on most pixels — which is how this looked before the
+ * implementation was read properly:
+ *
+ *  1. The kernel is the INTEGER one (weights summing to ~256), not the float
+ *     one. Pass `U8_t` to `get_gaussian_kernel`.
+ *  2. Each pass ends with `min(sum >> 8, 255)` — an arithmetic shift, so it
+ *     TRUNCATES. There is no `+128` rounding bias.
+ *  3. The horizontal result is written back to the `U8` destination before the
+ *     vertical pass reads it, so precision is quantised to 8 bits BETWEEN the
+ *     two passes. Accumulating both passes at full width and shifting once at
+ *     the end gives a different, slightly better answer.
+ *
+ * Borders replicate in both directions, unlike the derivative filters above.
+ *
+ * @param intKernel Integer kernel from `get_gaussian_kernel(size, sigma, k, U8_t)`.
+ */
+export function refGaussianBlurU8(
+    src: ArrayLike<number>,
+    w: number,
+    h: number,
+    intKernel: ArrayLike<number>
+): Int32Array {
+    const k = intKernel.length;
+    const half = k >> 1;
+
+    /** One separable pass along a line, with replicated ends. */
+    const convolveLine = (read: (i: number) => number, n: number) => {
+        const padded = new Int32Array(n + 2 * half);
+        for (let i = 0; i < half; i++) padded[i] = read(0);
+        for (let i = 0; i < n; i++) padded[half + i] = read(i);
+        for (let i = 0; i < half; i++) padded[half + n + i] = read(n - 1);
+
+        const out = new Int32Array(n);
+        for (let i = 0; i < n; i++) {
+            let sum = 0;
+            for (let t = 0; t < k; t++) sum += padded[i + t] * intKernel[t];
+            out[i] = Math.min(sum >> 8, 255);
+        }
+        return out;
+    };
+
+    // pass 1: horizontal, quantised to 8 bits before pass 2 sees it
+    const mid = new Int32Array(w * h);
+    for (let y = 0; y < h; y++) {
+        const row = convolveLine((x) => src[y * w + x], w);
+        for (let x = 0; x < w; x++) mid[y * w + x] = row[x];
+    }
+
+    // pass 2: vertical over that quantised intermediate
+    const out = new Int32Array(w * h);
+    for (let x = 0; x < w; x++) {
+        const col = convolveLine((y) => mid[y * w + x], h);
+        for (let y = 0; y < h; y++) out[y * w + x] = col[y];
+    }
+    return out;
+}
+
+/**
  * Separable 3×3 derivative filters, matching jsfeat's border convention.
  *
  * The border handling is ASYMMETRIC and worth stating explicitly, because it
@@ -204,6 +265,59 @@ export function refSobel(src: ArrayLike<number>, w: number, h: number) {
 /** Scharr: smoothing triple `[3, 10, 3]`. */
 export function refScharr(src: ArrayLike<number>, w: number, h: number) {
     return refDerivatives(src, w, h, [3, 10, 3]);
+}
+
+/**
+ * Affine warp with bilinear sampling, reproducing jsfeat's behaviour exactly.
+ *
+ * Three details are needed for exactness, and each one cost a measurement:
+ *
+ *  1. Read the transform coefficients back out of the `matrix_t`. It is `F32`,
+ *     so the implementation sees float32-rounded values, not whatever float64
+ *     literals the caller wrote.
+ *  2. Store the result through a `Uint8Array`. The library writes into a U8
+ *     destination, so an out-of-range value WRAPS modulo 256 rather than
+ *     clamping — and out-of-range values do occur, see below.
+ *  3. The bounds check uses `xs | 0`, which truncates TOWARD ZERO. A source
+ *     coordinate of `-0.5` therefore gives `ixs = 0` and passes `ixs >= 0`, so
+ *     the pixel is treated as inside the image and the "interpolation" runs
+ *     with a NEGATIVE weight — extrapolating instead of interpolating. On a
+ *     23x17 test warp this affected 13 pixels, 4 of which left [0,255] and
+ *     wrapped. Visible as speckle along the top and left edges of a warp.
+ *
+ * @param fill Value written where the source coordinate is out of bounds.
+ */
+export function refWarpAffine(
+    src: ArrayLike<number>,
+    srcW: number,
+    srcH: number,
+    dstW: number,
+    dstH: number,
+    coefficients: ArrayLike<number>,
+    fill: number
+): Uint8Array {
+    const m = coefficients;
+    const out = new Uint8Array(dstW * dstH);
+    for (let y = 0; y < dstH; y++) {
+        for (let x = 0; x < dstW; x++) {
+            const xs = m[0] * x + m[1] * y + m[2];
+            const ys = m[3] * x + m[4] * y + m[5];
+            const ixs = xs | 0;
+            const iys = ys | 0;
+
+            if (ixs >= 0 && iys >= 0 && ixs < srcW - 1 && iys < srcH - 1) {
+                const a = xs - ixs;
+                const b = ys - iys;
+                const off = srcW * iys + ixs;
+                const p0 = src[off] + a * (src[off + 1] - src[off]);
+                const p1 = src[off + srcW] + a * (src[off + srcW + 1] - src[off + srcW]);
+                out[y * dstW + x] = p0 + b * (p1 - p0);
+            } else {
+                out[y * dstW + x] = fill;
+            }
+        }
+    }
+    return out;
 }
 
 /**


### PR DESCRIPTION
Category **C2** of the [#87 plan](https://github.com/webarkit/jsfeatNext/issues/87#issuecomment-5153239244). **5 new cases, 247 → 252.** Tests and docs only, no `src/` changes.

Both operations now match a naive reference **bit-exactly**, so no tolerances are involved anywhere.

## `gaussian_blur` — the open question from C1

C1 left this unresolved: neither a float model nor a naive fixed-point one matched, landing 1–2 grey levels out. Three details were missing, and all three are required:

1. it uses the **integer** kernel (weights summing to ~256), not the float one;
2. each pass ends with `Math.min(sum >> 8, 255)` — an arithmetic shift, so it **truncates**, with no `+128` rounding bias;
3. the horizontal result is written **back into the U8 destination**, so precision is quantised to 8 bits **between** the two passes.

Point 3 is the trap. Accumulating both passes at full width and shifting once at the end produces a slightly *better* answer — which is exactly why it doesn't match. With all three modelled, agreement is exact across every shape and kernel size tested, including the sampled `exp()` path when `sigma` is given explicitly.

## `warp_affine` — three details, one of them a defect

Needed: read the coefficients back out of the `matrix_t` (it is `F32`, so the implementation sees float32-rounded values, not the float64 literals the caller wrote); store through a `Uint8Array` (out-of-range results **wrap**, not clamp); and account for the bounds check truncating toward zero.

**That last one is a genuine edge-case defect.** `ixs = xs | 0` truncates toward zero, so a source coordinate of `-0.5` gives `ixs = 0`, passes `ixs >= 0`, and is treated as inside the image. The interpolation weight `a = xs - ixs` goes **negative** and bilinear sampling becomes extrapolation — which can leave `[0,255]` and wrap modulo 256.

Measured on a 23×17 warp with a `(-0.5, -0.5)` translation: **13 pixels sampled with a negative weight, 4 of them wrapped.** Practical effect is speckle along the top and left edges, where `fill_value` was presumably intended. Coordinates below `-1` are fine — they truncate to `-1` and fail the check correctly.

Characterized here but **not filed as an issue** — happy to open one if you want it tracked alongside #110/#111/#114.

## Docs

`docs/implementation-notes.md` gains both, including the models that *failed*, so the next person doesn't repeat the same two dead ends.

## Still open in C2

`resample` — its `U8` fast path uses 8.8 fixed point and needs its own arithmetic model before the ±1 quantisation can be pinned exactly rather than merely bounded.

Verified: prettier clean, `tsc --noEmit` clean, `license-check` clean, `npm test` 251 passed + 1 expected fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
