### PR TITLE
feat(bench): add detector benchmarks, surfacing a real YAPE slowdown (#86 phase 2)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -88,13 +88,58 @@ Judged **against the noise floor above**, not in isolation:
 
 Since jsfeatNext is a port of jsfeat, ratios near **1.0× are the expected, healthy state** — the two are doing the same arithmetic. A *sustained* move is interesting; a single-run move is not.
 
+## Open finding: the YAPE detectors are consistently slower
+
+The first real signal this harness produced. Measured on an idle machine
+(power connected, browser and editor closed), discarding the warm-up run:
+
+| case | run 1 | run 2 | verdict |
+| --- | --- | --- | --- |
+| `fast_corners` thr 20 | 1.06× | 1.07× | noise |
+| `fast_corners` thr 60 | 1.11× | 1.06× | noise |
+| **`yape06`** | **1.35×** | **1.37×** | **real** |
+| **`yape`** | **1.31×** | **1.33×** | **real** |
+
+All in jsfeat's favour. `fast_corners` sits under the ~1.15× floor, so it says
+nothing. `yape06` and `yape` are well outside it and reproduce to within
+±0.02 — that tightness is itself evidence: noise disperses, a real difference
+converges.
+
+Worth recording how this was established, because the first attempt got it
+wrong. An earlier measurement taken with a browser and editor open put
+`fast_corners` as high as 1.23× and `yape06` at 1.51×. On the idle machine
+`fast_corners` collapsed into the noise floor while the YAPE gap **held and
+tightened**. CPU contention had inflated everything; only one of the two
+findings survived. Follow the "clean measurement" steps above before believing
+any number here.
+
+It is not an algorithmic difference: corner counts are identical on both sides
+(26,016 / 12,919 / 49,258 / 149), so both do the same work.
+
+**Leading hypothesis — not proven.** jsfeat defines its per-pixel helpers as
+closures *inside* the module IIFE, in the same scope as `detect`:
+
+```js
+var hessian_min_eigen_value = function (src, off, tr, Dxx, Dyy, Dxy, Dyx) { … };
+```
+
+jsfeatNext imports the same helpers from a separate module (`yape06_utils.ts`).
+`hessian_min_eigen_value` runs once per candidate pixel — tens of thousands of
+times per frame — and a local closure is a far easier inlining target for V8
+than a cross-module import.
+
+Confirming this needs a profile, not a benchmark. The cheap experiment is to
+move the helper into the same module and see whether the gap closes; that is a
+change to `src/`, so it belongs in its own issue rather than here (#86 is
+measurement infrastructure and explicitly rules out micro-optimising).
+
 ## No results are committed
 
 There is deliberately no `bench/results/*.json` in the repo. A committed baseline invites exactly the cross-machine comparison described above, and produces noisy diffs on every run. The ratio is recomputed from scratch each time, which is what makes it trustworthy.
 
 If historical tracking is wanted later, the thing to store is the **ratio**, not the raw `hz`.
 
-## Current scope (phase 1)
+## Phase 1: imgproc and ORB
 
 | Case | Why it is here |
 | --- | --- |
@@ -104,7 +149,25 @@ If historical tracking is wanted later, the thing to store is the **ratio**, not
 | `resample` — float path | The non-U8 branch, bypassing fixed point |
 | `orb.describe` | The per-frame hot spot (~5 ms in the pinball sample). Structurally unlike the filters: per-keypoint cost, sparse access through a rotated patch warp |
 
-Later phases fill in the remaining modules (`fast_corners`, `yape`, `optical_flow_lk`, `linalg`, `motion_estimator`, the cache pool) one PR at a time.
+## Phase 2: detectors
+
+| Case | Why it is here |
+| --- | --- |
+| `fast_corners.detect` — threshold 20 (~26k corners) | The detector the ORB pipeline uses |
+| `fast_corners.detect` — threshold 60 (~13k corners) | Half the corners: separates per-pixel scan cost from per-corner cost |
+| `yape06.detect` (~49k corners) | The densest detector at these settings |
+| `yape.detect` — radius 5 (~149 corners) | Needs `init()`; a very different corner density from the others |
+
+Detector cost scales with the number of corners found, so the counts were
+verified identical on both sides before writing the benches — otherwise the
+ratio would compare workloads rather than implementations.
+
+A second comparison comes free here: all four run over the same image in the
+same process, so their `hz` are comparable **to each other** within a run.
+"yape06 costs N× fast_corners" is as portable as the jsfeat ratio.
+
+Later phases fill in the remaining modules (`optical_flow_lk`, `linalg`,
+`motion_estimator`, the cache pool) one PR at a time.
 
 ## Notes on the inputs
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -97,7 +97,7 @@ closed), each discarding a warm-up run:
 | case | session A | session B | direction | verdict |
 | --- | --- | --- | --- | --- |
 | `fast_corners` thr 20 | 1.02 / 1.06\* / 1.14 / 1.01\* | 1.08 / 1.06 / 1.01\* / 1.04 | flips | noise |
