### PR TITLE
feat(bench): add motion_estimator throughput benchmarks

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -193,8 +193,7 @@ A second comparison comes free here: all four run over the same image in the
 same process, so their `hz` are comparable **to each other** within a run.
 "yape06 costs N× fast_corners" is as portable as the jsfeat ratio.
 
-Later phases fill in the remaining modules (`motion_estimator`, the cache
-pool) one PR at a time.
+Later phases fill in the remaining modules (the cache pool) one PR at a time.
 
 ## Phase 2, continued: optical_flow_lk
 
@@ -264,6 +263,60 @@ a throughput cost jsfeat's closure-per-module style does not, on hot paths
 called thousands of times per frame. Recorded here as an open finding for a
 future issue, same as YAPE — confirming it needs a profile, and any fix would
 touch `src/`, which #86 explicitly rules out doing here.
+
+**Update:** profiled (not just theorized) — see
+[#159](https://github.com/webarkit/jsfeatNext/issues/159). The `this.cache`
+dispatch hypothesis above turned out to be wrong (0.1% of self-time in
+`svd_invert`); the real cost is `matrix_t` re-allocating a `data_type` lookup
+table on every construction. `lu_solve`/`cholesky_solve`'s slowdown is *not*
+explained by that fix, since neither constructs any internal `matrix_t`.
+
+## Phase 2, continued: motion_estimator
+
+| Case | Why it is here |
+| --- | --- |
+| `motion_estimator.ransac` (homography2d, 40 points, 6 outliers) | The real per-frame call — `examples/sample_orb.html` fits a homography from ORB matches this way every frame |
+| `motion_estimator.lmeds` (homography2d, 40 points, 6 outliers) | Same kernel, different iteration-acceptance rule (median residual instead of a threshold) |
+
+Scoped to `ransac`/`lmeds` only — `get_subset`/`find_inliers` are internal
+helpers the two call every iteration, and benching them standalone would time
+a workload nobody calls directly. `homography2d` rather than `affine2d`: it's
+the same 8-DOF kernel the `linalg` finding above traces back to, keeping the
+two findings comparable. Input is `tests/parity/motion_estimator.test.ts`'s
+own fixture (40 correspondences, 6 gross outliers, fixed ground-truth
+homography), already proven to converge identically on both sides — not a
+shape invented for this bench.
+
+RANSAC/LMEDS draw a random subset every iteration via `Math.random`, so both
+sides need to draw the *same* subsets or the ratio compares different amounts
+of work. `bench()`'s `setup` option reseeds a deterministic generator once
+per mode (not per call, unlike the parity test) — enough by induction, since
+identical inputs and identical RNG state make a faithful port consume an
+identical number of random draws, keeping both streams in lockstep for the
+whole run. See the file's docstring for the full argument.
+
+Four runs on an idle machine, discarding a warm-up:
+
+| case | r1 | r2 | r3 | r4 | verdict |
+| --- | --- | --- | --- | --- | --- |
+| **`ransac`** | **1.42** | **1.44** | **1.41** | **1.43** | **real, very tight** |
+| `lmeds` | 3.09 | 1.32 | 1.02 | 1.30 | real, noisy, one large outlier |
+
+`ransac` is as tight as `svd_invert` from the `linalg` finding — jsfeat
+consistently ~1.4x faster, four runs spanning barely 0.03x. `lmeds` favours
+jsfeat in every sample too, but with real spread even ignoring the 3.09x
+outlier (1.02–1.32, wider than anything else measured so far in this suite).
+Reported rather than investigated further here — like the `svd_decompose`
+outlier in the `linalg` section above, discarding it without a stated cause
+(unlike the CPU-contention runs discarded elsewhere in this file, which had
+one) would be cherry-picking.
+
+Not yet profiled. Given `ransac`'s magnitude and tightness closely match
+`svd_invert`'s, and `motion_estimator.ransac`/`lmeds` call `homography2d.run`
+(`motion_model.ts`), which in turn calls `linalg.eigenVV` — the #159 fix,
+once it lands, is a plausible candidate to shrink this finding too, but that
+is a hypothesis to check by re-running this bench after #159, not a claim
+made now.
 
 ## Notes on the inputs
 

--- a/bench/motion_estimator.bench.ts
+++ b/bench/motion_estimator.bench.ts
@@ -36,7 +36,7 @@
  *
  */
 
-import { bench, describe, afterAll } from "vitest";
+import { bench, describe } from "vitest";
 import jsfeatNext from "../src/jsfeatNext";
 import jsfeat from "../tests/vendor/oracle.cjs";
 import { point_t } from "../src/point_t/point_t";
@@ -88,8 +88,18 @@ import { rng } from "../tests/properties/helpers";
  * never need to be re-synchronized because they never have a chance to drift
  * apart in the first place. (A plain reassignment is used rather than
  * `vi.spyOn` so the once-per-mode reset stays cheap and outside the timed
- * region either way.) The original `Math.random` is restored in `afterAll`
- * so a stubbed RNG never leaks into another bench file sharing this worker.
+ * region either way.)
+ *
+ * The original `Math.random` is restored via each `bench()` call's own
+ * `teardown` option, NOT a Vitest suite hook (`afterAll`/`afterEach`):
+ * Vitest's bench mode does not run standard test hooks at all (see
+ * `bench/detectors.bench.ts`'s docstring on why `beforeAll` doesn't work for
+ * `set_threshold`) — an earlier version of this file relied on `afterAll`
+ * for this exact cleanup and it silently never ran, leaving `Math.random`
+ * stubbed for any bench file sharing this worker afterwards (caught in
+ * review). `teardown` is tinybench's own option, symmetric to `setup` and
+ * verified to fire the same way: once per mode, after that mode's
+ * iterations finish.
  *
  * ## Input: the parity suite's own fixture, not a new one
  *
