### PR TITLE
ci(codecov): upload coverage for per-PR diff reporting

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,3 +43,13 @@ jobs:
             # threshold fails the build, deliberately — see vitest.config.ts.
             - name: Test (with coverage summary)
               run: npm run test:coverage
+
+            # Uploads lcov to Codecov for per-PR diff coverage and trends.
+            # Never fails the build: statuses are informational (codecov.yml),
+            # and an upload error (e.g. token missing on a fork PR) is ignored.
+            - name: Upload coverage to Codecov
+              uses: codecov/codecov-action@v5
+              with:
+                  token: ${{ secrets.CODECOV_TOKEN }}
+                  files: ./coverage/lcov.info
+                  fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ![Dependabot Badge](https://flat.badgen.net/dependabot/@webarkit/jsfeat-next?icon=dependabot)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![CI](https://github.com/webarkit/jsfeatNext/actions/workflows/CI.yml/badge.svg)](https://github.com/webarkit/jsfeatNext/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/webarkit/jsfeatNext/graph/badge.svg)](https://codecov.io/gh/webarkit/jsfeatNext)
 [![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/WebarkitO)](https://x.com/WebarkitO)
 
 # jsfeatNext 🚀

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,21 @@
+# Codecov configuration (follow-up to issue #123).
+#
+# Coverage in this repo is a GAP DETECTOR, not a gate — see vitest.config.ts.
+# Both statuses are informational: Codecov reports project and diff coverage
+# on every PR but can never fail one. The per-PR comment stays on because the
+# diff-coverage table (how much of the NEW code is exercised) is the one thing
+# the CI-printed summary cannot show.
+
+coverage:
+    status:
+        project:
+            default:
+                informational: true
+        patch:
+            default:
+                informational: true
+
+comment:
+    layout: "condensed_header, diff, files"
+    behavior: default
+    require_changes: true # stay silent on PRs that do not move coverage

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
             // coverage/coverage-summary.json (json-summary reporter) or the
             // HTML report, not a grep over the table.
             all: true,
-            reporter: ["text-summary", "text", "html"],
+            // lcov feeds the Codecov upload in CI; the others are for humans.
+            reporter: ["text-summary", "text", "html", "lcov"],
             reportsDirectory: "coverage",
         },
     },


### PR DESCRIPTION
## Summary

Follow-up to #123, whose step 4 deferred Codecov ("optional, decide after step 3") until the CI-printed summary existed. That landed in f24878a, so this adds the three missing pieces.

## What changed

| Piece | Why |
| --- | --- |
| `lcov` added to the coverage reporters | None of the existing reporters (`text-summary`, `text`, `html`) is ingestible by Codecov |
| `codecov/codecov-action@v5` step in CI | Uploads `coverage/lcov.info`, with `fail_ci_if_error: false` so an upload hiccup — or a fork PR without the token — can never fail the build |
| `codecov.yml` | Marks **both** the `project` and `patch` statuses `informational: true`: Codecov reports, never blocks |
| README badge | — |

## The policy from #123 is preserved

Coverage stays a **gap detector, not a gate**. Both Codecov statuses are informational precisely because #123 established the reasoning: all five defects found during #87 (#110, #111, #114, #119, #120) lived in code the suite already executed at 100%. A blocking percentage is how a suite full of shallow assertions gets written.

## What this actually buys

Per-PR **diff coverage** — how much of the *new* code a PR ships is exercised. That is the one thing the console summary cannot show, and it fits a repo where algorithm PRs are expected to arrive with their tests. Trend history and the badge are secondary.

`comment.require_changes: true` keeps Codecov silent on PRs that do not move coverage, so the bot does not add noise to docs-only changes.

## To activate

Needs **`CODECOV_TOKEN`** in the repo secrets. Without it the upload step is a no-op rather than a failure, so this PR is safe to merge before the token is set.

## Notes

- Verified locally: `lcov.info` is generated and contains all **35** `src/` files.
- If you inspect a locally-generated `lcov.info` on Windows, the `SF:` paths use backslashes (`src\index.ts`). That is a local artefact only — CI runs on ubuntu-24.04 and emits POSIX paths, which is what Codecov maps.
- `npm run test:coverage`: 265 tests green; `prettier --check` and `license-check` clean; `coverage/` stays gitignored.

Refs #123.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
