### PR TITLE
fix(matmath): invert_3x3 reports singularity instead of only returning NaN (#120)

### DIFF
--- a/src/matmath/matmath.ts
+++ b/src/matmath/matmath.ts
@@ -41,6 +41,7 @@
  */
 
 import { matrix_t } from "../matrix_t/matrix_t";
+import { JSFEAT_CONSTANTS } from "../constants/constants";
 
 /**
  * General matrix arithmetic on {@link matrix_t} operands: transpose,
@@ -301,12 +302,18 @@ export default class matmath {
 
     /**
      * Inverts a 3×3 matrix by the adjugate/determinant closed form
-     * (no pivoting — the input must be non-singular). Safe to call with
-     * `from === to` (in-place inversion).
+     * (no pivoting). Safe to call with `from === to` (in-place inversion).
+     *
+     * @returns `1` if the matrix was invertible, `0` if it is singular
+     * (`|det| < EPSILON`). On a singular input the destination is still written
+     * — with the non-finite values `1/det` produces, byte-identical to original
+     * jsfeat — so callers ignoring the return keep the previous behaviour, while
+     * those that check it can react before the `NaN`/`Infinity` propagates
+     * (issue #120). Mirrors {@link linalg.lu_solve}'s `1`/`0` convention.
      *
      * @param from 3×3 source matrix. @param to 3×3 destination.
      */
-    invert_3x3(from: matrix_t, to: matrix_t): void {
+    invert_3x3(from: matrix_t, to: matrix_t): number {
         const A = from.data,
             invA = to.data;
         const t1 = A[4];
@@ -325,7 +332,8 @@ export default class matmath {
         const t20 = A[6];
         const t21 = t20 * t14;
         const t23 = t20 * t17;
-        const t26 = 1.0 / (t9 * t2 - t11 * t5 - t15 * t2 + t18 * t5 + t21 * t4 - t23 * t1);
+        const det = t9 * t2 - t11 * t5 - t15 * t2 + t18 * t5 + t21 * t4 - t23 * t1;
+        const t26 = 1.0 / det;
         invA[0] = (t1 * t2 - t4 * t5) * t26;
         invA[1] = -(t14 * t2 - t17 * t5) * t26;
         invA[2] = -(-t14 * t4 + t17 * t1) * t26;
@@ -335,6 +343,8 @@ export default class matmath {
         invA[6] = -(-t13 * t5 + t1 * t20) * t26;
         invA[7] = -(t8 * t5 - t21) * t26;
         invA[8] = (t9 - t15) * t26;
+
+        return Math.abs(det) < JSFEAT_CONSTANTS.EPSILON ? 0 : 1;
     }
 
     /**

--- a/src/matmath/matmath.ts
+++ b/src/matmath/matmath.ts
@@ -311,6 +311,14 @@ export default class matmath {
      * those that check it can react before the `NaN`/`Infinity` propagates
      * (issue #120). Mirrors {@link linalg.lu_solve}'s `1`/`0` convention.
      *
+     * The threshold is **absolute** on the raw determinant, which scales with
+     * the cube of the entry magnitude, so a well-conditioned matrix whose
+     * entries are all very small (roughly below `0.005`) can be reported
+     * singular even though its inverse is finite. This does not arise for the
+     * O(1)-scaled matrices in this library (homographies, the normalization
+     * matrix); normalize the input if you invert arbitrarily-scaled 3×3s and
+     * need the status to be reliable.
+     *
      * @param from 3×3 source matrix. @param to 3×3 destination.
      */
     invert_3x3(from: matrix_t, to: matrix_t): number {

--- a/tests/parity/matmath.test.ts
+++ b/tests/parity/matmath.test.ts
@@ -170,6 +170,27 @@ describe("parity: matmath vs original jsfeat.matmath", () => {
         expectDataClose(inv, invo, 9);
     });
 
+    it("invert_3x3 — singular input stays byte-identical to jsfeat (#120)", () => {
+        // #120 added a 1/0 status return but did NOT touch the numbers: a
+        // singular matrix still yields the exact same non-finite pattern jsfeat
+        // produces from 1/det. Compared with Object.is so each +Infinity,
+        // -Infinity and NaN has to match jsfeat's slot exactly — a strictly
+        // stronger guard than "at least one entry is non-finite".
+        const vals = [1, 2, 3, 2, 4, 6, 1, 1, 1]; // rows 1,2 dependent -> det 0
+        const a = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const ao = new jsfeat.matrix_t(3, 3, jsfeat.F32_t | jsfeat.C1_t);
+        a.data.set(vals);
+        ao.data.set(vals);
+        const inv = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const invo = new jsfeat.matrix_t(3, 3, jsfeat.F32_t | jsfeat.C1_t);
+
+        expect(mm.invert_3x3(a, inv)).toBe(0); // jsfeatNext reports singular...
+        jsfeat.matmath.invert_3x3(ao, invo); // ...jsfeat gives no such signal
+        for (let i = 0; i < 9; i++) {
+            expect(Object.is(inv.data[i], invo.data[i])).toBe(true);
+        }
+    });
+
     it("multiply_3x3", () => {
         const { next: a, orig: ao } = makePair(3, 3, 13);
         const { next: b, orig: bo } = makePair(3, 3, 14);

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -275,17 +275,30 @@ describe("edge cases: linalg and matmath on degenerate matrices", () => {
         expect(2 * x0 + 6 * x1).toBeCloseTo(2, 4);
     });
 
-    it("CHARACTERIZATION: invert_3x3 of a singular matrix silently yields non-finite values", () => {
-        // Same family as #102: no error, no signal, just garbage the caller
-        // will happily use. Pinned so a future guard is a deliberate change.
-        const singular = square(3, [1, 2, 3, 2, 4, 6, 1, 1, 1]);
+    it("invert_3x3 reports failure on a singular matrix and success on an invertible one (#120)", () => {
+        // #120: invert_3x3 now returns 1/0 like lu_solve, so a caller can react
+        // before the NaN/Infinity propagates. The numeric output is unchanged —
+        // still the non-finite values 1/det produces, byte-identical to jsfeat —
+        // so this is an additive signal, not a divergence.
+        const singular = square(3, [1, 2, 3, 2, 4, 6, 1, 1, 1]); // rows 1,2 dependent
         expect(jsfeatNext.matmath.mat3x3_determinant(singular)).toBe(0);
 
         const inverse = new jsfeatNext.matrix_t(3, 3, F32C1);
-        jsfeatNext.matmath.invert_3x3(singular, inverse);
+        expect(jsfeatNext.matmath.invert_3x3(singular, inverse)).toBe(0);
+        // ...and the output is still the old non-finite garbage (parity kept).
         let nonFinite = 0;
         for (let i = 0; i < 9; i++) if (!Number.isFinite(inverse.data[i])) nonFinite++;
         expect(nonFinite).toBeGreaterThan(0);
+
+        // An invertible matrix returns 1 and a finite, correct inverse (A·A⁻¹ = I).
+        const A = square(3, [2, 0, 1, 1, 3, 2, 1, 0, 1]);
+        const Ai = new jsfeatNext.matrix_t(3, 3, F32C1);
+        expect(jsfeatNext.matmath.invert_3x3(A, Ai)).toBe(1);
+        const P = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.matmath.multiply_3x3(P, A, Ai);
+        for (const [i, want] of [1, 0, 0, 0, 1, 0, 0, 0, 1].entries()) {
+            expect(P.data[i]).toBeCloseTo(want, 5);
+        }
     });
 });
 

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -299,6 +299,15 @@ describe("edge cases: linalg and matmath on degenerate matrices", () => {
         for (const [i, want] of [1, 0, 0, 0, 1, 0, 0, 0, 1].entries()) {
             expect(P.data[i]).toBeCloseTo(want, 5);
         }
+
+        // An invertible matrix with a NEGATIVE determinant must also return 1.
+        // This is what guards the `Math.abs` in the singularity check: a row
+        // swap has det = -1, and without the abs `-1 < EPSILON` would falsely
+        // report it singular.
+        const neg = square(3, [0, 1, 0, 1, 0, 0, 0, 0, 1]); // det = -1
+        expect(jsfeatNext.matmath.mat3x3_determinant(neg)).toBe(-1);
+        const negI = new jsfeatNext.matrix_t(3, 3, F32C1);
+        expect(jsfeatNext.matmath.invert_3x3(neg, negI)).toBe(1);
     });
 });
 

--- a/tests/properties/edge-cases.test.ts
+++ b/tests/properties/edge-cases.test.ts
@@ -49,12 +49,12 @@ import { U8C1, F32C1, uniformImage, dstImage, keypointPool, pixelRange } from ".
  * and says nothing about any of it.
  *
  * Most of what follows asserts that an invariant established elsewhere still
- * holds at the boundary. `box_blur_gray` below kernel size used to be a
- * characterization of inherited-broken behaviour; #114 fixed it, so that block
- * now asserts the invariant (a uniform image round-trips at every size). One
- * block still CHARACTERIZES behaviour that is wrong but inherited from jsfeat —
- * `invert_3x3` on a singular matrix — labelled, citing its issue, and written
- * to be replaced by a fix rather than kept.
+ * holds at the boundary. Two blocks here used to CHARACTERIZE inherited-broken
+ * behaviour, pinned so a fix would be a deliberate change; both have since been
+ * fixed and now assert the invariant instead: `box_blur_gray` below kernel size
+ * (#114 — a uniform image round-trips at every size) and `invert_3x3` on a
+ * singular matrix (#120 — it now returns 0 to report the singularity). No
+ * characterization-of-a-defect blocks remain.
  */
 
 const ip = jsfeatNext.imgproc;


### PR DESCRIPTION
## Summary

`matmath.invert_3x3` divided by the determinant without checking it, so a singular matrix returned a matrix of `NaN`/`±Infinity` with **no signal** — no return value, no exception, no flag. `NaN` then propagates through `multiply_3x3`, warps and pose estimates and surfaces far from the cause.

Closes #120.

## Fix — option (a) from the issue

Return **`1`** on success, **`0`** when `|det| < EPSILON`, mirroring `linalg.lu_solve`'s existing `1`/`0` convention in this codebase.

The change is **additive**:
- the function was `void`, so callers ignoring the result keep working;
- the numeric output is **unchanged** — the destination still gets the non-finite values `1/det` produces, byte-identical to original jsfeat.

So **parity holds and no `divergences` entry is needed** — this is a signal added alongside the existing numbers, not a change to them. Callers that check the status can now react before the `NaN` spreads.

## Blast radius: zero internally

The only in-tree caller is `motion_model`'s denormalize step (`invert_3x3(this.T1, this.T1)`), which inverts the **normalization matrix** — non-singular by construction (built from the point centroid and scale), so it never reaches the singular path and needs no change. The singular case only arises for **external** callers inverting an arbitrary 3×3, e.g. a degenerate homography.

## Why a status and not a throw

Same family as #102 (`svd_invert`, resolved there by throwing). A status fits better here because `invert_3x3` sits near RANSAC hot paths in `motion_model`, where a degenerate sample is *expected* and simply discarded — a throw would need call-site handling for a routine event. (Moot in practice, since the internal caller is never singular, but it keeps the API friendly for external hot-loop use.)

## Tests

Replaces the `CHARACTERIZATION` test that pinned the silent `NaN` with one asserting the new behaviour:
- singular input → returns `0`, output still non-finite (parity kept);
- invertible input → returns `1`, and `A · A⁻¹ = I`.

`npm test`: **264 passed**. `tsc --noEmit`, `prettier --check`, `license-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