-| `fast_corners` thr 60 | 1.04 / 1.09 / 1.05\* / 1.08 | 1.06 / 1.05 / 1.11 / 1.10 | mostly jsfeat | below floor |
+| `fast_corners` thr 60 | 1.04 / 1.09 / 1.05\* / 1.08 | 1.06 / 1.05 / 1.11 / 1.10 | 7/8 jsfeat | below floor |
 | **`yape06`** | 1.30 / 1.33 / 1.38 / 1.27 | 1.45 / 1.35 / 1.11 / 1.32 | **always jsfeat** | **real** |
 | **`yape`** | 1.53 / 1.38 / 1.25 / 1.42 | 1.30 / 1.23 / 1.24 / 1.26 | **always jsfeat** | **real** |
 
@@ -115,9 +115,10 @@ not enough to characterise a spread, only a direction. Do not read a tight
 cluster within one session as precision.
 
 `fast_corners` at threshold 20 changes sign and is plain noise. Threshold 60 is
-more equivocal — it never favours jsfeatNext across eight samples, but never
-clears the ~1.15x floor either. Recorded as below-floor-but-directional rather
-than folded in with thr 20; it is not a finding, and it is not quite nothing.
+more equivocal — jsfeatNext wins once out of eight samples (marked \* above),
+jsfeat the other seven, and none of the eight clears the ~1.15x floor.
+Recorded as below-floor-but-directional rather than folded in with thr 20; it
+is not a finding, and it is not quite nothing.
 
 ### How this was established, including two wrong turns
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -90,37 +90,63 @@ Since jsfeatNext is a port of jsfeat, ratios near **1.0× are the expected, heal
 
 ## Open finding: the YAPE detectors are consistently slower
 
-The first real signal this harness produced. Measured on an idle machine
-(power connected, browser and editor closed), discarding the warm-up run:
+The first real signal this harness produced. Eight samples, pooled from two
+separate sessions on an idle machine (power connected, browser and editor
+closed), each discarding a warm-up run:
 
-| case | run 1 | run 2 | verdict |
-| --- | --- | --- | --- |
-| `fast_corners` thr 20 | 1.06× | 1.07× | noise |
-| `fast_corners` thr 60 | 1.11× | 1.06× | noise |
-| **`yape06`** | **1.35×** | **1.37×** | **real** |
-| **`yape`** | **1.31×** | **1.33×** | **real** |
+| case | session A | session B | direction | verdict |
+| --- | --- | --- | --- | --- |
+| `fast_corners` thr 20 | 1.02 / 1.06\* / 1.14 / 1.01\* | 1.08 / 1.06 / 1.01\* / 1.04 | flips | noise |
+| `fast_corners` thr 60 | 1.04 / 1.09 / 1.05\* / 1.08 | 1.06 / 1.05 / 1.11 / 1.10 | mostly jsfeat | below floor |
+| **`yape06`** | 1.30 / 1.33 / 1.38 / 1.27 | 1.45 / 1.35 / 1.11 / 1.32 | **always jsfeat** | **real** |
+| **`yape`** | 1.53 / 1.38 / 1.25 / 1.42 | 1.30 / 1.23 / 1.24 / 1.26 | **always jsfeat** | **real** |
 
