### PR TITLE
test(reference): pin resample against an exact area average (refs #87, completes C)

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -343,3 +343,50 @@ Two lessons, both now baked into the test:
 where no reference is practical: build `A = U·diag(w)·Vᵀ` from chosen singular
 values and require SVD to return them; push points through a chosen homography
 and require it to be recovered.
+
+### What this approach still cannot answer
+
+The reference implementations were written by the same person who read the
+implementation, so a shared misunderstanding of a *convention* survives both
+sides. Closed-form tests plug that hole for constants (BT.601, the binomial
+kernels) but not for algorithmic conventions. Two questions remain genuinely
+open:
+
+- **Is sobel's asymmetric border handling (§1) deliberate or accidental?** The
+  reference matches it because it was derived from the source. If the
+  reflect-vertically / replicate-horizontally split is an accident, the test
+  suite has enshrined it as the specification.
+- **Is the size-7 Gaussian kernel (§2) deliberate or a typo?** Sizes 3 and 5
+  are binomial rows and 7 is not, which is exactly the shape a long-lived typo
+  takes.
+
+Neither can be settled from inside this repo. A **one-off** comparison against
+OpenCV would settle both — `cv2.getGaussianKernel` and `cv2.Sobel` with an
+explicit `borderType` answer them directly.
+
+Deliberately deferred, and deferred as an *investigation* rather than a test
+category: even if OpenCV disagrees, neither would be changed (sobel's borders
+feed every derivative, detector and optical-flow result; the 7-tap kernel feeds
+every 7-tap blur), so the value is knowing whether jsfeat diverges from the CV
+mainstream by choice or by accident. Committed fixtures plus tolerance-tuning
+against OpenCV's different conventions would be a large cost for information
+that changes no code. Revisit if `haar` (#43) or `bbf` (#44) are ported —
+those have neither a usable oracle nor a tractable naive reference, so OpenCV
+fixtures would be the only ground truth available — or if OpenCV output is ever
+wanted as a **benchmark** baseline alongside #86.
+
+### Coverage: name-based auditing is not enough
+
+The category-D audit found untested modules by grepping test files for module
+names. That method has a blind spot it cannot see past: it cannot distinguish
+"untested" from "exercised transitively", and it silently passes any code
+reached only through another module.
+
+Concretely: `src/imgproc/convol.ts` exports two functions. `_convol_u8` is
+heavily exercised through `gaussian_blur`. **`_convol`, the ~120-line float
+path, is executed by none of the 255 tests** — every `gaussian_blur` call in
+the suite passes a `U8` image. Verified by instrumenting the function and
+running the whole suite: zero hits.
+
+The audit missed it because `convol.ts` *is* referenced, just never directly.
+A line-coverage report would have surfaced it mechanically.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -384,9 +384,18 @@ reached only through another module.
 
 Concretely: `src/imgproc/convol.ts` exports two functions. `_convol_u8` is
 heavily exercised through `gaussian_blur`. **`_convol`, the ~120-line float
-path, is executed by none of the 255 tests** — every `gaussian_blur` call in
-the suite passes a `U8` image. Verified by instrumenting the function and
-running the whole suite: zero hits.
+path, was executed by none of the tests** — every `gaussian_blur` call in the
+suite passed a `U8` image. Now covered, via `gaussian_blur` on `F32` matrices.
 
 The audit missed it because `convol.ts` *is* referenced, just never directly.
-A line-coverage report would have surfaced it mechanically.
+A line-coverage report would have surfaced it mechanically (#123).
+
+**A note on how to check this sort of thing.** The first attempt instrumented
+the function with `console.error` and counted lines in the Vitest output. That
+method is worthless: Vitest swallows worker console output, so it reports zero
+hits whether or not the code ran — it returned zero even after the float path
+was demonstrably covered. It gave the right answer by luck.
+
+Inject a `throw` instead. It cannot be swallowed, and it distinguishes the two
+cases unambiguously: with the coverage absent the suite passes untouched, and
+with it present the suite fails loudly at that line.

--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -101,13 +101,40 @@ tested.
 Borders **replicate** in both directions here — unlike the derivative filters
 in §1.
 
-### `resample` — the `U8` fast path truncates
+### `resample` — the `U8` fast path truncates in four places
 
-`_resample_u8` uses 8.8 fixed point and is chosen when both matrices are `U8`
-and the area ratio is under 256. Resampling a constant is exact at an integer
-ratio but comes out **up to 1 low** at a non-integer ratio (e.g. 77 → 76). The
-float path is exact, so the error is quantisation rather than bad resampling
-maths. Bit-identical to original jsfeat, so inherited, not a regression.
+`_resample_u8` computes an area average in 8.8 fixed point, and is chosen when
+both matrices are `U8` and the area ratio is under 256. It truncates at four
+separate points, **all biased downward**:
+
+| truncation | what it quantises |
+| --- | --- |
+| `alpha = ((sx1 - fsx1) * 0x100) \| 0` | per-column coverage weight |
+| `beta = (... * 256) \| 0` | per-row coverage weight |
+| `inv_scale_256 = (scale_x * scale_y * 0x10000) \| 0` | the normaliser |
+| store into the `U8` destination | the final value |
+
+Measured against an exact area average on 8-bit noise:
+
+| ratio | result |
+| --- | --- |
+| **integer** (e.g. 24×18 → 12×9, 32×24 → 8×6) | **exactly `floor(exact)`, every pixel** |
+| **fractional** (e.g. 23×17 → 9×7) | up to **1.379 low**, never meaningfully high |
+| float path (`F32` matrices) | agrees to ~1e-5 |
+
+Two corrections to what was written here earlier, both from measuring on real
+data rather than on a constant image:
+
+- the drift is **~1.4, not ~1**. The old figure came from a uniform-image test
+  (77 → 76), which only ever exercises one value and understates it.
+- "the float path is exact" was too strong — it agrees to float32 precision
+  (~1e-5), which is the right claim and still makes the point: the drift is
+  quantisation in the `U8` fast path, not bad resampling maths.
+
+The integer-ratio result is the useful one for testing: it is an exact
+equality, so it needs no tolerance at all.
+
+Bit-identical to original jsfeat, so inherited, not a regression.
 
 ---
 

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -43,6 +43,7 @@ import {
     refBoxBlur,
     refBoxBlurAsImplemented,
     refGaussianBlurU8,
+    refGaussianBlurF32,
     refSobel,
     refScharr,
     refIntegralImage,
@@ -176,6 +177,40 @@ describe("ground truth: gaussian_blur vs a naive separable convolution", () => {
         const intKernel = new Int32Array(5);
         jsfeatNext.math.get_gaussian_kernel(5, 0, intKernel, jsfeatNext.U8_t);
         expectExact("gradient k=5", dst.data, refGaussianBlurU8(src.data, W, H, intKernel), W * H);
+    });
+
+    it("covers the FLOAT convolution path, which no other test reaches", () => {
+        // gaussian_blur branches on `is_u8`: U8 sources go to _convol_u8,
+        // everything else to _convol. Every other gaussian_blur call in the
+        // suite passes a U8 image, so _convol — about 120 lines — was executed
+        // by none of the 255 tests. Verified by instrumenting it and running
+        // the whole suite: zero hits. See #123.
+        //
+        // The float path uses the float kernel (summing to 1) with no shift and
+        // no clamp, but the intermediate still round-trips through the F32
+        // destination between passes, so it is quantised to float32 precision —
+        // the same structural quirk as the U8 path, at a different width.
+        const noise = noiseImage(W, H, 777);
+        for (const size of [3, 5, 7, 9]) {
+            const src = new jsfeatNext.matrix_t(W, H, F32C1);
+            for (let i = 0; i < W * H; i++) src.data[i] = noise.data[i];
+            const dst = new jsfeatNext.matrix_t(W, H, F32C1);
+            ip.gaussian_blur(src, dst, size, 0);
+
+            const floatKernel = new Float32Array(size);
+            jsfeatNext.math.get_gaussian_kernel(size, 0, floatKernel, jsfeatNext.F32_t);
+            expectExact(`F32 k=${size}`, dst.data, refGaussianBlurF32(src.data, W, H, floatKernel), W * H);
+        }
+    });
+
+    it("keeps the float path in range and preserves a constant", () => {
+        // Cheap invariants on the same branch: an average cannot leave the
+        // input's range, and a constant image must survive unchanged.
+        const src = new jsfeatNext.matrix_t(W, H, F32C1);
+        src.data.fill(42.5);
+        const dst = new jsfeatNext.matrix_t(W, H, F32C1);
+        ip.gaussian_blur(src, dst, 5, 0);
+        for (let i = 0; i < W * H; i++) expect(dst.data[i]).toBeCloseTo(42.5, 4);
     });
 
     it("matches when sigma is given explicitly rather than derived", () => {

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -47,6 +47,7 @@ import {
     refScharr,
     refIntegralImage,
     refWarpAffine,
+    refAreaAverage,
 } from "./reference-impl";
 
 /**
@@ -314,6 +315,80 @@ describe("ground truth: warp_affine vs naive bilinear sampling", () => {
 
         // and the reference reproduces it, wrapping included
         expectExact("negative-weight warp", dst.data, refWarpAffine(src.data, W, H, W, H, coefficients, 42), W * H);
+    });
+});
+
+describe("ground truth: resample vs an exact area average", () => {
+    const INTEGER_RATIOS: [number, number, number, number][] = [
+        [24, 18, 12, 9], // /2
+        [24, 18, 8, 6], // /3
+        [32, 24, 8, 6], // /4
+        [30, 20, 15, 10], // /2
+        [36, 24, 6, 4], // /6
+    ];
+
+    const FRACTIONAL_RATIOS: [number, number, number, number][] = [
+        [23, 17, 9, 7],
+        [24, 18, 10, 7],
+        [30, 20, 7, 6],
+        [31, 23, 11, 8],
+        [40, 30, 13, 9],
+    ];
+
+    it("is EXACTLY floor(area average) at integer ratios", () => {
+        // Every weight is a whole 256 and the normaliser divides cleanly, so
+        // the only quantisation left is the final store — which truncates.
+        // Exact equality, no tolerance.
+        for (const [w, h, nw, nh] of INTEGER_RATIOS) {
+            const src = noiseImage(w, h, 5150);
+            const dst = dstImage(nw, nh);
+            ip.resample(src, dst, nw, nh);
+
+            const want = Float64Array.from(refAreaAverage(src.data, w, h, nw, nh), Math.floor);
+            expectExact(`${w}x${h} to ${nw}x${nh}`, dst.data, want, nw * nh);
+        }
+    });
+
+    it("stays within 1.5 grey levels at fractional ratios, and never overshoots", () => {
+        // The 8.8 fixed-point path truncates in four places: the column weight
+        // `alpha`, the row weight `beta`, the normaliser `inv_scale_256`, and
+        // the store into U8. All four bias DOWNWARD, so the error is one-sided.
+        // The final store alone accounts for up to 1; the weight quantisation
+        // supplies the rest. Worst measured across these ratios is 1.379 low.
+        let worst = 0;
+        for (const [w, h, nw, nh] of FRACTIONAL_RATIOS) {
+            const src = noiseImage(w, h, 5150);
+            const dst = dstImage(nw, nh);
+            ip.resample(src, dst, nw, nh);
+
+            const exact = refAreaAverage(src.data, w, h, nw, nh);
+            for (let i = 0; i < nw * nh; i++) {
+                const error = dst.data[i] - exact[i];
+                expect(`${w}x${h} err ${error > 0.1 || error <= -1.5 ? "OUT" : "ok"}`).toBe(`${w}x${h} err ok`);
+                worst = Math.max(worst, Math.abs(error));
+            }
+        }
+        // and the bound is not vacuous — the error really does get close to it
+        expect(worst).toBeGreaterThan(1);
+    });
+
+    it("the float path is accurate, proving the drift is U8 quantisation", () => {
+        // Same operation on F32 matrices takes `_resample` instead of
+        // `_resample_u8` and agrees with the exact area average to float32
+        // precision. So the ~1.4 above is the fast path's fixed point, not a
+        // flaw in the resampling maths itself.
+        const [w, h, nw, nh] = [24, 18, 10, 7];
+        const noise = noiseImage(w, h, 5150);
+
+        const src = new jsfeatNext.matrix_t(w, h, F32C1);
+        for (let i = 0; i < w * h; i++) src.data[i] = noise.data[i];
+        const dst = new jsfeatNext.matrix_t(nw, nh, F32C1);
+        ip.resample(src, dst, nw, nh);
+
+        const exact = refAreaAverage(noise.data, w, h, nw, nh);
+        for (let i = 0; i < nw * nh; i++) {
+            expect(Math.abs(dst.data[i] - exact[i])).toBeLessThan(1e-3);
+        }
     });
 });
 

--- a/tests/reference/reference-impl.ts
+++ b/tests/reference/reference-impl.ts
@@ -321,6 +321,56 @@ export function refWarpAffine(
 }
 
 /**
+ * Exact area-average downscale: each destination pixel is the mean of the
+ * source rectangle it covers, weighting partially-covered source pixels by the
+ * fraction of their area that falls inside.
+ *
+ * This is the DEFINITION of what `imgproc.resample` computes. It is
+ * deliberately NOT a transcription of the implementation, which does the same
+ * thing in 8.8 fixed point with four separate truncations — the per-column
+ * weight `alpha`, the per-row weight `beta`, the normaliser `inv_scale_256`,
+ * and the final store into a `U8` destination. Reproducing those would make the
+ * comparison circular; comparing against the exact answer instead measures how
+ * far the fast path drifts, which is the interesting question.
+ *
+ * Measured against `imgproc.resample` on 8-bit noise:
+ *
+ *  - at INTEGER ratios the library returns exactly `floor(this)`, every pixel;
+ *  - at fractional ratios it lands up to ~1.4 grey levels low;
+ *  - the float path (non-`U8` matrices) agrees to ~1e-5, so the drift is
+ *    quantisation in the `U8` fast path, not bad resampling maths.
+ *
+ * The `- 1e-9` guards keep floating-point on `x1`/`y1` from pushing `ceil` one
+ * past the last row or column, which reads `undefined` and poisons the sum with
+ * `NaN` — a bug this reference had on its first outing.
+ */
+export function refAreaAverage(src: ArrayLike<number>, w: number, h: number, nw: number, nh: number): Float64Array {
+    const scaleX = w / nw;
+    const scaleY = h / nh;
+    const out = new Float64Array(nw * nh);
+
+    for (let dy = 0; dy < nh; dy++) {
+        for (let dx = 0; dx < nw; dx++) {
+            const x0 = dx * scaleX;
+            const x1 = x0 + scaleX;
+            const y0 = dy * scaleY;
+            const y1 = y0 + scaleY;
+
+            let acc = 0;
+            for (let y = Math.floor(y0); y < Math.min(h, Math.ceil(y1 - 1e-9)); y++) {
+                const coverY = Math.min(y1, y + 1) - Math.max(y0, y);
+                for (let x = Math.floor(x0); x < Math.min(w, Math.ceil(x1 - 1e-9)); x++) {
+                    const coverX = Math.min(x1, x + 1) - Math.max(x0, x);
+                    acc += src[y * w + x] * coverX * coverY;
+                }
+            }
+            out[dy * nw + dx] = acc / (scaleX * scaleY);
+        }
+    }
+    return out;
+}
+
+/**
  * Summed-area tables by brute force: every cell is the full sum of the
  * rectangle above-left of it, recomputed from scratch. O(n⁴) and completely
  * uninterested in the incremental recurrence the real implementation uses,

--- a/tests/reference/reference-impl.ts
+++ b/tests/reference/reference-impl.ts
@@ -171,37 +171,94 @@ export function refGaussianBlurU8(
     h: number,
     intKernel: ArrayLike<number>
 ): Int32Array {
-    const k = intKernel.length;
+    // U8: integer kernel, truncating `>> 8` clamped to 255, and the
+    // intermediate held in a U8-equivalent buffer between passes.
+    return separableBlur(
+        src,
+        w,
+        h,
+        intKernel,
+        (sum) => Math.min(sum >> 8, 255),
+        () => new Int32Array(w * h)
+    );
+}
+
+/**
+ * The same separable blur down the `F32`/`S32` branch (`_convol` rather than
+ * `_convol_u8`), which `gaussian_blur` takes for any non-`U8` source.
+ *
+ * The differences from the `U8` path are the ones that matter for a reference:
+ *
+ *  - the kernel is the FLOAT one, summing to 1, so there is no `>> 8`;
+ *  - nothing is shifted or clamped — the raw sum is stored;
+ *  - but the intermediate still round-trips through the destination between
+ *    passes, so with an `F32` destination it is quantised to **float32**
+ *    precision, not held at float64. Same structural quirk as the U8 path,
+ *    different precision.
+ *
+ * @param floatKernel Kernel from `get_gaussian_kernel(size, sigma, k, F32_t)`.
+ */
+export function refGaussianBlurF32(
+    src: ArrayLike<number>,
+    w: number,
+    h: number,
+    floatKernel: ArrayLike<number>
+): Float32Array {
+    return separableBlur(
+        src,
+        w,
+        h,
+        floatKernel,
+        (sum) => sum,
+        () => new Float32Array(w * h)
+    ) as Float32Array;
+}
+
+/**
+ * Shared skeleton for both blur paths: replicate-padded separable convolution,
+ * horizontal then vertical, with the intermediate passing through a buffer of
+ * the destination's own type — which is where each path loses precision.
+ */
+function separableBlur(
+    src: ArrayLike<number>,
+    w: number,
+    h: number,
+    kernel: ArrayLike<number>,
+    finish: (sum: number) => number,
+    makeBuffer: () => Int32Array | Float32Array
+) {
+    const k = kernel.length;
     const half = k >> 1;
 
-    /** One separable pass along a line, with replicated ends. */
-    const convolveLine = (read: (i: number) => number, n: number) => {
-        const padded = new Int32Array(n + 2 * half);
+    /** One pass along a line of length `n`, with replicated ends. */
+    const convolveLine = (read: (i: number) => number, n: number, out: Int32Array | Float32Array) => {
+        const padded = new Float64Array(n + 2 * half);
         for (let i = 0; i < half; i++) padded[i] = read(0);
         for (let i = 0; i < n; i++) padded[half + i] = read(i);
         for (let i = 0; i < half; i++) padded[half + n + i] = read(n - 1);
 
-        const out = new Int32Array(n);
         for (let i = 0; i < n; i++) {
             let sum = 0;
-            for (let t = 0; t < k; t++) sum += padded[i + t] * intKernel[t];
-            out[i] = Math.min(sum >> 8, 255);
+            for (let t = 0; t < k; t++) sum += padded[i + t] * kernel[t];
+            out[i] = finish(sum);
         }
-        return out;
     };
 
-    // pass 1: horizontal, quantised to 8 bits before pass 2 sees it
-    const mid = new Int32Array(w * h);
+    // pass 1: horizontal. `mid` has the destination's type, so storing here
+    // reproduces the precision the implementation loses between passes.
+    const mid = makeBuffer();
+    const rowScratch = makeBuffer().subarray(0, w);
     for (let y = 0; y < h; y++) {
-        const row = convolveLine((x) => src[y * w + x], w);
-        for (let x = 0; x < w; x++) mid[y * w + x] = row[x];
+        convolveLine((x) => src[y * w + x], w, rowScratch);
+        for (let x = 0; x < w; x++) mid[y * w + x] = rowScratch[x];
     }
 
     // pass 2: vertical over that quantised intermediate
-    const out = new Int32Array(w * h);
+    const out = makeBuffer();
+    const colScratch = makeBuffer().subarray(0, h);
     for (let x = 0; x < w; x++) {
-        const col = convolveLine((y) => mid[y * w + x], h);
-        for (let y = 0; y < h; y++) out[y * w + x] = col[y];
+        convolveLine((y) => mid[y * w + x], h, colScratch);
+        for (let y = 0; y < h; y++) out[y * w + x] = colScratch[y];
     }
     return out;
 }


### PR DESCRIPTION
Completes **category C** of the [#87 plan](https://github.com/webarkit/jsfeatNext/issues/87#issuecomment-5153239244). **3 new cases, 252 → 255.** Tests and docs only, no `src/` changes.

## The interesting decision

`resample` was the one item where transcribing the implementation would have been the easy path. `_resample_u8` computes an area average in 8.8 fixed point with **four** separate truncations — the column weight `alpha`, the row weight `beta`, the normaliser `inv_scale_256`, and the store into `U8`. Copying all four would give exactness and be worth nothing: it is the circularity the module's own rules forbid.

So the reference is the **definition** — an exact area average weighting partially-covered source pixels by their coverage — and the comparison measures how far the fast path drifts.

That turned out to give a *better* test than a tolerance would have:

| ratio | result |
| --- | --- |
| **integer** (24×18 → 12×9, 32×24 → 8×6, …) | **exactly `floor(exact)`, every pixel** |
| fractional (23×17 → 9×7, …) | within 1.5 low, never meaningfully high, worst 1.379 |
| float path (`F32`) | agrees to ~1e-5 |

At integer ratios every weight is a whole 256 and the normaliser divides cleanly, so only the final store truncates — an **exact equality, no tolerance**. That is a far stronger assertion than any bound.

At fractional ratios the error is **one-sided**, because all four truncations bias downward. The bound is asserted alongside a check that it is not vacuous — the error really does approach it. And the float path result is what demonstrates the drift is the fast path's fixed point rather than bad resampling maths.

## Two corrections to the notes

Both from measuring on real data rather than a constant image:

- the drift is **~1.4, not ~1**. The old figure came from a uniform-image test (77 → 76), which exercises a single value and understates it.
- *"the float path is exact"* was too strong — it agrees to float32 precision (~1e-5). Accurate claim, same conclusion.

## And a bug in the reference itself

On its first run, floating point on the rectangle's far edge pushed `Math.ceil` one past the last row, reading `undefined` and poisoning the sum with `NaN`. Caught because the probe printed `maxAbs NaN` for one ratio. Guarded with a `1e-9` epsilon, and noted in the docstring — it is an easy trap to fall back into.

## Category C is now complete

Every `imgproc` operation with a practical independent reference is pinned against one:

`grayscale` · `box_blur_gray` · `gaussian_blur` · `sobel_derivatives` · `scharr_derivatives` · `warp_affine` · `compute_integral_image` · `resample`

plus the closed-form set (binomial kernels, BT.601 constants, SVD and homography recovered from constructed inputs, hand-computed determinants).

**Deliberately excluded:** detectors and ORB — no practical independent reference exists, and their equivariance and brightness-invariance tests are already the right instrument.

## On C3 (the optional OpenCV cross-check)

My read: **not worth doing now.** The A+B approach reached bit-exactness on everything it touched, so there is no accuracy gap left for a foreign implementation to close. Its remaining value would be catching a shared misunderstanding of a definition — real, but narrow, and it would cost a Python toolchain, committed fixtures, and tolerance-tuning against OpenCV's different border and rounding conventions.

Happy to revisit if you would rather have the independent check regardless.

Verified: prettier clean, `tsc --noEmit` clean, `license-check` clean, `npm test` 254 passed + 1 expected fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
