### PR TITLE
fix(imgproc): make box_blur_gray correct below the kernel size and at radius 3

### DIFF
--- a/src/imgproc/imgproc.ts
+++ b/src/imgproc/imgproc.ts
@@ -153,176 +153,67 @@ export class imgproc extends jsfeatNext {
         if (typeof options === "undefined") {
             options = 0;
         }
-        const w = src.cols,
-            h = src.rows,
-            h2 = h << 1,
-            w2 = w << 1;
-        let i = 0,
-            x = 0,
-            y = 0,
-            end = 0;
+        const w = src.cols | 0,
+            h = src.rows | 0;
+        const radiusPlusOne = (radius + 1) | 0;
         const windowSize = ((radius << 1) + 1) | 0;
-        const radiusPlusOne = (radius + 1) | 0,
-            radiusPlus2 = (radiusPlusOne + 1) | 0;
-        const scale = options & JSFEAT_CONSTANTS.BOX_BLUR_NOSCALE ? 1 : 1.0 / (windowSize * windowSize);
+        const area = (windowSize * windowSize) | 0;
+        const noscale = (options & JSFEAT_CONSTANTS.BOX_BLUR_NOSCALE) !== 0;
 
         const tmp_buff = this.cache.get_buffer((w * h) << 2);
-
-        let sum = 0,
-            dstIndex = 0,
-            srcIndex = 0,
-            nextPixelIndex = 0,
-            previousPixelIndex = 0;
-        const data_i32 = tmp_buff.i32; // to prevent overflow
-        let data_u8 = src.data;
-        let hold = 0;
+        const data_i32 = tmp_buff.i32; // first pass, kept at full int precision
 
         dst.resize(w, h, src.channel);
 
-        // first pass
-        // no need to scale
-        //data_u8 = src.data;
-        //data_i32 = tmp;
+        let x = 0,
+            y = 0,
+            i = 0,
+            sum = 0,
+            base = 0,
+            lo = 0,
+            hi = 0;
+
+        // First pass: horizontal box sum of each row, written TRANSPOSED into
+        // `data_i32` (element [x, y] at `x * h + y`). The window is clamped to
+        // the row, so the border replicates and the running sum stays correct
+        // even when `w < windowSize` — the case that produced garbage before
+        // (issue #114).
+        const src_u8 = src.data;
         for (y = 0; y < h; ++y) {
-            dstIndex = y;
-            sum = radiusPlusOne * data_u8[srcIndex];
-
-            for (i = (srcIndex + 1) | 0, end = (srcIndex + radius) | 0; i <= end; ++i) {
-                sum += data_u8[i];
+            base = y * w;
+            // Prime the window centred on x = 0: positions -radius..0 all clamp
+            // to column 0, so it contributes `radius + 1` copies of that pixel.
+            sum = radiusPlusOne * src_u8[base];
+            for (i = 1; i <= radius; ++i) {
+                sum += src_u8[base + (i < w ? i : w - 1)];
             }
-
-            nextPixelIndex = (srcIndex + radiusPlusOne) | 0;
-            previousPixelIndex = srcIndex;
-            hold = data_u8[previousPixelIndex];
-            for (x = 0; x < radius; ++x, dstIndex += h) {
-                data_i32[dstIndex] = sum;
-                sum += data_u8[nextPixelIndex] - hold;
-                nextPixelIndex++;
+            for (x = 0; x < w; ++x) {
+                data_i32[x * h + y] = sum;
+                hi = x + radiusPlusOne; // pixel entering the window: x + radius + 1
+                lo = x - radius; // pixel leaving the window: x - radius
+                sum += src_u8[base + (hi < w ? hi : w - 1)] - src_u8[base + (lo > 0 ? lo : 0)];
             }
-            for (; x < w - radiusPlus2; x += 2, dstIndex += h2) {
-                data_i32[dstIndex] = sum;
-                sum += data_u8[nextPixelIndex] - data_u8[previousPixelIndex];
-
-                data_i32[dstIndex + h] = sum;
-                sum += data_u8[nextPixelIndex + 1] - data_u8[previousPixelIndex + 1];
-
-                nextPixelIndex += 2;
-                previousPixelIndex += 2;
-            }
-            for (; x < w - radiusPlusOne; ++x, dstIndex += h) {
-                data_i32[dstIndex] = sum;
-                sum += data_u8[nextPixelIndex] - data_u8[previousPixelIndex];
-
-                nextPixelIndex++;
-                previousPixelIndex++;
-            }
-
-            hold = data_u8[nextPixelIndex - 1];
-            for (; x < w; ++x, dstIndex += h) {
-                data_i32[dstIndex] = sum;
-
-                sum += hold - data_u8[previousPixelIndex];
-                previousPixelIndex++;
-            }
-
-            srcIndex += w;
         }
-        //
-        // second pass
-        srcIndex = 0;
-        //data_i32 = tmp; // this is a transpose
-        data_u8 = dst.data;
 
-        // dont scale result
-        if (scale == 1) {
-            for (y = 0; y < w; ++y) {
-                dstIndex = y;
-                sum = radiusPlusOne * data_i32[srcIndex];
-
-                for (i = (srcIndex + 1) | 0, end = (srcIndex + radius) | 0; i <= end; ++i) {
-                    sum += data_i32[i];
-                }
-
-                nextPixelIndex = srcIndex + radiusPlusOne;
-                previousPixelIndex = srcIndex;
-                hold = data_i32[previousPixelIndex];
-
-                for (x = 0; x < radius; ++x, dstIndex += w) {
-                    data_u8[dstIndex] = sum;
-                    sum += data_i32[nextPixelIndex] - hold;
-                    nextPixelIndex++;
-                }
-                for (; x < h - radiusPlus2; x += 2, dstIndex += w2) {
-                    data_u8[dstIndex] = sum;
-                    sum += data_i32[nextPixelIndex] - data_i32[previousPixelIndex];
-
-                    data_u8[dstIndex + w] = sum;
-                    sum += data_i32[nextPixelIndex + 1] - data_i32[previousPixelIndex + 1];
-
-                    nextPixelIndex += 2;
-                    previousPixelIndex += 2;
-                }
-                for (; x < h - radiusPlusOne; ++x, dstIndex += w) {
-                    data_u8[dstIndex] = sum;
-
-                    sum += data_i32[nextPixelIndex] - data_i32[previousPixelIndex];
-                    nextPixelIndex++;
-                    previousPixelIndex++;
-                }
-                hold = data_i32[nextPixelIndex - 1];
-                for (; x < h; ++x, dstIndex += w) {
-                    data_u8[dstIndex] = sum;
-
-                    sum += hold - data_i32[previousPixelIndex];
-                    previousPixelIndex++;
-                }
-
-                srcIndex += h;
+        // Second pass: box sum along the transposed rows (the original columns),
+        // written back into `dst` in normal layout. Same clamped running sum.
+        // The scaled path divides EXACTLY by the window area instead of
+        // multiplying by the float reciprocal `1 / area`; that reciprocal
+        // truncated 128 to 127 at radius 3 (issue #114), so a uniform image did
+        // not round-trip. Exact integer division fixes it and, since the input
+        // is non-negative, `Math.floor` is the same truncation jsfeat intended.
+        const dst_out = dst.data;
+        for (y = 0; y < w; ++y) {
+            base = y * h;
+            sum = radiusPlusOne * data_i32[base];
+            for (i = 1; i <= radius; ++i) {
+                sum += data_i32[base + (i < h ? i : h - 1)];
             }
-        } else {
-            for (y = 0; y < w; ++y) {
-                dstIndex = y;
-                sum = radiusPlusOne * data_i32[srcIndex];
-
-                for (i = (srcIndex + 1) | 0, end = (srcIndex + radius) | 0; i <= end; ++i) {
-                    sum += data_i32[i];
-                }
-
-                nextPixelIndex = srcIndex + radiusPlusOne;
-                previousPixelIndex = srcIndex;
-                hold = data_i32[previousPixelIndex];
-
-                for (x = 0; x < radius; ++x, dstIndex += w) {
-                    data_u8[dstIndex] = sum * scale;
-                    sum += data_i32[nextPixelIndex] - hold;
-                    nextPixelIndex++;
-                }
-                for (; x < h - radiusPlus2; x += 2, dstIndex += w2) {
-                    data_u8[dstIndex] = sum * scale;
-                    sum += data_i32[nextPixelIndex] - data_i32[previousPixelIndex];
-
-                    data_u8[dstIndex + w] = sum * scale;
-                    sum += data_i32[nextPixelIndex + 1] - data_i32[previousPixelIndex + 1];
-
-                    nextPixelIndex += 2;
-                    previousPixelIndex += 2;
-                }
-                for (; x < h - radiusPlusOne; ++x, dstIndex += w) {
-                    data_u8[dstIndex] = sum * scale;
-
-                    sum += data_i32[nextPixelIndex] - data_i32[previousPixelIndex];
-                    nextPixelIndex++;
-                    previousPixelIndex++;
-                }
-                hold = data_i32[nextPixelIndex - 1];
-                for (; x < h; ++x, dstIndex += w) {
-                    data_u8[dstIndex] = sum * scale;
-
-                    sum += hold - data_i32[previousPixelIndex];
-                    previousPixelIndex++;
-                }
-
-                srcIndex += h;
+            for (x = 0; x < h; ++x) {
+                dst_out[x * w + y] = noscale ? sum : Math.floor(sum / area);
+                hi = x + radiusPlusOne;
+                lo = x - radius;
+                sum += data_i32[base + (hi < h ? hi : h - 1)] - data_i32[base + (lo > 0 ? lo : 0)];
             }
         }
 

--- a/src/imgproc/imgproc.ts
+++ b/src/imgproc/imgproc.ts
@@ -153,6 +153,11 @@ export class imgproc extends jsfeatNext {
         if (typeof options === "undefined") {
             options = 0;
         }
+        // Coerce the radius to an integer up front. The index arithmetic below
+        // (`x - radius`, the warm-up bound) uses it directly, so a fractional
+        // radius would otherwise produce fractional typed-array indices, whose
+        // reads are `undefined`, poisoning the running sum to NaN.
+        radius = radius | 0;
         const w = src.cols | 0,
             h = src.rows | 0;
         const radiusPlusOne = (radius + 1) | 0;

--- a/src/imgproc/imgproc.ts
+++ b/src/imgproc/imgproc.ts
@@ -157,7 +157,10 @@ export class imgproc extends jsfeatNext {
             h = src.rows | 0;
         const radiusPlusOne = (radius + 1) | 0;
         const windowSize = ((radius << 1) + 1) | 0;
-        const area = (windowSize * windowSize) | 0;
+        // NOT `| 0`: the area is a square, so it overflows a signed 32-bit int
+        // once windowSize passes ~46340 (radius ~23170). Kept as a float — it is
+        // only ever a divisor in `Math.floor(sum / area)`, so there is no cost.
+        const area = windowSize * windowSize;
         const noscale = (options & JSFEAT_CONSTANTS.BOX_BLUR_NOSCALE) !== 0;
 
         const tmp_buff = this.cache.get_buffer((w * h) << 2);

--- a/tests/divergences.test.ts
+++ b/tests/divergences.test.ts
@@ -226,4 +226,89 @@ describe("intentional divergences from jsfeat", () => {
             }
         });
     });
+    describe("imgproc.box_blur_gray clamps the window and divides exactly (#114)", () => {
+        /**
+         * jsfeat's box blur diverges from a correct average in two ways, both
+         * inherited and both registered here:
+         *
+         *  1. Below the kernel size (`cols < 2r+1` or `rows < 2r+1`) its
+         *     sliding-window sums are never primed, so it reads outside the
+         *     image and returns garbage — famously NOT preserving a uniform
+         *     image. jsfeatNext clamps the window to the image (replicated
+         *     border), so a uniform image round-trips at every size.
+         *  2. It scales by the float reciprocal `1 / area` and truncates, which
+         *     comes out 1 low wherever the true mean is an integer the reciprocal
+         *     undershoots. The clearest case is a uniform 128 at radius 3:
+         *     `128 * 49 * (1/49) = 127.999999999999986` -> 127. jsfeatNext
+         *     divides exactly, so it stays 128.
+         *
+         * Parity is preserved where jsfeat is correct: at radius 2 on non-edge
+         * data the two agree bit-for-bit, which is what tests/parity pins.
+         */
+        it("preserves a uniform image below the kernel size, where jsfeat returns garbage", () => {
+            const W = 4,
+                H = 4,
+                V = 128,
+                RADIUS = 2; // window 5 > image 4, so jsfeat's sums are never primed
+            const next = new jsfeatNext.matrix_t(W, H, U8C1);
+            const orig = new jsfeat.matrix_t(W, H, OU8C1);
+            next.data.fill(V);
+            orig.data.fill(V);
+            const dstN = new jsfeatNext.matrix_t(W, H, U8C1);
+            const dstO = new jsfeat.matrix_t(W, H, OU8C1);
+            jsfeatNext.imgproc.box_blur_gray(next, dstN, RADIUS, 0);
+            jsfeat.imgproc.box_blur_gray(orig, dstO, RADIUS, 0);
+
+            // jsfeatNext: uniform in, uniform out.
+            for (let i = 0; i < W * H; i++) expect(dstN.data[i]).toBe(V);
+            // jsfeat: at least one pixel is wrong, which is the whole point.
+            let jsfeatWrong = 0;
+            for (let i = 0; i < W * H; i++) if (dstO.data[i] !== V) jsfeatWrong++;
+            expect(jsfeatWrong).toBeGreaterThan(0);
+        });
+
+        it("returns the exact mean at radius 3 where jsfeat comes out 1 low", () => {
+            const W = 32,
+                H = 32,
+                V = 128,
+                RADIUS = 3;
+            const next = new jsfeatNext.matrix_t(W, H, U8C1);
+            const orig = new jsfeat.matrix_t(W, H, OU8C1);
+            next.data.fill(V);
+            orig.data.fill(V);
+            const dstN = new jsfeatNext.matrix_t(W, H, U8C1);
+            const dstO = new jsfeat.matrix_t(W, H, OU8C1);
+            jsfeatNext.imgproc.box_blur_gray(next, dstN, RADIUS, 0);
+            jsfeat.imgproc.box_blur_gray(orig, dstO, RADIUS, 0);
+
+            // Interior only, to isolate the reciprocal defect from any border.
+            for (let y = RADIUS; y < H - RADIUS; y++) {
+                for (let x = RADIUS; x < W - RADIUS; x++) {
+                    expect(dstN.data[y * W + x]).toBe(128);
+                    expect(dstO.data[y * W + x]).toBe(127);
+                }
+            }
+        });
+
+        it("still matches jsfeat exactly at radius 2 on non-uniform data (parity preserved)", () => {
+            // The divergence is scoped: where jsfeat is correct, jsfeatNext
+            // agrees bit-for-bit. Radius 2 on noise never crosses a reciprocal
+            // boundary, and the image is larger than the kernel.
+            const W = 24,
+                H = 20,
+                RADIUS = 2;
+            const next = new jsfeatNext.matrix_t(W, H, U8C1);
+            const orig = new jsfeat.matrix_t(W, H, OU8C1);
+            let seed = 1234;
+            for (let i = 0; i < W * H; i++) {
+                seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+                next.data[i] = orig.data[i] = (seed >>> 16) & 0xff;
+            }
+            const dstN = new jsfeatNext.matrix_t(W, H, U8C1);
+            const dstO = new jsfeat.matrix_t(W, H, OU8C1);
+            jsfeatNext.imgproc.box_blur_gray(next, dstN, RADIUS, 0);
+            jsfeat.imgproc.box_blur_gray(orig, dstO, RADIUS, 0);
+            for (let i = 0; i < W * H; i++) expect(dstN.data[i]).toBe(dstO.data[i]);
+        });
+    });
 });

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -200,6 +200,19 @@ describe("box_blur_gray preserves a uniform image at every size (#114 fixed)", (
             expect([min, max]).toEqual([128, 128]);
         }
     });
+
+    it("preserves a uniform image at a radius past the int32 area overflow", () => {
+        // The window area is windowSize^2; at radius >= 23170 that squares past
+        // 2^31, so coercing it with `| 0` would wrap negative and the exact
+        // division would return garbage. A degenerate but legal call (radius far
+        // larger than the image, so every clamped window is the whole image)
+        // must still round-trip a uniform image. Regression guard for the `area`
+        // coercion caught in review of the #114 fix.
+        const dst = dstImage(8, 8);
+        ip.box_blur_gray(flat(8, 8, 128), dst, 30000, 0);
+        const { min, max } = pixelRange(dst, 8, 8);
+        expect([min, max]).toEqual([128, 128]);
+    });
 });
 
 describe("edge cases: detectors on tiny images and oversized borders", () => {

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -49,10 +49,12 @@ import { U8C1, F32C1, uniformImage, dstImage, keypointPool, pixelRange } from ".
  * and says nothing about any of it.
  *
  * Most of what follows asserts that an invariant established elsewhere still
- * holds at the boundary. Two blocks instead CHARACTERIZE behaviour that is
- * wrong but inherited from jsfeat — `box_blur_gray` below kernel size (#114)
- * and `invert_3x3` on a singular matrix. Those are labelled, cite their issue,
- * and are written to be replaced by a fix rather than kept.
+ * holds at the boundary. `box_blur_gray` below kernel size used to be a
+ * characterization of inherited-broken behaviour; #114 fixed it, so that block
+ * now asserts the invariant (a uniform image round-trips at every size). One
+ * block still CHARACTERIZES behaviour that is wrong but inherited from jsfeat —
+ * `invert_3x3` on a singular matrix — labelled, citing its issue, and written
+ * to be replaced by a fix rather than kept.
  */
 
 const ip = jsfeatNext.imgproc;

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -162,38 +162,25 @@ describe("edge cases: compute_integral_image at boundary sizes", () => {
     });
 });
 
-describe("edge cases: box_blur_gray below kernel size — KNOWN BUG #114", () => {
-    // A blur is an average, so a uniform image must round-trip at ANY size.
-    // box_blur_gray only manages it once the image is at least as large as the
-    // kernel; below that the sliding-window sums are never correctly primed and
-    // the output is grossly wrong. Bit-identical in original jsfeat, so this is
-    // inherited rather than a jsfeatNext regression.
+describe("box_blur_gray preserves a uniform image at every size (#114 fixed)", () => {
+    // A blur is an average, so a uniform image must round-trip at ANY size and
+    // radius. Before #114 two things broke that: the sliding-window sums were
+    // never primed when the image was smaller than the kernel, and the float
+    // `1 / area` reciprocal came out 1 low at radius 3. The window is now
+    // clamped to the image and the area divides exactly, so both are fixed.
     //
-    // These are CHARACTERIZATION tests pinning today's broken output. When #114
-    // is fixed they must fail — that is the point.
+    // These are the inverse of the old characterization tests, which pinned the
+    // broken output; they now assert the invariant directly.
 
-    it("is correct at every size at or above the kernel, in both dimensions", () => {
-        // The real invariant, asserted across the whole region where it holds
-        // rather than at one sampled point per radius.
-        //
-        // The reliable region is BOTH cols >= 2r+1 AND rows >= 2r+1 — not
-        // `min(cols, rows)`. The two passes run along cols and then along rows,
-        // and either being shorter than the window is enough to break it. Below
-        // the region the result is erratic rather than uniformly wrong: some
-        // dimension pairs land on the right value by coincidence, which is why
-        // the failing side is pinned with `it.fails` instead of exact values.
-        // See #114.
+    it("round-trips a uniform image at every size from 1x1 up, below and above the kernel", () => {
         const offenders: string[] = [];
         for (const radius of [1, 2, 3, 4]) {
-            const kernel = 2 * radius + 1;
-            for (let cols = kernel; cols <= kernel + 6; cols++) {
-                for (let rows = kernel; rows <= kernel + 6; rows++) {
+            for (let cols = 1; cols <= 2 * radius + 3; cols++) {
+                for (let rows = 1; rows <= 2 * radius + 3; rows++) {
                     const dst = dstImage(cols, rows);
                     ip.box_blur_gray(flat(cols, rows, 128), dst, radius, 0);
                     const { min, max } = pixelRange(dst, cols, rows);
-                    // radius 3 lands 1 low from float truncation — a separate
-                    // defect with its own test below, so allow a single level
-                    if (Math.abs(min - 128) > 1 || Math.abs(max - 128) > 1) {
+                    if (min !== 128 || max !== 128) {
                         offenders.push(`${cols}x${rows} r=${radius} -> [${min},${max}]`);
                     }
                 }
@@ -202,43 +189,14 @@ describe("edge cases: box_blur_gray below kernel size — KNOWN BUG #114", () =>
         expect(offenders).toEqual([]);
     });
 
-    it("is exact for radii whose reciprocal window area rounds up", () => {
-        for (const radius of [1, 2, 4]) {
+    it("is exact at every radius on a large uniform image, radius 3 included", () => {
+        // Radius 3 was the visible face of the float-reciprocal defect:
+        // 128 * 49 * (1 / 49) = 127.999999999999986 truncated to 127. Exact
+        // division removes it, and the other radii stay exact.
+        for (const radius of [1, 2, 3, 4, 5, 8]) {
             const dst = dstImage(32, 32);
             ip.box_blur_gray(flat(32, 32, 128), dst, radius, 0);
             const { min, max } = pixelRange(dst, 32, 32);
-            expect([min, max]).toEqual([128, 128]);
-        }
-    });
-
-    it("BUG #114: radius 3 comes out 1 low even on a large image", () => {
-        // scale is the float 1/49, and 128 * 49 * (1/49) = 127.999999999999986,
-        // which truncates to 127. Only radius 3 hits this for radii 1..8.
-        const dst = dstImage(32, 32);
-        ip.box_blur_gray(flat(32, 32, 128), dst, 3, 0);
-        const { min, max } = pixelRange(dst, 32, 32);
-        expect([min, max]).toEqual([127, 127]);
-    });
-
-    // Declared with `it.fails`: the body asserts the CORRECT behaviour, and the
-    // test passes only because that assertion currently fails. Fix #114 and
-    // this flips to a failure, forcing a deliberate update.
-    //
-    // Deliberately not pinning the wrong values. They are not stable — the
-    // window reads outside the image, so the result depends on surrounding
-    // library state. The identical call returns 85 in isolation and 142 when
-    // run after the tests above it. That instability is itself part of the bug
-    // and is recorded in #114; asserting the numbers would just be flaky.
-    it.fails("BUG #114: a uniform image is NOT preserved when smaller than the kernel", () => {
-        for (const [size, radius] of [
-            [1, 1],
-            [2, 1],
-            [1, 2],
-            [4, 2],
-        ] as [number, number][]) {
-            const dst = dstImage(size, size);
-            ip.box_blur_gray(flat(size, size, 128), dst, radius, 0);
-            const { min, max } = pixelRange(dst, size, size);
             expect([min, max]).toEqual([128, 128]);
         }
     });

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -98,12 +98,42 @@ describe("ground truth: box_blur_gray vs a naive clamped-window mean", () => {
         // Since #114 the library divides the window sum EXACTLY by the area, so
         // `refBoxBlur` (exact division) is its oracle with no tolerance anywhere
         // — including radius 3, which used to come out 1 low from the float
-        // reciprocal. The below-kernel shapes are now covered too, in the
-        // separate suite below; here we stay at or above the kernel.
+        // reciprocal. Below-kernel shapes are covered separately below, on
+        // non-uniform data; here we stay at or above the kernel.
         for (const [w, h] of SHAPES) {
             const src = noiseImage(w, h, 4242);
             for (let radius = 1; radius <= 5; radius++) {
                 if (Math.min(w, h) < 2 * radius + 1) continue;
+                const dst = dstImage(w, h);
+                ip.box_blur_gray(src, dst, radius, 0);
+                expectExact(`${w}x${h} r=${radius}`, dst.data, refBoxBlur(src.data, w, h, radius), w * h);
+            }
+        }
+    });
+
+    it("matches the reference on small NON-UNIFORM shapes, below and at the kernel (#114)", () => {
+        // The critical coverage for the #114 fix. A uniform image is symmetric
+        // to a transpose and cannot distinguish a mis-clamped replicated border
+        // (every pixel is equal, so a wrong-but-in-range index reads the same
+        // value), so the uniform suite cannot verify the border/transpose
+        // indexing on the exact shapes the fix is about. These do: an asymmetric
+        // pattern (different in x and y) over 1xN, Nx1 and small squares, at
+        // radii that put the window past the image on one or both axes.
+        const pattern = (w: number, h: number) => image(w, h, (x, y) => (x * 37 + y * 101 + 13) & 0xff);
+        const SMALL: [number, number][] = [
+            [1, 1],
+            [1, 5],
+            [5, 1],
+            [2, 3],
+            [3, 2],
+            [3, 3],
+            [4, 4],
+            [2, 7],
+            [7, 2],
+        ];
+        for (const [w, h] of SMALL) {
+            const src = pattern(w, h);
+            for (let radius = 1; radius <= 4; radius++) {
                 const dst = dstImage(w, h);
                 ip.box_blur_gray(src, dst, radius, 0);
                 expectExact(`${w}x${h} r=${radius}`, dst.data, refBoxBlur(src.data, w, h, radius), w * h);

--- a/tests/reference/imgproc.test.ts
+++ b/tests/reference/imgproc.test.ts
@@ -94,25 +94,29 @@ describe("ground truth: box_blur_gray vs a naive clamped-window mean", () => {
         [32, 24],
     ];
 
-    it("matches the reference exactly at every radius and shape", () => {
-        // Compared against the float-reciprocal reference, so no tolerance is
-        // needed anywhere — including radius 3, whose truncation is part of the
-        // arithmetic being modelled rather than slack to be absorbed.
+    it("matches the exact clamped-window mean at every radius and shape (#114)", () => {
+        // Since #114 the library divides the window sum EXACTLY by the area, so
+        // `refBoxBlur` (exact division) is its oracle with no tolerance anywhere
+        // — including radius 3, which used to come out 1 low from the float
+        // reciprocal. The below-kernel shapes are now covered too, in the
+        // separate suite below; here we stay at or above the kernel.
         for (const [w, h] of SHAPES) {
             const src = noiseImage(w, h, 4242);
             for (let radius = 1; radius <= 5; radius++) {
-                if (Math.min(w, h) < 2 * radius + 1) continue; // #114 territory
+                if (Math.min(w, h) < 2 * radius + 1) continue;
                 const dst = dstImage(w, h);
                 ip.box_blur_gray(src, dst, radius, 0);
-                expectExact(`${w}x${h} r=${radius}`, dst.data, refBoxBlurAsImplemented(src.data, w, h, radius), w * h);
+                expectExact(`${w}x${h} r=${radius}`, dst.data, refBoxBlur(src.data, w, h, radius), w * h);
             }
         }
     });
 
-    it("differs from exact division only at radius 3, and only by 1", () => {
-        // Isolates the #114 truncation defect: the library's answer is right
-        // wherever the reciprocal is exactly representable, and one low where
-        // it is not. Asserting the shape of the error rather than tolerating it.
+    it("the old float reciprocal differed from exact division only at radius 3, by 1", () => {
+        // Documents why #114 was worth fixing. `refBoxBlurAsImplemented` models
+        // the arithmetic the library used BEFORE the fix (multiply by the float
+        // `1 / area`); comparing it to exact division shows the error was right
+        // wherever the reciprocal is representable and one low where it is not.
+        // The library no longer behaves this way — this pins the motivation.
         for (const [w, h] of SHAPES) {
             const src = noiseImage(w, h, 4242);
             for (let radius = 1; radius <= 5; radius++) {
@@ -137,7 +141,7 @@ describe("ground truth: box_blur_gray vs a naive clamped-window mean", () => {
         const src = image(W, H, (x, y) => (x * 7 + y * 3) & 0xff);
         const dst = dstImage(W, H);
         ip.box_blur_gray(src, dst, 2, 0);
-        expectExact("gradient r=2", dst.data, refBoxBlurAsImplemented(src.data, W, H, 2), W * H);
+        expectExact("gradient r=2", dst.data, refBoxBlur(src.data, W, H, 2), W * H);
     });
 });
 

--- a/tests/reference/reference-impl.ts
+++ b/tests/reference/reference-impl.ts
@@ -67,28 +67,28 @@ function clamp(v: number, n: number) {
 }
 
 /**
- * Box blur: mean of the `(2r+1)²` neighbourhood, borders replicated.
+ * Box blur: mean of the `(2r+1)²` neighbourhood, borders replicated, with EXACT
+ * division by the window area.
  *
- * Verified bit-exact against `imgproc.box_blur_gray` for radius 1 and 2 on
- * non-uniform input. Radius 3 differs by at most 1 because the library scales
- * by the float `1/49` and truncates — see #114, which also covers the much
- * larger breakage when the image is smaller than the kernel.
+ * Since #114 this is what `imgproc.box_blur_gray` computes, so it is the
+ * library's oracle: bit-exact at every radius and every size, including images
+ * smaller than the kernel. (Before #114 the library scaled by the float `1/area`
+ * and truncated, which came out 1 low at radius 3; that historical behaviour is
+ * `refBoxBlurAsImplemented` below.)
  */
 export function refBoxBlur(src: ArrayLike<number>, w: number, h: number, radius: number): Int32Array {
     return boxBlur(src, w, h, radius, false);
 }
 
 /**
- * The same box blur, but reproducing the library's ARITHMETIC as well as its
- * maths: it scales by the float reciprocal `1/area` and truncates, rather than
- * dividing exactly.
+ * The box blur as `imgproc.box_blur_gray` computed it BEFORE #114: scaling by
+ * the float reciprocal `1/area` and truncating, rather than dividing exactly.
  *
- * This exists so the ground-truth comparison can be exact at every radius. The
- * two differ only where the reciprocal is not exactly representable — radius 3,
- * where `128 * 49 * (1/49) = 127.999999999999986` truncates to 127 (#114). With
- * an exact-division reference the only way to accommodate that is a ±1
- * tolerance, and a tolerance wide enough to absorb the defect is also wide
- * enough to hide a real off-by-one.
+ * The library no longer behaves this way — kept only to document why #114
+ * mattered. The two references differ only where the reciprocal is not exactly
+ * representable — radius 3, where `128 * 49 * (1/49) = 127.999999999999986`
+ * truncates to 127. Do NOT use this as the oracle for the current library; use
+ * `refBoxBlur`.
  */
 export function refBoxBlurAsImplemented(src: ArrayLike<number>, w: number, h: number, radius: number): Int32Array {
     return boxBlur(src, w, h, radius, true);


### PR DESCRIPTION
## Summary

`box_blur_gray` was wrong in two inherited ways, both of which change output — so they belong before 1.0, not after (the reasoning in #121). With #119 already merged, this closes the **#121** umbrella.

Closes #114.

## The two defects

**1. Garbage below the kernel size.** When `cols < 2r+1` or `rows < 2r+1`, the sliding-window phase bounds (`x < w - radiusPlus2`, then `x < w - radiusPlusOne`) go negative, the middle phases are skipped, and the warm-up reads past the row end into other rows or buffer padding. A uniform image was not preserved, and the output was **non-deterministic** — it depended on leftover pool state, returning 85 in isolation and 142 after other work.

**2. Radius-3 float truncation.** The scaled path multiplied by the float reciprocal `1/area` and truncated. `128 * 49 * (1/49) = 127.999999999999986 → 127`. It comes out 1 low wherever the true mean is an integer the reciprocal undershoots; radius 3 on a uniform image is the clearest case.

## The fix

Both passes rewritten as a **clamped running sum**:

- The window is clamped to the image (replicated border), so it is correct at **every** size and still **O(1) per pixel** — no fallback path, no per-size branching.
- The scaled store divides **exactly** (`Math.floor(sum / area)`) instead of using the reciprocal. The input is non-negative, so `floor` is the same truncation jsfeat intended, only without the representation error.

The result is that the library now computes the exact clamped-window mean, which is *simpler* than the four-phase unrolled original (net −62 lines in the function) and correct by construction.

## Parity

Both defects exist in original jsfeat (`tests/vendor/jsfeat-master.js`), so these are deliberate divergences of the same class as #102 — *the documented answer where jsfeat returned garbage*. Registered in `tests/divergences.test.ts`, cross-checked against the live jsfeat oracle:

- uniform image preserved below the kernel where jsfeat returns garbage;
- exact `128` at radius 3 where jsfeat gives `127`;
- **parity preserved at radius 2 on non-uniform data**, where jsfeat is correct — this is what `tests/parity` pins, and it stays green.

## Tests

- `tests/reference/imgproc.test.ts` — ground truth now compares against `refBoxBlur` (exact division). `refBoxBlurAsImplemented` is kept only to document the old arithmetic and why the fix mattered.
- `tests/properties/edge-cases.test.ts` — the KNOWN-BUG characterization block is replaced by invariant tests: a uniform image round-trips at **every size from 1×1 up**, and every radius is exact including 3. The old `it.fails` (which pinned the un-preserved uniform) and the "radius 3 comes out 1 low" case are gone, inverted by the fix.
- `tests/divergences.test.ts` — the entry above.

`npm test`: 22 files, **261 passed**. `tsc --noEmit`, `prettier --check`, `license-check` all clean.

## Release

This is the second half of the planned **0.12.0** — a small release scoped to #121 (the two output-changing correctness fixes). #119 is already in `dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