-All in jsfeat's favour. `fast_corners` sits under the ~1.15× floor, so it says
-nothing. `yape06` and `yape` are well outside it and reproduce to within
-±0.02 — that tightness is itself evidence: noise disperses, a real difference
-converges.
+\* = jsfeatNext was the faster side in that run; every other figure favours
+jsfeat.
 
-Worth recording how this was established, because the first attempt got it
-wrong. An earlier measurement taken with a browser and editor open put
-`fast_corners` as high as 1.23× and `yape06` at 1.51×. On the idle machine
-`fast_corners` collapsed into the noise floor while the YAPE gap **held and
-tightened**. CPU contention had inflated everything; only one of the two
-findings survived. Follow the "clean measurement" steps above before believing
-any number here.
+`yape06` and `yape` favour jsfeat in **all eight** samples and sit around 1.3x.
+That consistency of *direction* is the evidence — not any single magnitude. The
+magnitudes are noisier than they first appeared: `yape06` spans 1.11 to 1.45
+and `yape` 1.23 to 1.53. Quote this as "roughly 1.3x", never to two decimals.
+
+Note which case is tight is **not stable between sessions**: session A had
+`yape06` clustered and `yape` spread, session B the reverse. Four samples are
+not enough to characterise a spread, only a direction. Do not read a tight
+cluster within one session as precision.
+
+`fast_corners` at threshold 20 changes sign and is plain noise. Threshold 60 is
+more equivocal — it never favours jsfeatNext across eight samples, but never
+clears the ~1.15x floor either. Recorded as below-floor-but-directional rather
+than folded in with thr 20; it is not a finding, and it is not quite nothing.
+
+### How this was established, including two wrong turns
+
+The first measurement was taken with a browser and editor open. It put
+`fast_corners` as high as 1.23x and `yape06` at 1.51x. On an idle machine
+`fast_corners` collapsed into the noise floor while the YAPE gap held: CPU
+contention had inflated everything, and only one of the two findings survived.
+
+The second was worse, because the harness itself was wrong. `set_threshold`
+mutates a singleton and was being called from the `describe` bodies, which
+Vitest runs during collection — so both `fast_corners` suites actually ran at
+threshold 60, and the case labelled "threshold 20" measured the same workload as
+its neighbour. The ratio stayed valid (both sides ran at 60), but one case was
+not measuring what it claimed to. Caught in review; see the `threshold()` helper
+in `detectors.bench.ts` for the fix and why the obvious alternatives do not work.
+
+That episode also cost an over-confident claim: an earlier version of this
+section reported the YAPE ratios as reproducing "to within +/-0.02". That was
+two samples. Eight give a range roughly ten times wider. The finding survived;
+the precision claim did not.
 
 It is not an algorithmic difference: corner counts are identical on both sides
 (26,016 / 12,919 / 49,258 / 149), so both do the same work.
 
-**Leading hypothesis — not proven.** jsfeat defines its per-pixel helpers as
+**Leading hypothesis - not proven.** jsfeat defines its per-pixel helpers as
 closures *inside* the module IIFE, in the same scope as `detect`:
 
 ```js
-var hessian_min_eigen_value = function (src, off, tr, Dxx, Dyy, Dxy, Dyx) { … };
+var hessian_min_eigen_value = function (src, off, tr, Dxx, Dyy, Dxy, Dyx) { ... };
 ```
 
 jsfeatNext imports the same helpers from a separate module (`yape06_utils.ts`).

--- a/bench/detectors.bench.ts
+++ b/bench/detectors.bench.ts
@@ -82,6 +82,20 @@ const W = 640;
 const H = 480;
 const BORDER = 20;
 
