### PR TITLE
docs(readme): correct the stale test-suite description

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In the browser (UMD build), the global is the namespace directly:
 - TypeScript definitions, with full TSDoc on every public class/method (`npm run docs` to generate a browsable API reference locally)
 - UMD (browser `<script>`) + ESM builds, built with **Vite** library mode
 - npm package
-- 57+ characterization tests asserting numeric/behavioral parity against the original jsfeat
+- 250+ tests across 22 files: characterization tests asserting numeric/behavioral parity against the original jsfeat, plus property/invariant tests, ground-truth reference tests, and a registry of intentional divergences
 
 ## Modules 📚
 


### PR DESCRIPTION
## Summary

The "List of features" section claimed **57+ characterization tests**. The suite
is now **22 files / 257 tests**, and it stopped being characterization-only some
time ago.

```diff
-- 57+ characterization tests asserting numeric/behavioral parity against the original jsfeat
+- 250+ tests across 22 files: characterization tests asserting numeric/behavioral parity
+  against the original jsfeat, plus property/invariant tests, ground-truth reference tests,
+  and a registry of intentional divergences
```

## Why both halves needed fixing

The count understated the suite roughly fourfold, but the description was the
more misleading half: calling it all "characterization tests asserting parity"
hid the work done under #87 entirely.

Current breakdown:

| Area | Files |
|---|---|
| `tests/parity/` — jsfeat oracle characterization | 9 |
| `tests/properties/` — property/invariant + edge cases | 9 |
| `tests/reference/` — ground-truth references | 2 |
| `tests/api-shape.test.ts`, `tests/divergences.test.ts` | 2 |

I wrote "250+" rather than "257" so the line does not go stale again on the next
test added.

## Notes

- Documentation only; no source, test or build changes.
- Verified with `npm test` (22 files, 256 passed + 1 expected fail — the
  `it.fails` that pins #114) and `prettier --check`.

## Related

- The property/invariant and ground-truth work this now reflects: #87 (closed)
- Remaining ground-truth strand: #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)