@@ -149,9 +159,6 @@ function makeCorrespondences(seed: number) {
 }
 
 const originalRandom = Math.random;
-afterAll(() => {
-    Math.random = originalRandom;
-});
 
 describe("motion_estimator.ransac (homography2d, 40 points, 6 outliers)", () => {
     const { from, to } = makeCorrespondences(1234);
@@ -174,6 +181,9 @@ describe("motion_estimator.ransac (homography2d, 40 points, 6 outliers)", () => 
             setup: () => {
                 Math.random = rng(2024);
             },
+            teardown: () => {
+                Math.random = originalRandom;
+            },
         }
     );
 
@@ -185,6 +195,9 @@ describe("motion_estimator.ransac (homography2d, 40 points, 6 outliers)", () => 
         {
             setup: () => {
                 Math.random = rng(2024);
+            },
+            teardown: () => {
+                Math.random = originalRandom;
             },
         }
     );
@@ -211,6 +224,9 @@ describe("motion_estimator.lmeds (homography2d, 40 points, 6 outliers)", () => {
             setup: () => {
                 Math.random = rng(777);
             },
+            teardown: () => {
+                Math.random = originalRandom;
+            },
         }
     );
 
@@ -222,6 +238,9 @@ describe("motion_estimator.lmeds (homography2d, 40 points, 6 outliers)", () => {
         {
             setup: () => {
                 Math.random = rng(777);
+            },
+            teardown: () => {
+                Math.random = originalRandom;
             },
         }
     );

--- a/bench/motion_estimator.bench.ts
+++ b/bench/motion_estimator.bench.ts
@@ -1,0 +1,228 @@
+/*
+ *  motion_estimator.bench.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { bench, describe, afterAll } from "vitest";
+import jsfeatNext from "../src/jsfeatNext";
+import jsfeat from "../tests/vendor/oracle.cjs";
+import { point_t } from "../src/point_t/point_t";
+import { rng } from "../tests/properties/helpers";
+
+/**
+ * Throughput benchmarks for `motion_estimator.ransac` / `.lmeds` with the
+ * `homography2d` kernel (issue #86, phase 2 continued).
+ *
+ * Read the RATIO, not the `hz` — see bench/README.md for why, and for the
+ * measured noise floor (ignore anything under ~1.15x).
+ *
+ * ## Scope: ransac/lmeds only, not get_subset/find_inliers
+ *
+ * `motion_estimator` has four public methods. `get_subset` and `find_inliers`
+ * are internal helpers `ransac`/`lmeds` call on every iteration; benching them
+ * standalone would time an artificial workload nobody calls directly.
+ * `ransac`/`lmeds` are the real per-frame hot path (`examples/sample_orb.html`
+ * calls `motion_estimator.ransac` once per frame to fit the homography from
+ * ORB matches), so those are what this file measures.
+ *
+ * `homography2d` rather than `affine2d`: it is the 8-DOF kernel `linalg`'s
+ * finding (#158, #159) traces back to via `motion_model.ts`'s `mLtL`, so
+ * benching it here keeps the two findings comparable.
+ *
+ * ## Both sides must draw the same "random" subsets
+ *
+ * RANSAC/LMEDS pick a random minimal-sample subset every iteration via
+ * `Math.random`, and how many iterations converge depends on which points
+ * that draws. If the two sides drew different subsets, the ratio would
+ * compare different amounts of work, not the two implementations — the same
+ * failure mode `bench/detectors.bench.ts`'s `assertEqualCounts` guards
+ * against, just at the RNG level instead of the input level.
+ *
+ * `tests/parity/motion_estimator.test.ts` solves this by re-seeding
+ * `Math.random` with the same deterministic generator on both sides
+ * immediately before each of its two calls (one per implementation). This
+ * file reuses the same seeds via `bench()`'s `setup` option instead, which
+ * only runs once per mode (warmup, then run) — NOT before every timed
+ * iteration, unlike the parity test's per-call reset.
+ *
+ * That is still enough to keep both sides doing the same work, by induction:
+ * `run` mode's first timed call starts from an identical freshly-seeded
+ * generator on both sides. Given identical inputs and an identical RNG
+ * state, a faithful port produces identical output (the parity test already
+ * proves this to 5 decimal places) and therefore consumes an identical
+ * number of `Math.random()` draws — so the *next* call also starts from
+ * matching state on both sides, and so on for the whole run. The two streams
+ * never need to be re-synchronized because they never have a chance to drift
+ * apart in the first place. (A plain reassignment is used rather than
+ * `vi.spyOn` so the once-per-mode reset stays cheap and outside the timed
+ * region either way.) The original `Math.random` is restored in `afterAll`
+ * so a stubbed RNG never leaks into another bench file sharing this worker.
+ *
+ * ## Input: the parity suite's own fixture, not a new one
+ *
+ * 40 correspondences, 6 gross outliers, synthesized from a fixed ground-truth
+ * homography — `tests/parity/motion_estimator.test.ts`'s exact setup, already
+ * proven to converge identically on both sides. Reusing it here means this
+ * bench's workload is provably realistic rather than a shape invented for
+ * throughput measurement.
+ */
+
+const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
+const U8C1 = jsfeatNext.U8_t | jsfeatNext.C1_t;
+const OF32C1 = jsfeat.F32_t | jsfeat.C1_t;
+const OU8C1 = jsfeat.U8_t | jsfeat.C1_t;
+
+const N = 40;
+const OUTLIERS = 6;
+/** Ground-truth homography used to synthesize correspondences. */
+const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+
+/**
+ * `motion_model.ts` only ever reads `.x`/`.y` off these points (verified —
+ * `level`/`score`/`angle` are dead weight for this kernel), but `point_t`
+ * requires them, and its constructor leaves fields unset by design (points
+ * are meant to be written directly in hot detector loops, not constructed
+ * per-point) — so they're filled here with the same "not computed" values
+ * `fast_corners`/`orb` use elsewhere in this repo.
+ */
+function point(x: number, y: number) {
+    const p = new point_t();
+    p.x = x;
+    p.y = y;
+    p.level = 0;
+    p.score = 0;
+    p.angle = -1;
+    return p;
+}
+
+function makeCorrespondences(seed: number) {
+    const rand = rng(seed);
+    const from: ReturnType<typeof point>[] = [];
+    const to: ReturnType<typeof point>[] = [];
+    for (let i = 0; i < N; i++) {
+        const x = 10 + rand() * 300;
+        const y = 10 + rand() * 220;
+        const wsc = 1.0 / (GT[6] * x + GT[7] * y + GT[8]);
+        let X = (GT[0] * x + GT[1] * y + GT[2]) * wsc;
+        let Y = (GT[3] * x + GT[4] * y + GT[5]) * wsc;
+        if (i < OUTLIERS) {
+            X += 40 + rand() * 60;
+            Y -= 40 + rand() * 60;
+        }
+        from.push(point(x, y));
+        to.push(point(X, Y));
+    }
+    return { from, to };
+}
+
+const originalRandom = Math.random;
+afterAll(() => {
+    Math.random = originalRandom;
+});
+
+describe("motion_estimator.ransac (homography2d, 40 points, 6 outliers)", () => {
+    const { from, to } = makeCorrespondences(1234);
+
+    const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+    const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+    const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+
+    const paramsO = new jsfeat.ransac_params_t(4, 3.0, 0.5, 0.99);
+    const kernelO = new jsfeat.motion_model.homography2d();
+    const modelO = new jsfeat.matrix_t(3, 3, OF32C1);
+    const maskO = new jsfeat.matrix_t(N, 1, OU8C1);
+
+    bench(
+        "jsfeatNext",
+        () => {
+            jsfeatNext.motion_estimator.ransac(params, jsfeatNext.homography2d, from, to, N, model, mask, 1000);
+        },
+        {
+            setup: () => {
+                Math.random = rng(2024);
+            },
+        }
+    );
+
+    bench(
+        "jsfeat (reference)",
+        () => {
+            jsfeat.motion_estimator.ransac(paramsO, kernelO, from, to, N, modelO, maskO, 1000);
+        },
+        {
+            setup: () => {
+                Math.random = rng(2024);
+            },
+        }
+    );
+});
+
+describe("motion_estimator.lmeds (homography2d, 40 points, 6 outliers)", () => {
+    const { from, to } = makeCorrespondences(1234);
+
+    const params = new jsfeatNext.ransac_params_t(4, 0, 0.45, 0.99);
+    const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+    const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+
+    const paramsO = new jsfeat.ransac_params_t(4, 0, 0.45, 0.99);
+    const kernelO = new jsfeat.motion_model.homography2d();
+    const modelO = new jsfeat.matrix_t(3, 3, OF32C1);
+    const maskO = new jsfeat.matrix_t(N, 1, OU8C1);
+
+    bench(
+        "jsfeatNext",
+        () => {
+            jsfeatNext.motion_estimator.lmeds(params, jsfeatNext.homography2d, from, to, N, model, mask, 1000);
+        },
+        {
+            setup: () => {
+                Math.random = rng(777);
+            },
+        }
+    );
+
+    bench(
+        "jsfeat (reference)",
+        () => {
+            jsfeat.motion_estimator.lmeds(paramsO, kernelO, from, to, N, modelO, maskO, 1000);
+        },
+        {
+            setup: () => {
+                Math.random = rng(777);
+            },
+        }
+    );
+});


### PR DESCRIPTION
## Summary

Phase 2 of #86, continued: `motion_estimator.ransac` and `.lmeds` with the `homography2d` kernel — the real per-frame call `examples/sample_orb.html` makes to fit a homography from ORB matches. No changes to `src/`.

## Scope: ransac/lmeds only

`motion_estimator` has four public methods. `get_subset`/`find_inliers` are internal helpers `ransac`/`lmeds` call every iteration — benching them standalone would time a workload nobody calls directly. `homography2d` rather than `affine2d`: it's the same 8-DOF kernel the `linalg` finding (#158/#159) traces back to via `motion_model.ts`, keeping the two findings comparable.

## Input and the RNG problem

Reuses `tests/parity/motion_estimator.test.ts`'s own fixture (40 correspondences, 6 gross outliers, fixed ground-truth homography) — already proven to converge identically on both sides, not a shape invented for this bench.

RANSAC/LMEDS draw a random minimal-sample subset every iteration via `Math.random`. If the two sides drew different subsets, the ratio would compare different amounts of work — the same failure mode `assertEqualCounts` (#155/#156) guards against, at the RNG level instead of the input level.

The parity test solves this by reseeding `Math.random` immediately before each of its two calls. This file reuses the same seeds via `bench()`'s `setup` option instead, which only runs once per mode (warmup, then run) — not per timed iteration. The file's docstring works through why that's still enough by induction: `run` mode's first call starts from identical state on both sides; identical inputs + identical RNG state make a faithful port consume an identical number of `Math.random()` draws (the parity test already proves output matches to 5 decimal places); so the *next* call also starts in sync, and so on for the whole run — the streams never get a chance to drift apart.

(Caught while writing this: `point_t`'s constructor leaves fields unset by design — points are meant to be written directly in hot detector loops — so `level`/`score`/`angle` need explicit "not computed" values even though `homography2d`'s kernel never reads them, verified from `motion_model.ts`.)

## Result

Four runs on an idle machine, discarding a warm-up:

| case | r1 | r2 | r3 | r4 | verdict |
| --- | --- | --- | --- | --- | --- |
| **`ransac`** | **1.42** | **1.44** | **1.41** | **1.43** | **real, very tight** |
| `lmeds` | 3.09 | 1.32 | 1.02 | 1.30 | real, noisy, one large outlier |

`ransac` is as tight as `svd_invert` from #158 — jsfeat consistently ~1.4x faster across four runs spanning barely 0.03x. `lmeds` favours jsfeat every time too, but with real spread even setting the 3.09x aside (1.02–1.32x). Reported rather than investigated further, per this suite's own discipline against discarding inconvenient samples without a stated cause.

Neither case has been profiled. Both `ransac` and `lmeds` call `homography2d.run` → `linalg.eigenVV` internally, so #159's fix is a plausible candidate to shrink this too — noted as a hypothesis to check by re-running this bench after #159 lands, not a claim made now.

## Verification

`npm test`: **265 passed**. `tsc --noEmit` against a scope that actually includes `bench/**/*` (see #157). `prettier --check`, `license-check` (90 files) all clean. Bench measured on an idle machine, warm-up discarded, four samples.

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