+/**
+ * Keypoint pool size, shared by every case.
+ *
+ * Sized to the densest detector here (yape06, 49,258) plus ~20% headroom, not
+ * to the image. `detect` writes `corners[i]` with no length check, so an
+ * undersized pool throws rather than truncating — an overrun still fails
+ * loudly, it just fails at 60k instead of 307k.
+ *
+ * Image-sized pools (W * H = 307,200 each) would allocate ~2.4M keypoint
+ * objects across the four suites for a workload whose worst case needs 49,258.
+ * That is GC pressure inside a performance measurement, for no coverage.
+ */
+const POOL = 60000;
+
 /** The same deterministic noise on both sides. */
 function pair() {
     const next = noiseImage(W, H, 4242);
@@ -90,49 +104,80 @@ function pair() {
     return { next, orig };
 }
 
+/**
+ * `fast_corners.set_threshold` mutates the singleton, so it CANNOT be called
+ * from a `describe` body: Vitest runs every `describe` callback during
+ * collection, before any `bench` callback runs. The last assignment in the file
+ * would win and every case would silently measure that one threshold.
+ *
+ * Nor can it go in `beforeAll` — Vitest's bench mode does not run the standard
+ * test hooks at all, so the call would simply never happen and both cases would
+ * run at the constructor default.
+ *
+ * `bench`'s own `setup` option is the one that works. It runs once per mode
+ * (warmup, then run) rather than per iteration, so it costs nothing inside the
+ * timed region.
+ */
+function threshold(thr: number) {
+    return {
+        setup: () => {
+            jsfeatNext.fast_corners.set_threshold(thr);
+            jsfeat.fast_corners.set_threshold(thr);
+        },
+    };
+}
+
 describe("fast_corners.detect — threshold 20 (~26k corners)", () => {
     const { next, orig } = pair();
-    // Pools are allocated once, outside the timed region, and sized to the
-    // image: detect() writes corners[i] with no length check, so an undersized
-    // pool throws rather than truncating.
-    const poolN = keypointPool(W * H);
-    const poolO = keypointPool(W * H);
+    // Pools are allocated once, outside the timed region.
+    const poolN = keypointPool(POOL);
+    const poolO = keypointPool(POOL);
 
-    jsfeatNext.fast_corners.set_threshold(20);
-    jsfeat.fast_corners.set_threshold(20);
+    bench(
+        "jsfeatNext",
+        () => {
+            jsfeatNext.fast_corners.detect(next, poolN, BORDER);
+        },
+        threshold(20)
+    );
 
-    bench("jsfeatNext", () => {
-        jsfeatNext.fast_corners.detect(next, poolN, BORDER);
-    });
-
-    bench("jsfeat (reference)", () => {
-        jsfeat.fast_corners.detect(orig, poolO, BORDER);
-    });
+    bench(
+        "jsfeat (reference)",
+        () => {
+            jsfeat.fast_corners.detect(orig, poolO, BORDER);
+        },
+        threshold(20)
+    );
 });
 
 describe("fast_corners.detect — threshold 60 (~13k corners)", () => {
     // Half the corners of the case above: separates the per-pixel scan cost
     // from the per-corner cost, which the single-threshold case conflates.
     const { next, orig } = pair();
-    const poolN = keypointPool(W * H);
-    const poolO = keypointPool(W * H);
+    const poolN = keypointPool(POOL);
+    const poolO = keypointPool(POOL);
 
-    jsfeatNext.fast_corners.set_threshold(60);
-    jsfeat.fast_corners.set_threshold(60);
+    bench(
+        "jsfeatNext",
+        () => {
+            jsfeatNext.fast_corners.detect(next, poolN, BORDER);
+        },
+        threshold(60)
+    );
 
-    bench("jsfeatNext", () => {
-        jsfeatNext.fast_corners.detect(next, poolN, BORDER);
-    });
-
-    bench("jsfeat (reference)", () => {
-        jsfeat.fast_corners.detect(orig, poolO, BORDER);
-    });
+    bench(
+        "jsfeat (reference)",
+        () => {
+            jsfeat.fast_corners.detect(orig, poolO, BORDER);
+        },
+        threshold(60)
+    );
 });
 
 describe("yape06.detect (~49k corners)", () => {
     const { next, orig } = pair();
-    const poolN = keypointPool(W * H);
-    const poolO = keypointPool(W * H);
+    const poolN = keypointPool(POOL);
+    const poolO = keypointPool(POOL);
 
     bench("jsfeatNext", () => {
         jsfeatNext.yape06.detect(next, poolN, BORDER);
@@ -144,11 +189,12 @@ describe("yape06.detect (~49k corners)", () => {
 });
 
 describe("yape.detect — radius 5 (~149 corners)", () => {
-    // yape needs init() to size its internal buffers; done once here, outside
-    // the timed region, mirroring examples/sample_yape.html (radius 5, 1 level).
+    // yape needs init() to size its internal buffers. Unlike set_threshold this
+    // is safe in the describe body: both sides are initialised to the same
+    // dimensions, so collection-order clobbering is a no-op here.
     const { next, orig } = pair();
-    const poolN = keypointPool(W * H);
-    const poolO = keypointPool(W * H);
+    const poolN = keypointPool(POOL);
+    const poolO = keypointPool(POOL);
 
     jsfeatNext.yape.init(W, H, 5, 1);
     jsfeat.yape.init(W, H, 5, 1);

--- a/bench/detectors.bench.ts
+++ b/bench/detectors.bench.ts
@@ -1,0 +1,163 @@
+/*
+ *  detectors.bench.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { bench, describe } from "vitest";
+import jsfeatNext from "../src/jsfeatNext";
+import jsfeat from "../tests/vendor/oracle.cjs";
+import { noiseImage, keypointPool } from "../tests/properties/helpers";
+
+/**
+ * Throughput benchmarks for the corner detectors (issue #86, phase 2).
+ *
+ * Read the RATIO, not the `hz` — see bench/README.md for why, and for the
+ * measured noise floor (ignore anything under ~1.15x).
+ *
+ * ## Both sides must do the same work
+ *
+ * Detector cost scales with how many corners are found, so a bench that let the
+ * two implementations detect different counts would be comparing workloads, not
+ * implementations. Verified before writing this file, on this exact input:
+ *
+ *   fast_corners  threshold 20 -> 26,016 vs 26,016
+ *   fast_corners  threshold 60 -> 12,919 vs 12,919
+ *   yape06                     -> 49,258 vs 49,258
+ *   yape          radius 5     ->    149 vs 149
+ *
+ * Identical on both sides in every case, so the ratio is meaningful.
+ *
+ * ## Why noise rather than cornerScene
+ *
+ * cornerScene is built for the correctness tests — a handful of clean shapes —
+ * and yields only ~27 corners at border 20, so the bench would mostly time call
+ * overhead. Seeded noise is dense texture: tens of thousands of corners, i.e. a
+ * detector actually doing detector work.
+ *
+ * ## A second, portable comparison
+ *
+ * Because all three detectors run over the same image in the same process,
+ * their `hz` values are comparable *to each other* within a run. "yape06 costs
+ * N x fast_corners" is as portable as the jsfeat ratio, and is the interesting
+ * number when choosing a detector for a frame budget.
+ */
+
+const OU8C1 = jsfeat.U8_t | jsfeat.C1_t;
+
+// 640x480: the webcam frame size the WebAR examples run at.
+const W = 640;
+const H = 480;
+const BORDER = 20;
+
+/** The same deterministic noise on both sides. */
+function pair() {
+    const next = noiseImage(W, H, 4242);
+    const orig = new jsfeat.matrix_t(W, H, OU8C1);
+    orig.data.set(next.data);
+    return { next, orig };
+}
+
+describe("fast_corners.detect — threshold 20 (~26k corners)", () => {
+    const { next, orig } = pair();
+    // Pools are allocated once, outside the timed region, and sized to the
+    // image: detect() writes corners[i] with no length check, so an undersized
+    // pool throws rather than truncating.
+    const poolN = keypointPool(W * H);
+    const poolO = keypointPool(W * H);
+
+    jsfeatNext.fast_corners.set_threshold(20);
+    jsfeat.fast_corners.set_threshold(20);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.fast_corners.detect(next, poolN, BORDER);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.fast_corners.detect(orig, poolO, BORDER);
+    });
+});
+
+describe("fast_corners.detect — threshold 60 (~13k corners)", () => {
+    // Half the corners of the case above: separates the per-pixel scan cost
+    // from the per-corner cost, which the single-threshold case conflates.
+    const { next, orig } = pair();
+    const poolN = keypointPool(W * H);
+    const poolO = keypointPool(W * H);
+
+    jsfeatNext.fast_corners.set_threshold(60);
+    jsfeat.fast_corners.set_threshold(60);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.fast_corners.detect(next, poolN, BORDER);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.fast_corners.detect(orig, poolO, BORDER);
+    });
+});
+
+describe("yape06.detect (~49k corners)", () => {
+    const { next, orig } = pair();
+    const poolN = keypointPool(W * H);
+    const poolO = keypointPool(W * H);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.yape06.detect(next, poolN, BORDER);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.yape06.detect(orig, poolO, BORDER);
+    });
+});
+
+describe("yape.detect — radius 5 (~149 corners)", () => {
+    // yape needs init() to size its internal buffers; done once here, outside
+    // the timed region, mirroring examples/sample_yape.html (radius 5, 1 level).
+    const { next, orig } = pair();
+    const poolN = keypointPool(W * H);
+    const poolO = keypointPool(W * H);
+
+    jsfeatNext.yape.init(W, H, 5, 1);
+    jsfeat.yape.init(W, H, 5, 1);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.yape.detect(next, poolN, 5);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.yape.detect(orig, poolO, 5);
+    });
+});

