### PR TITLE
docs(orb): document the 20px edge margin for describe() (#110)

### DIFF
--- a/src/orb/orb.ts
+++ b/src/orb/orb.ts
@@ -81,6 +81,27 @@ export class orb extends jsfeatNext {
      * Each keypoint's `angle` is used to rotation-rectify its patch, making
      * the descriptor rotation-invariant.
      *
+     * @remarks
+     * **Keep keypoints at least 20 px from every image edge.** Each descriptor
+     * bit compares two samples of the rotation-rectified patch, taken through
+     * {@link rectify_patch}'s `warp_affine` with a **constant fill of `128`**.
+     * A keypoint closer to an edge than the sampling reach has some samples fall
+     * outside the image; those read `128` regardless of image content, so the
+     * bits that touch them are decided by the fill rather than by the image, and
+     * the descriptor is silently degraded. There is no return value or flag
+     * marking which descriptors are affected (issue #110).
+     *
+     * The reach is **not** the 32 px patch size — only the 256 sampled pairs are
+     * read, and the largest coordinate component in the sampling pattern is 13,
+     * so the furthest sample sits `13·√2 ≈ 18.4 px` from the centre at the worst
+     * rotation; adding the bilinear neighbour gives a safe margin of **20 px**.
+     * Measured (post-0.12.0, a single keypoint swept over 360 angles with a clean
+     * brightness lift): contamination persists to distance 18 and vanishes from
+     * **19** upward, so 20 keeps ~1 px of slack. The FAST/YAPE detectors already
+     * take a `border` argument for exactly this; pass ≥ 20 when the descriptors
+     * feed a matcher. (OpenCV instead rejects such keypoints via `edgeThreshold`,
+     * default 31.)
+     *
      * @param src         Source grayscale image the keypoints live in.
      * @param corners     Keypoints to describe (uses `x`, `y`, `angle`).
      * @param count       Number of keypoints to process.

--- a/src/orb/rectify_patch.ts
+++ b/src/orb/rectify_patch.ts
@@ -78,5 +78,9 @@ export function rectify_patch(
     H.data[4] = cosine;
     H.data[5] = (-sine - cosine) * psize * 0.5 + py;
 
+    // Constant fill of 128: patch samples that fall outside `src` read this
+    // fixed value rather than image content, which silently degrades the
+    // descriptor for keypoints within ~20 px of an edge. See the margin note on
+    // `orb.describe` and issue #110.
     imgProcessor.warp_affine(src, dst, H, 128);
 }

--- a/tests/properties/detectors.test.ts
+++ b/tests/properties/detectors.test.ts
@@ -365,12 +365,16 @@ describe("detector invariants", () => {
             const STEPS = 360;
             // Bounded non-uniform pattern in [20, 179]; +40 stays <= 219, so the
             // lift never saturates and every in-image sample shifts by exactly 40.
-            const patt = (dx: number) => (x: number, y: number) => 20 + (((x * 37 + y * 101) ^ (x * 13)) % 160) + dx;
+            // `>>> 0` forces the XOR to an unsigned 32-bit int, so `% 160` cannot
+            // go negative and the range is guaranteed [20, 179].
+            const patt = (dx: number) => (x: number, y: number) =>
+                20 + ((((x * 37 + y * 101) ^ (x * 13)) >>> 0) % 160) + dx;
             const sweep = (offset: number, distance: number) => {
                 const img = image(96, 96, patt(offset));
                 const corners = Array.from({ length: STEPS }, (_, a) => {
                     const k = new jsfeatNext.keypoint_t(distance, 48, 0, 0, -1);
-                    k.angle = (a * 360) / STEPS;
+                    // keypoint_t.angle is RADIANS: sweep one full circle evenly.
+                    k.angle = (a / STEPS) * 2 * Math.PI;
                     return k;
                 });
                 const d = new jsfeatNext.matrix_t(32, STEPS, U8C1);

--- a/tests/properties/detectors.test.ts
+++ b/tests/properties/detectors.test.ts
@@ -38,7 +38,7 @@
 
 import { describe, it, expect } from "vitest";
 import jsfeatNext from "../../src/jsfeatNext";
-import { U8C1, cornerScene, uniformImage, keypointPool, hammingDistance } from "./helpers";
+import { U8C1, cornerScene, uniformImage, keypointPool, hammingDistance, image } from "./helpers";
 
 /**
  * Property/invariant tests for the detectors and the ORB descriptor
@@ -347,6 +347,40 @@ describe("detector invariants", () => {
             expect(distance).toBeGreaterThan(0);
             // ...but only a handful of bits: only edge-adjacent patches suffer.
             expect(distance).toBeLessThan(bits * 0.01);
+        });
+
+        it("the 20px safe margin holds at the WORST rotation, not just angle 0 (#110)", () => {
+            // The scene tests above describe at angle 0, where the sampling
+            // pattern reaches at most 13px on an axis. The worst case is the
+            // diagonal — 13*sqrt(2) = 18.4px — reached only under rotation, so an
+            // angle-0 test cannot see it. This sweeps one keypoint over 360
+            // angles at a controlled distance from the left edge and checks the
+            // brightness-offset invariance there.
+            //
+            // Pins the re-measurement done for the 0.12.0 release: #119 changed
+            // warp_affine to FILL the (-1,0) source band with the 128 constant
+            // (instead of extrapolating brightness-consistently), which widened
+            // the contaminated band by ~2px. Contamination now vanishes from
+            // distance 19 up, so 20 is safe with ~1px slack; it is present at 16.
+            const STEPS = 360;
+            // Bounded non-uniform pattern in [20, 179]; +40 stays <= 219, so the
+            // lift never saturates and every in-image sample shifts by exactly 40.
+            const patt = (dx: number) => (x: number, y: number) => 20 + (((x * 37 + y * 101) ^ (x * 13)) % 160) + dx;
+            const sweep = (offset: number, distance: number) => {
+                const img = image(96, 96, patt(offset));
+                const corners = Array.from({ length: STEPS }, (_, a) => {
+                    const k = new jsfeatNext.keypoint_t(distance, 48, 0, 0, -1);
+                    k.angle = (a * 360) / STEPS;
+                    return k;
+                });
+                const d = new jsfeatNext.matrix_t(32, STEPS, U8C1);
+                orb.describe(img, corners, STEPS, d);
+                return d;
+            };
+            // At distance 20 the whole rotated reach stays inside: bit-identical.
+            expect(hammingDistance(sweep(0, 20).data, sweep(40, 20).data, STEPS * 32)).toBe(0);
+            // At distance 16 the diagonal samples cross the edge: invariance lost.
+            expect(hammingDistance(sweep(0, 16).data, sweep(40, 16).data, STEPS * 32)).toBeGreaterThan(0);
         });
 
         it("gives clearly different descriptors to different keypoints", () => {


### PR DESCRIPTION
## Summary

Fix (a) from #110, the recommended first step: `orb.describe()` silently degrades a descriptor when a keypoint is close enough to an image edge that part of its sampling pattern falls outside and reads `rectify_patch`'s constant fill of `128` instead of image content — with no flag telling the caller which descriptors are affected.

This removes the **silent** part. No behaviour change, no API change, no parity risk.

Closes #110 (the optional (b) guard is folded into #83 — see below).

## What changed

- **`orb.describe()` TSDoc** now states the **≥ 20 px** edge margin, derives it (the largest sampling-pattern component is 13, so the furthest sample sits `13·√2 ≈ 18.4 px` from the centre at the worst rotation; +1 for the bilinear neighbour → 20), and points at the FAST/YAPE `border` argument. Notes that OpenCV instead rejects such keypoints via `edgeThreshold`.
- **`rectify_patch`** gets a matching note on the `128` fill.
- **A rotation-aware test.** The existing #110 characterization describes at angle 0, where the pattern only reaches 13 px on an axis — it cannot see the diagonal worst case that appears under rotation. The new test sweeps one keypoint over 360 angles at a controlled edge distance: bit-identical at distance 20, contaminated at 16.

## Re-measured for 0.12.0 (this is the timing-driven part)

#119 (shipped in 0.12.0) changed what `warp_affine` does near edges — it now **fills** the `(-1, 0)` source band with the `128` constant instead of extrapolating (which was brightness-consistent). That widened the contaminated band by ~2 px:

| keypoint distance from edge | contaminated bits (1 kp × 360 angles, clean +40 lift) |
| --- | --- |
| 16 | 537 |
| 17 | 168 |
| 18 | 15 |
| **19** | **0** |
| 20 | 0 |

So contamination now vanishes from **19** up, where #110 originally reported 17. **20 px stays safe, now with ~1 px of slack** — and the derivation (`13·√2 + 1 ≈ 19.4`) matches. The angle-0 scene characterizations are unaffected (border 8 still 2 bits of 8960).

This is a small, real interaction worth recording: #119 traded extrapolated-but-brightness-consistent edge samples for a hard constant, which is more honest (the value is clearly "outside") but breaks the brightness invariance for that thin band.

## Not in scope

- **(b) a describable-margin guard** (a status array / margin filter so callers know which keypoints were fully describable) — stays open, folded into #83, where descriptor quality starts to matter for matching and pose.
- **(c) border replication** — rejected on #110: it changes descriptor bytes (a parity break) and only makes an edge patch differently wrong.

## Verification

`npm test`: **264 passed**. `tsc --noEmit`, `prettier --check`, `license-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
