### PR TITLE
fix(imgproc): fill the (-1, 0) source band in warp_affine instead of extrapolating

### DIFF
--- a/docs/implementation-notes.md
+++ b/docs/implementation-notes.md
@@ -197,26 +197,113 @@ Verified with five seeds — zeros, a copy of `prev_xy`, `+1`, `+50`, and
 `-9999` everywhere — all producing **bit-identical** output. Identical code
 path in original jsfeat, so the docstring is what is out of step.
 
-### `warp_affine` extrapolates just outside the top-left edge
+### `warp_affine` extrapolated just outside the top-left edge — FIXED in [#119](https://github.com/webarkit/jsfeatNext/issues/119)
 
-The bounds check is `ixs >= 0 && iys >= 0 && ...` where `ixs = xs | 0`, and
-`| 0` truncates **toward zero**. So a source coordinate of `-0.5` yields
-`ixs = 0`, passes the check, and is treated as inside the image. The
-interpolation weight `a = xs - ixs` is then **negative**, and the "bilinear
-interpolation" becomes an extrapolation.
+Kept because the mechanism is worth understanding and because original jsfeat
+still behaves this way.
 
-The result can leave `[0, 255]`, and because the destination is a `Uint8Array`
-it **wraps modulo 256** rather than clamping. On a 23×17 test warp with a
+The bounds check was `ixs >= 0 && iys >= 0 && ...` where `ixs = xs | 0`, and
+`| 0` truncates **toward zero**. So a source coordinate of `-0.5` yielded
+`ixs = 0`, passed the check, and was treated as inside the image. The
+interpolation weight `a = xs - ixs` was then **negative**, and the "bilinear
+interpolation" became an extrapolation.
+
+The result could leave `[0, 255]`, and because the destination is a `Uint8Array`
+it **wrapped modulo 256** rather than clamping. On a 23×17 test warp with a
 `(-0.5, -0.5)` translation: 13 pixels sampled with a negative weight, 4 of them
-out of range and wrapped.
+out of range and wrapped. Concretely, with `src[0] = 200` and `src[1] = 20`,
+a weight of `-0.5` gives `200 + (-0.5)(20 - 200) = 290`, stored as **34** — a
+bright pixel becomes a dark one. Visible as speckle along the top and left
+edges, where `fill_value` was intended.
 
-Practical effect: speckle along the top and left edges of a warped image, where
-`fill_value` was probably intended. Coordinates below `-1` are unaffected —
-they truncate to `-1` and fail the check correctly.
+The fix tests the **float** coordinates (`xs >= 0 && ys >= 0`) instead of their
+truncation. Two consequences worth noting:
 
