### PR TITLE
docs(readme): drop the broken Dependabot badge, note Dependabot in Contributing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 ![github stars](https://flat.badgen.net/github/stars/webarkit/jsfeatNext)
 ![github forks](https://flat.badgen.net/github/forks/webarkit/jsfeatNext)
 ![npm package version](https://flat.badgen.net/npm/v/@webarkit/jsfeat-next)
-![Dependabot Badge](https://flat.badgen.net/dependabot/@webarkit/jsfeat-next?icon=dependabot)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](https://github.com/prettier/prettier)
 [![CI](https://github.com/webarkit/jsfeatNext/actions/workflows/CI.yml/badge.svg)](https://github.com/webarkit/jsfeatNext/actions/workflows/CI.yml)
 [![codecov](https://codecov.io/gh/webarkit/jsfeatNext/graph/badge.svg)](https://codecov.io/gh/webarkit/jsfeatNext)
@@ -139,6 +138,8 @@ Every public class, interface, method and property has TSDoc comments. Run `npm 
 ## Contributing 🤝
 
 See [`AGENTS.md`](AGENTS.md) for the canonical contribution conventions (Conventional Commits, PRs target `dev` not `main`, numeric-parity expectations) and [`MAINTAINERS.md`](MAINTAINERS.md) for the release process.
+
+Dependencies and GitHub Actions are kept current by [Dependabot](https://docs.github.com/en/code-security/dependabot), which opens its own PRs against `dev` — they go through the same CI and review as any other change.
 
 ## Releases & changelog 📦
 


### PR DESCRIPTION
## Summary

The Dependabot badge had been rendering as a bare label with no icon. It turns out **it is not an icon problem** — the URL returns **HTTP 500** and the SVG literally reads `dependabot: 404`:

```
$ curl -sw "HTTP %{http_code}\n" "https://flat.badgen.net/dependabot/@webarkit/jsfeat-next?icon=dependabot"
HTTP 500
<title>dependabot: 404</title>
```

badgen's `/dependabot/` endpoint served the old standalone **Dependabot.com** service, which GitHub acquired and shut down. Dependabot is now built into GitHub and no longer exposes that API, so badgen gets a 404 upstream. **Not recoverable by changing the URL** — the data source no longer exists.

## Scope check: the rest of badgen is fine

Verified before touching anything, so no other badge needs changing:

| badge | result |
| --- | --- |
| `github/release` | HTTP 200 — `release: v0.13.0` |
| `github/stars` | HTTP 200 — `stars: 12` |
| `npm/v` | HTTP 200 — `npm: v0.13.0` |
| `dependabot` | **HTTP 500** |

(Nice side effect: the release and npm badges already show the fresh 0.13.0.)

## What replaces it

A sentence in **Contributing**, where it is information *for contributors* — explaining why automated PRs appear and that they follow the same CI and review as anything else — rather than decoration:

> Dependencies and GitHub Actions are kept current by [Dependabot](https://docs.github.com/en/code-security/dependabot), which opens its own PRs against `dev` — they go through the same CI and review as any other change.

"We use Dependabot" is not something a reader evaluating the library needs from a badge, unlike release / npm / CI / codecov, which each say something about project state. And a broken badge costs more credibility than a ninth working one would add.

Docs only — one line removed, one added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