--- a/bench/detectors.bench.ts
+++ b/bench/detectors.bench.ts
@@ -127,11 +127,33 @@ function threshold(thr: number) {
     };
 }
 
+/**
+ * `detect`'s return value is discarded inside every timed `bench` callback --
+ * checking it there would put a branch inside the measured region. Instead,
+ * call once outside the timed region, with a scratch pool, and assert both
+ * implementations agree. If a future change makes them diverge, this throws
+ * during collection rather than silently reporting a ratio for two different
+ * workloads.
+ */
+function assertEqualCounts(name: string, next: number, orig: number) {
+    if (next !== orig) {
+        throw new Error(`${name}: jsfeatNext found ${next} corners, jsfeat found ${orig}`);
+    }
+}
+
 describe("fast_corners.detect — threshold 20 (~26k corners)", () => {
     const { next, orig } = pair();
     // Pools are allocated once, outside the timed region.
     const poolN = keypointPool(POOL);
     const poolO = keypointPool(POOL);
+
+    jsfeatNext.fast_corners.set_threshold(20);
+    jsfeat.fast_corners.set_threshold(20);
+    assertEqualCounts(
+        "fast_corners thr 20",
+        jsfeatNext.fast_corners.detect(next, keypointPool(POOL), BORDER),
+        jsfeat.fast_corners.detect(orig, keypointPool(POOL), BORDER)
+    );
 
     bench(
         "jsfeatNext",
@@ -157,6 +179,14 @@ describe("fast_corners.detect — threshold 60 (~13k corners)", () => {
     const poolN = keypointPool(POOL);
     const poolO = keypointPool(POOL);
 
+    jsfeatNext.fast_corners.set_threshold(60);
+    jsfeat.fast_corners.set_threshold(60);
+    assertEqualCounts(
+        "fast_corners thr 60",
+        jsfeatNext.fast_corners.detect(next, keypointPool(POOL), BORDER),
+        jsfeat.fast_corners.detect(orig, keypointPool(POOL), BORDER)
+    );
+
     bench(
         "jsfeatNext",
         () => {
@@ -179,6 +209,12 @@ describe("yape06.detect (~49k corners)", () => {
     const poolN = keypointPool(POOL);
     const poolO = keypointPool(POOL);
 
+    assertEqualCounts(
+        "yape06",
+        jsfeatNext.yape06.detect(next, keypointPool(POOL), BORDER),
+        jsfeat.yape06.detect(orig, keypointPool(POOL), BORDER)
+    );
+
     bench("jsfeatNext", () => {
         jsfeatNext.yape06.detect(next, poolN, BORDER);
     });
@@ -198,6 +234,12 @@ describe("yape.detect — radius 5 (~149 corners)", () => {
 
     jsfeatNext.yape.init(W, H, 5, 1);
     jsfeat.yape.init(W, H, 5, 1);
+
+    assertEqualCounts(
+        "yape r5",
+        jsfeatNext.yape.detect(next, keypointPool(POOL), 5),
+        jsfeat.yape.detect(orig, keypointPool(POOL), 5)
+    );
 
     bench("jsfeatNext", () => {
         jsfeatNext.yape.detect(next, poolN, 5);


### PR DESCRIPTION
## Summary

Phase 2 of #86, first module group: **`fast_corners`** (two thresholds), **`yape06`** and **`yape`**, all as A/B ratios against the vendored jsfeat oracle. No changes to `src/`.

## Both sides must do the same work

Detector cost scales with how many corners are found, so a bench that let the two implementations detect different counts would compare *workloads*, not implementations. Verified before writing anything, on this exact input:

| case | jsfeatNext | jsfeat |
| --- | --- | --- |
| `fast_corners` thr 20 | 26,016 | 26,016 |
| `fast_corners` thr 60 | 12,919 | 12,919 |
| `yape06` | 49,258 | 49,258 |
| `yape` radius 5 | 149 | 149 |

Identical everywhere. Each suite now also asserts this equality once, outside the timed region (`assertEqualCounts`) — a future divergence throws during collection rather than silently reporting a ratio for two different workloads (caught in review).

## ⚠️ This produced the harness's first real finding

Eight samples, pooled from two idle-machine sessions (power connected, browser and editor closed), each discarding a warm-up run:

| case | direction | verdict |
| --- | --- | --- |
| `fast_corners` thr 20 | flips | noise |
| `fast_corners` thr 60 | 7/8 jsfeat | below floor |
| **`yape06`** | **8/8 jsfeat, ~1.3x** | **real** |
| **`yape`** | **8/8 jsfeat, ~1.3x** | **real** |

`yape06` and `yape` favour jsfeat in every sample and sit around 1.3x — that consistency of *direction* is the evidence. The magnitudes are noisier than first reported: `yape06` spans 1.11–1.45, `yape` spans 1.23–1.53. Full table and per-sample data in `bench/README.md`.

**Correction from an earlier version of this PR:** the first two-sample measurement claimed the YAPE ratios reproduced "to within ±0.02". That was two samples. Eight give a much wider range — the finding survives, the precision claim did not. Recorded as a caught mistake in the README rather than quietly fixed, so the episode is visible to whoever reads it next.

### Two measurement episodes worth reading before trusting any number here

A first attempt, taken with a browser and editor open, put `fast_corners` as high as **1.23×** and `yape06` at **1.51×**. On an idle machine `fast_corners` collapsed into the noise floor while the YAPE gap held — CPU contention had inflated everything, and only one of the two apparent findings survived.

A second attempt was invalidated by a harness bug, caught in review: `set_threshold` mutates a singleton and was being called from `describe` bodies, which Vitest runs entirely during collection, before any `bench` callback. The last assignment in the file won, so both `fast_corners` suites actually ran at threshold 60 — the case labelled "threshold 20" was measuring its neighbour's workload. Fixed with `bench()`'s own `setup` option, which runs once per mode (warmup, then run) rather than per iteration.

Both episodes, and why the obvious "fixes" (`beforeAll`, image-sized pools) don't work, are recorded in `bench/README.md`.

### Leading hypothesis — not proven

Not algorithmic: identical corner counts, now asserted, mean both sides do the same work.

jsfeat defines its per-pixel helpers as closures *inside* the module IIFE, in the same scope as `detect`:

```js
var hessian_min_eigen_value = function (src, off, tr, Dxx, Dyy, Dxy, Dyx) { … };
```

jsfeatNext imports the same helpers from a separate module (`yape06_utils.ts`). `hessian_min_eigen_value` runs **once per candidate pixel** — tens of thousands of times per frame — and a local closure is a far easier inlining target for V8 than a cross-module import.

Confirming this needs a **profile, not a benchmark**, and the fix would touch `src/`. So it is recorded in `bench/README.md` as an open finding for its own issue rather than acted on here: **#86 is measurement infrastructure and explicitly rules out micro-optimising anything.**

## A second comparison, free

All four detectors run over the same image in the same process, so their `hz` are comparable **to each other** within a run.

## Pool sizing

Pools were originally sized to the image (`W * H`), allocating ~2.4M keypoint objects across the four suites for a workload whose densest case needs 49,258 — avoidable GC pressure inside a performance measurement (caught in review). Replaced with a single `POOL = 60000` constant, headroom over the densest case; `detect()` still has no length check, so an overrun still throws.

## Verification

`npm test`: **265 passed** (benchmarks stay out of the test run). `tsc --noEmit`, `prettier --check`, `license-check` (87 files) all clean. Bench suite smoke-tested: assertions pass, ratios report normally.

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