-Identical bounds check in original jsfeat, so inherited rather than introduced
-here. Characterized in `tests/reference/imgproc.test.ts`; tracked as
-[#119](https://github.com/webarkit/jsfeatNext/issues/119).
+- It matches what `warp_perspective` in the same file already did (`xs > 0 &&
+  ys > 0`, plus `Math.max(xs - ixs, 0)` on the weights). The two warps were
+  inconsistent; they no longer are.
+- Both weights are now always in `[0, 1)`, so every sample is a convex
+  combination of four bytes. Leaving `[0, 255]` is not merely unlikely, it is
+  **unreachable** — the wrap path is gone rather than guarded.
+
+Identical bounds check in original jsfeat (`tests/vendor/jsfeat-master.js:3524`),
+so inherited rather than introduced here. The divergence is registered in
+`tests/divergences.test.ts`.
+
+#### How OpenCV does it, and why parity with it is unreachable
+
+Useful context before anyone tries to pin `warp_affine` against `cv2.warpAffine`
+in the ground-truth harness ([#132](https://github.com/webarkit/jsfeatNext/issues/132)).
+
+Verified against OpenCV **4.14.0-pre**, `modules/imgproc/src/imgwarp.cpp`, not
+recalled: line references below are from that source.
+
+**1. The bug is structurally impossible in OpenCV's formulation.** Coordinates
+are computed in fixed point — `INTER_BITS = 5`, so 32 sub-pixel steps
+(`imgproc.hpp:292-295`) — and split as (`imgwarp.cpp:2351-2356`):
+
+```cpp
+int X = (X0 + adelta[x1]) >> (AB_BITS - INTER_BITS);
+xy[x1*2]  = saturate_cast<short>(X >> INTER_BITS);              // integer part
+alpha[x1] = (short)((Y & (INTER_TAB_SIZE-1))*INTER_TAB_SIZE +
+                    (X & (INTER_TAB_SIZE-1)));                  // fractional part
+```
+
+Two operations do the work, and both matter:
+
+- `X >> INTER_BITS` is an **arithmetic** right shift, so it rounds toward
+  −∞ — a true floor, unlike `| 0` which truncates toward zero.
+- `X & (INTER_TAB_SIZE-1)` masks the low 5 bits. On a negative two's-complement
+  integer that yields the **non-negative remainder**.
+
+Together they are the mathematically correct decomposition `x = floor(x) +
+frac(x)` with `frac(x) ∈ [0, 1)`. jsfeat's pair — truncate toward zero, then
+subtract — is not, and that is the whole of #119. OpenCV did not guard against
+the negative case; it picked arithmetic where the case cannot arise.
+
+**2. Partial neighbourhoods are interpolated, not discarded.** In
+`RemapBilinear` (`imgwarp.cpp:758-797`) a destination pixel is filled wholesale
+only when the **entire** 2×2 lies outside:
+
+```cpp
+if( borderType == BORDER_CONSTANT &&
+    (sx >= ssize.width || sx+1 < 0 || sy >= ssize.height || sy+1 < 0) )
+    D[0] = cval[0];
+```
+
+Note `sx+1 < 0`, not `sx < 0`: at `sx = -1` the neighbour at `sx+1 = 0` is
+inside, so the pixel survives. Otherwise each of the four taps is resolved
+individually through `borderInterpolate`, taps that fall outside take the border
+value, and all four are still blended:
+
+```cpp
+D[0] = castOp(WT(v0*w[0] + v1*w[1] + v2*w[2] + v3*w[3]));
+```
+
+jsfeat instead requires the whole neighbourhood to be inside
+(`ixs < src_width - 1`), so it discards those pixels entirely — see the note in
+section 4 on what the identity transform loses.
+
+**3. Saturation, not wrap.** The cast on the `U8` path saturates, so an
+out-of-range accumulation clamps to 255. Assigning to a `Uint8Array` in
+JavaScript keeps the low 8 bits instead, which is why an extrapolated 290 became
+34 rather than 255.
+
+**4. Quantised weights.** `w = wtab + FXY[dx]*4` reads four coefficients from a
+precomputed table indexed by the quantised fractional part
+(`INTER_TAB_SIZE2 = 1024` entries). jsfeat uses full float weights.
+
+##### Consequence
+
+Points 2, 3 and 4 mean **bit-exactness with `cv2.warpAffine` is unreachable by
+design**, even where both implementations are correct. `refWarpAffine` in
+`tests/reference/reference-impl.ts` therefore stays the specification for this
+function; OpenCV is not a usable oracle for it.
+
+One nuance worth keeping straight: on pure interpolation accuracy jsfeat's
+full-float weights are *better* than OpenCV's 1/32 quantisation. The fixed point
+is a SIMD optimisation, not an accuracy choice, and it does not transfer to
+JavaScript — porting it here would cost precision and buy nothing.
 
 ### `invert_3x3` on a singular matrix — [#120](https://github.com/webarkit/jsfeatNext/issues/120)
 
@@ -241,9 +328,29 @@ silently. This is an intentional divergence, registered in
 
 ### `warp_affine` / `warp_perspective` under the identity transform
 
-Does **not** reproduce the input exactly: the interior is bit-exact but the
-outermost 1-pixel ring is filled with `fill_value`, because bilinear sampling
-treats it as out of bounds.
+Does **not** reproduce the input exactly: the interior is bit-exact, but the
+**right column and the bottom row** are filled with `fill_value`, because
+bilinear sampling needs a full 2×2 neighbourhood and the check is
+`ixs < src_width - 1 && iys < src_height - 1`.
+
+Earlier revisions of this note said "the outermost 1-pixel ring". That is
+wrong, and the correction is kept rather than silently edited: left and top are
+reproduced exactly, since a source coordinate of `0` is inside. Measured on a
+6×5 identity warp, `F` marking a filled pixel:
+
+```
+. . . . . F
+. . . . . F
+. . . . . F
+. . . . . F
+F F F F F F
+```
+
+OpenCV does not lose these: it applies `borderMode` per sample, so an edge pixel
+whose 2×2 neighbourhood is only partly inside still gets interpolated. Whether
+to follow suit is open — unlike #119 this is deterministic, defensible
+behaviour rather than garbage, so changing it would be the expensive kind of
+parity break.
 
 ### `equalize_histogram` of a uniform image returns 255
 

--- a/src/imgproc/imgproc.ts
+++ b/src/imgproc/imgproc.ts
@@ -1155,6 +1155,14 @@ export class imgproc extends jsfeatNext {
      * Only the first 6 coefficients of `transform` are used, mapping
      * destination → source coordinates (inverse warping).
      *
+     * A sample is inside `src` only when its source coordinate is ≥ 0 on both
+     * axes and leaves a full bilinear neighbourhood available; everything else
+     * receives `fill_value`. The bounds test therefore looks at the float
+     * coordinates rather than their truncation — `xs | 0` rounds toward zero,
+     * so a coordinate of `-0.5` would otherwise test as `0`, pass as inside,
+     * and be "interpolated" with a negative weight (issue #119). This matches
+     * what {@link warp_perspective} already did.
+     *
      * @param src        Source grayscale image.
      * @param dst        Destination image (same size as `src`).
      * @param transform  2×3 (or 3×3, first 6 entries) dst→src affine transform.
@@ -1196,7 +1204,7 @@ export class imgproc extends jsfeatNext {
                 ixs = xs | 0;
                 iys = ys | 0;
 
-                if (ixs >= 0 && iys >= 0 && ixs < src_width - 1 && iys < src_height - 1) {
+                if (xs >= 0 && ys >= 0 && ixs < src_width - 1 && iys < src_height - 1) {
                     a = xs - ixs;
                     b = ys - iys;
                     off = src_width * iys + ixs;

--- a/tests/divergences.test.ts
+++ b/tests/divergences.test.ts
@@ -55,6 +55,8 @@ import jsfeat from "./vendor/oracle.cjs";
 
 const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
 const OF32C1 = jsfeat.F32_t | jsfeat.C1_t;
+const U8C1 = jsfeatNext.U8_t | jsfeatNext.C1_t;
+const OU8C1 = jsfeat.U8_t | jsfeat.C1_t;
 
 describe("intentional divergences from jsfeat", () => {
     describe("linalg.svd_invert rejects non-square input (#102)", () => {
@@ -116,6 +118,111 @@ describe("intentional divergences from jsfeat", () => {
             jsfeatNext.matmath.multiply(P, A, Ai);
             for (const [i, want] of [1, 0, 0, 1].entries()) {
                 expect(P.data[i]).toBeCloseTo(want, 5);
+            }
+        });
+    });
+    describe("imgproc.warp_affine fills the (-1, 0) source band instead of extrapolating (#119)", () => {
+        /**
+         * jsfeat's bounds check is `ixs >= 0` on `xs | 0`, which truncates
+         * TOWARD ZERO. A source coordinate of -0.5 therefore yields ixs = 0,
+         * tests as inside the image, and is "interpolated" with a NEGATIVE
+         * weight -- an extrapolation past the edge pixel. The destination is a
+         * Uint8Array, so a result outside [0,255] wraps modulo 256 instead of
+         * clamping: an extrapolated 258 is stored as 2.
+         *
+         * jsfeatNext tests the float coordinates instead, so that one-pixel
+         * band receives `fill_value` as intended. This is the same class of
+         * divergence as #102 -- we return the documented answer where jsfeat
+         * returned garbage -- and it also makes `warp_affine` consistent with
+         * `warp_perspective`, which already guarded on the floats and clamped
+         * its weights with `Math.max(xs - ixs, 0)`.
+         *
+         * Note this changes ORB descriptors for keypoints near an image edge,
+         * since `orb/rectify_patch.ts` samples through `warp_affine` -- the
+         * population tracked by #110.
+         */
+        const W = 23,
+            H = 17;
+        const COEFFS = [1, 0, -0.5, 0, 1, -0.5];
+
+        /** Same 8-bit noise on both sides, plus the shared F32 transform. */
+        function setup() {
+            const next = new jsfeatNext.matrix_t(W, H, U8C1);
+            const orig = new jsfeat.matrix_t(W, H, OU8C1);
+            let seed = 2468;
+            for (let i = 0; i < W * H; i++) {
+                seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+                next.data[i] = orig.data[i] = (seed >>> 16) & 0xff;
+            }
+            const tN = new jsfeatNext.matrix_t(3, 3, F32C1);
+            const tO = new jsfeat.matrix_t(3, 3, OF32C1);
+            tN.data.set([...COEFFS, 0, 0, 1]);
+            tO.data.set([...COEFFS, 0, 0, 1]);
+            return { next, orig, tN, tO };
+        }
+
+        it("fills the band where jsfeat extrapolates with a negative weight", () => {
+            const { next, orig, tN, tO } = setup();
+            const FILL = 42;
+            const dstN = new jsfeatNext.matrix_t(W, H, U8C1);
+            const dstO = new jsfeat.matrix_t(W, H, OU8C1);
+            jsfeatNext.imgproc.warp_affine(next, dstN, tN, FILL);
+            jsfeat.imgproc.warp_affine(orig, dstO, tO, FILL);
+
+            let banded = 0;
+            let differing = 0;
+            for (let y = 0; y < H; y++) {
+                for (let x = 0; x < W; x++) {
+                    const i = y * W + x;
+                    const xs = tN.data[0] * x + tN.data[1] * y + tN.data[2];
+                    const ys = tN.data[3] * x + tN.data[4] * y + tN.data[5];
+                    if (!((xs > -1 && xs < 0) || (ys > -1 && ys < 0))) continue;
+                    banded++;
+                    expect(dstN.data[i]).toBe(FILL);
+                    if (dstO.data[i] !== FILL) differing++;
+                }
+            }
+            // The band is non-empty, and jsfeat really does produce something
+            // else there -- otherwise this would be a divergence on paper only.
+            expect(banded).toBeGreaterThan(0);
+            expect(differing).toBeGreaterThan(0);
+        });
+
+        it("no sampled value can leave [0,255] any more, so nothing wraps", () => {
+            // With the float bounds test both weights are in [0,1), so every
+            // sampled pixel is a convex combination of four bytes. Sampling with
+            // a fill_value outside the source range makes any wrap obvious:
+            // a wrapped extrapolation would land on some unrelated value.
+            const { next, tN } = setup();
+            const dstN = new jsfeatNext.matrix_t(W, H, U8C1);
+            jsfeatNext.imgproc.warp_affine(next, dstN, tN, 200);
+
+            let srcMin = 255,
+                srcMax = 0;
+            for (let i = 0; i < W * H; i++) {
+                srcMin = Math.min(srcMin, next.data[i]);
+                srcMax = Math.max(srcMax, next.data[i]);
+            }
+            for (let i = 0; i < W * H; i++) {
+                const v = dstN.data[i];
+                const sampled = v >= srcMin && v <= srcMax;
+                expect(sampled || v === 200).toBe(true);
+            }
+        });
+
+        it("still matches jsfeat exactly away from the band (parity preserved)", () => {
+            // The divergence is scoped: a transform that never produces a
+            // negative source coordinate stays bit-compatible.
+            const { next, orig, tN, tO } = setup();
+            tN.data.set([1, 0, 2.5, 0, 1, 1.5, 0, 0, 1]);
+            tO.data.set([1, 0, 2.5, 0, 1, 1.5, 0, 0, 1]);
+            const dstN = new jsfeatNext.matrix_t(W, H, U8C1);
+            const dstO = new jsfeat.matrix_t(W, H, OU8C1);
+            jsfeatNext.imgproc.warp_affine(next, dstN, tN, 0);
+            jsfeat.imgproc.warp_affine(orig, dstO, tO, 0);
+
+            for (let i = 0; i < W * H; i++) {
+                expect(dstN.data[i]).toBe(dstO.data[i]);
             }
         });
     });

--- a/tests/parity/imgproc.test.ts
+++ b/tests/parity/imgproc.test.ts
@@ -244,7 +244,29 @@ describe("parity: imgproc vs original jsfeat.imgproc", () => {
         const dstO = new jsfeat.matrix_t(W, H, OU8C1);
         ip.warp_affine(next, dstN, tN, 0);
         jsfeat.imgproc.warp_affine(orig, dstO, tO, 0);
-        expectSame(dstN.data, dstO.data, W * H);
+
+        // Parity holds everywhere EXCEPT the one-pixel band where a source
+        // coordinate falls in (-1, 0): jsfeat treats it as inside and
+        // extrapolates with a negative weight, jsfeatNext fills it (#119).
+        // Asserting the difference is exactly that band -- rather than skipping
+        // the comparison -- keeps this test meaningful and pins the blast
+        // radius, so an unrelated regression in warp_affine still fails here.
+        let diverged = 0;
+        for (let y = 0; y < H; y++) {
+            for (let x = 0; x < W; x++) {
+                const i = y * W + x;
+                const xs = tN.data[0] * x + tN.data[1] * y + tN.data[2];
+                const ys = tN.data[3] * x + tN.data[4] * y + tN.data[5];
+                const inBand = (xs > -1 && xs < 0) || (ys > -1 && ys < 0);
+                if (inBand) {
+                    diverged++;
+                    expect(dstN.data[i]).toBe(0); // fill_value
+                } else {
+                    expect(dstN.data[i]).toBe(dstO.data[i]);
+                }
+            }
+        }
+        expect(diverged).toBeGreaterThan(0);
     });
 
     it("hough_transform — original jsfeat is BROKEN here, jsfeatNext fixes it (documented divergence)", () => {

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -322,34 +322,40 @@ describe("ground truth: warp_affine vs naive bilinear sampling", () => {
         }
     });
 
-    it("treats source coordinates in (-1, 0) as inside, extrapolating with a negative weight", () => {
-        // `xs | 0` truncates toward zero, so xs = -0.5 gives ixs = 0 and passes
-        // the `ixs >= 0` bounds check. The interpolation weight `a = xs - ixs`
-        // is then negative and the result is an extrapolation, which can leave
-        // [0,255] and wrap in the U8 destination. Characterizing the current
-        // behaviour, not endorsing it.
+    it("fills source coordinates in (-1, 0) instead of extrapolating (#119)", () => {
+        // `xs | 0` truncates toward zero, so before #119 a source coordinate of
+        // -0.5 gave ixs = 0, passed the `ixs >= 0` bounds check, and was
+        // "interpolated" with a negative weight -- an extrapolation that could
+        // leave [0,255] and wrap in the U8 destination. The bounds test now
+        // reads the float coordinates, so that band receives `fill_value`.
+        //
+        // Original jsfeat still extrapolates here; see tests/divergences.test.ts.
         const src = noiseImage(W, H, 2468);
+        const FILL = 42;
         const { matrix, coefficients } = transform([1, 0, -0.5, 0, 1, -0.5]);
         const dst = new jsfeatNext.matrix_t(W, H, U8C1);
-        ip.warp_affine(src, dst, matrix, 42);
+        ip.warp_affine(src, dst, matrix, FILL);
 
-        // count how many sampled pixels get a negative weight
-        let negativeWeight = 0;
+        // Every pixel whose source coordinate lands in the (-1, 0) band on
+        // either axis must now be filled, and there must be some of them --
+        // otherwise this test would pass vacuously.
+        let banded = 0;
         for (let y = 0; y < H; y++) {
             for (let x = 0; x < W; x++) {
                 const xs = coefficients[0] * x + coefficients[1] * y + coefficients[2];
                 const ys = coefficients[3] * x + coefficients[4] * y + coefficients[5];
-                const ixs = xs | 0;
-                const iys = ys | 0;
-                if (ixs >= 0 && iys >= 0 && ixs < W - 1 && iys < H - 1 && (xs - ixs < 0 || ys - iys < 0)) {
-                    negativeWeight++;
-                }
+                const inBand = (xs > -1 && xs < 0) || (ys > -1 && ys < 0);
+                if (!inBand) continue;
+                banded++;
+                expect(dst.data[y * W + x]).toBe(FILL);
             }
         }
-        expect(negativeWeight).toBeGreaterThan(0);
+        expect(banded).toBeGreaterThan(0);
 
-        // and the reference reproduces it, wrapping included
-        expectExact("negative-weight warp", dst.data, refWarpAffine(src.data, W, H, W, H, coefficients, 42), W * H);
+        // No sample can leave [0,255] any more: with the float bounds test both
+        // weights are in [0,1), so every sampled value is a convex combination
+        // of four bytes. Nothing can wrap.
+        expectExact("filled band warp", dst.data, refWarpAffine(src.data, W, H, W, H, coefficients, FILL), W * H);
     });
 });
 

--- a/tests/reference/reference-impl.ts
+++ b/tests/reference/reference-impl.ts
@@ -325,22 +325,30 @@ export function refScharr(src: ArrayLike<number>, w: number, h: number) {
 }
 
 /**
- * Affine warp with bilinear sampling, reproducing jsfeat's behaviour exactly.
+ * Affine warp with bilinear sampling — the specification `imgproc.warp_affine`
+ * is checked against.
  *
- * Three details are needed for exactness, and each one cost a measurement:
+ * Two details are needed for exactness, and each one cost a measurement:
  *
  *  1. Read the transform coefficients back out of the `matrix_t`. It is `F32`,
  *     so the implementation sees float32-rounded values, not whatever float64
  *     literals the caller wrote.
  *  2. Store the result through a `Uint8Array`. The library writes into a U8
- *     destination, so an out-of-range value WRAPS modulo 256 rather than
- *     clamping — and out-of-range values do occur, see below.
- *  3. The bounds check uses `xs | 0`, which truncates TOWARD ZERO. A source
- *     coordinate of `-0.5` therefore gives `ixs = 0` and passes `ixs >= 0`, so
- *     the pixel is treated as inside the image and the "interpolation" runs
- *     with a NEGATIVE weight — extrapolating instead of interpolating. On a
- *     23x17 test warp this affected 13 pixels, 4 of which left [0,255] and
- *     wrapped. Visible as speckle along the top and left edges of a warp.
+ *     destination, so an out-of-range value would WRAP modulo 256 rather than
+ *     clamp. Since #119 that can no longer happen — see below — but the store
+ *     is kept faithful to the implementation rather than relying on that.
+ *
+ * The bounds test reads the FLOAT coordinates, not their truncation. `xs | 0`
+ * rounds toward zero, so before #119 a source coordinate of `-0.5` gave
+ * `ixs = 0`, passed `ixs >= 0`, and was "interpolated" with a negative weight
+ * — extrapolating instead of interpolating. On a 23x17 test warp that affected
+ * 13 pixels, 4 of which left [0,255] and wrapped, visible as speckle along the
+ * top and left edges. Original jsfeat still behaves that way; the divergence is
+ * registered in `tests/divergences.test.ts`.
+ *
+ * With the float test, both interpolation weights are always in [0, 1), so the
+ * sampled value is a convex combination of four bytes and can no longer leave
+ * [0, 255] at all.
  *
  * @param fill Value written where the source coordinate is out of bounds.
  */
@@ -362,7 +370,7 @@ export function refWarpAffine(
             const ixs = xs | 0;
             const iys = ys | 0;
 
-            if (ixs >= 0 && iys >= 0 && ixs < srcW - 1 && iys < srcH - 1) {
+            if (xs >= 0 && ys >= 0 && ixs < srcW - 1 && iys < srcH - 1) {
                 const a = xs - ixs;
                 const b = ys - iys;
                 const off = srcW * iys + ixs;


### PR DESCRIPTION
## Summary

`warp_affine` treated source coordinates in `(-1, 0)` as inside the image and sampled them with a **negative** interpolation weight — extrapolating rather than interpolating. Because the destination is a `Uint8Array`, a result outside `[0, 255]` wrapped modulo 256 instead of clamping, so an extrapolated 258 was stored as 2. Visible as speckle along the top and left edges of a warp.

Closes #119. Part of the #121 checklist.

## The fix, and why not `Math.floor`

#119 proposed `Math.floor` for the bounds test. While implementing it I found something that suggests a better answer: **`warp_perspective`, in the same file, never had this bug.**

```ts
// warp_perspective — already defensive
if (xs > 0 && ys > 0 && ixs < src_width - 1 && iys < src_height - 1) {
    a = Math.max(xs - ixs, 0.0);
    b = Math.max(ys - iys, 0.0);
```

It guards on the **float** coordinates rather than their truncation, and clamps the weights as a second line of defence. `warp_affine` guarded on `ixs`/`iys` instead.

So the change is a one-line alignment with its own sibling:

```diff
-if (ixs >= 0 && iys >= 0 && ixs < src_width - 1 && iys < src_height - 1) {
+if (xs >= 0 && ys >= 0 && ixs < src_width - 1 && iys < src_height - 1) {
```

Same outcome as `Math.floor`, no extra call in the inner loop, and it makes the two warps consistent instead of introducing a third convention.

**A consequence worth stating:** both weights are now always in `[0, 1)`, so every sampled value is a convex combination of four bytes. The out-of-range wrap is not merely unlikely any more — it is unreachable.

## Parity

Original jsfeat has the identical defect (`tests/vendor/jsfeat-master.js`), so this is a deliberate divergence, registered in `tests/divergences.test.ts` per #102. It is the easy class: *we return the documented answer where jsfeat returned garbage*.

The parity test was **not** relaxed. It now asserts that the difference is **exactly** the affected band and that everything else still matches the oracle bit-for-bit, so an unrelated regression in `warp_affine` still fails there:

```ts
if (inBand) { diverged++; expect(dstN.data[i]).toBe(0); }
else        { expect(dstN.data[i]).toBe(dstO.data[i]); }
expect(diverged).toBeGreaterThan(0);
```

## Tests

- `tests/reference/reference-impl.ts` — `refWarpAffine` now models the fixed algorithm; its doc comment records what jsfeat still does and why nothing can wrap any more.
- `tests/reference/imgproc.test.ts` — the characterization that pinned the old behaviour is replaced by one asserting the band is filled. It counts the banded pixels and fails if there are none, so it cannot pass vacuously.
- `tests/divergences.test.ts` — three cases: the band is filled where jsfeat produces something else, no sampled value can leave the source range, and a transform away from the band stays bit-compatible.

`npm test`: 22 files, 259 passed + 1 expected fail (the `it.fails` pinning #114). `tsc --noEmit`, `prettier --check` and `license-check` all clean.

## ⚠️ Follow-up this blocks

`orb/rectify_patch.ts` samples through `warp_affine`, so **ORB descriptors for keypoints near an image edge change with this PR** — the population #110 is about. The margins quoted there ("border 8 → 2 bits of 8960, border ≥ 16 → 0") were measured before this change and need re-measuring before any ORB border guidance is written. #121 called this sequencing out; this is the commit that triggers it.

## Not included

- `dist/` is not rebuilt — see the question in the review comment below.
- The `radius 3` rounding defect and the box-blur clamp are #114, on their own branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
