### PR TITLE
docs(optical_flow_lk): correct the curr_xy docstring — it is pure output (#111)

### DIFF
--- a/src/optical_flow_lk/optical_flow_lk.ts
+++ b/src/optical_flow_lk/optical_flow_lk.ts
@@ -73,8 +73,12 @@ export class optical_flow_lk extends jsfeatNext {
      * @param prev_pyr Pyramid of the previous frame.
      * @param curr_pyr Pyramid of the current frame.
      * @param prev_xy  Input point coordinates, interleaved `[x0,y0,x1,y1,…]`.
-     * @param curr_xy  Output tracked coordinates (same layout). Seed it with
-     *                 a prediction or a copy of `prev_xy`.
+     * @param curr_xy  **Pure output** — tracked coordinates in the same layout.
+     *                 Only needs to be allocated; its incoming contents are
+     *                 ignored. The coarsest level starts from `prev_xy`, not from
+     *                 `curr_xy`, so seeding it with a prediction has no effect
+     *                 (issue #111). OpenCV's opt-in `OPTFLOW_USE_INITIAL_FLOW`
+     *                 has no equivalent here yet.
      * @param count    Number of points to track.
      * @param win_size Side of the square tracking window (e.g. 15 or 21).
      * @param max_iter Max refinement iterations per level. Default 30.


### PR DESCRIPTION
## Summary

`track()` documented `curr_xy` as an input to seed with a prediction:

```
@param curr_xy  Output tracked coordinates (same layout). Seed it with
                a prediction or a copy of prev_xy.
```

but the implementation **never reads it**. The coarsest pyramid level initialises from `prev_xy`, and every finer level chains from its own result, so the caller's value never enters the computation. Anyone following the docstring and feeding a motion prediction (from a previous frame's velocity, an IMU, a homography) got the same result as passing zeros.

Closes #111.

## Fix — option (a): correct the documentation

`curr_xy` is now described as a **pure output** buffer that only needs allocating, with a pointer to #111 and a note that OpenCV's opt-in `OPTFLOW_USE_INITIAL_FLOW` has no equivalent here yet.

Inherited from jsfeat (identical code path, `tests/vendor/jsfeat-master.js`), so the docstring — not the algorithm — was out of step. **No behaviour change, no parity risk.** Documentation only.

## Not in scope

**(b) real opt-in initial-flow support.** Genuinely useful for AR tracking (#96/#97), where a prediction can cut iterations or rescue large inter-frame motion beyond the tracker's measured displacement ceiling. It would have to be **opt-in and default-off** — honouring the seed unconditionally changes numeric output and would be a parity break needing a `divergences` entry. Left as a follow-up.

## Verification

Docstring-only diff (6 lines, all inside the TSDoc). `tsc --noEmit` and `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
