### PR TITLE
feat(bench): add cache pool throughput benchmarks, closing out phase 2

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -65,7 +65,7 @@ impact:
 | **CPU contention** | The dominant one. Another busy process means the OS scheduler hands the bench less CPU time — a browser with many tabs, a background build, an antivirus scan. |
 | **Thermal state / turbo boost** | Has *memory*: the first seconds run boosted, then the clock drops under sustained load. So the **first** bench of a session tends to look faster than the last — a systematic bias in favour of whatever is measured first. |
 | **Power profile** | On a laptop, **on battery vs plugged in** can change everything: Windows throttles aggressively on battery. |
-| **Memory pressure / GC** | Smaller than people assume, but real: with RAM nearly full the collector runs more often and that time lands inside the measurement. These benches allocate their buffers *outside* the timed region, so this is a minor factor here. |
+| **Memory pressure / GC** | Smaller than people assume, but real: with RAM nearly full the collector runs more often and that time lands inside the measurement. Every case in this suite allocates its buffers *outside* the timed region — with one deliberate exception: `cache.bench.ts`'s `_pool_node_t.resize` case, where the allocation being measured is the whole point, so it runs inside the timed region on purpose. |
 
 In practice:
 
@@ -193,7 +193,12 @@ A second comparison comes free here: all four run over the same image in the
 same process, so their `hz` are comparable **to each other** within a run.
 "yape06 costs N× fast_corners" is as portable as the jsfeat ratio.
 
-Phase 2 covers every module this way, one PR at a time.
+Phase 2 covers each module this way, one PR at a time. As of this PR:
+`imgproc`, `orb`, `fast_corners`, `yape06`, `yape`, `optical_flow_lk`,
+`linalg`, `motion_estimator` and the `cache` pool have a bench file.
+`math`, `matmath` and `transform` do not yet, and there is no standalone
+`motion_model` case (only the `motion_estimator` benches that exercise it
+indirectly via `homography2d`).
 
 ## Phase 2, continued: optical_flow_lk
 
@@ -318,12 +323,12 @@ once it lands, is a plausible candidate to shrink this finding too, but that
 is a hypothesis to check by re-running this bench after #159, not a claim
 made now.
 
-## Phase 2, continued: the cache pool — last module of this phase
+## Phase 2, continued: the cache pool
 
 | Case | Why it is here |
 | --- | --- |
 | `cache.get_buffer` + `put_buffer` — steady state | The overwhelmingly common path: real callers request the same size call after call for the life of a session, so a node almost never needs to grow |
-| `cache.get_buffer` — forced resize every call | The rare path (`_pool_node_t.resize`: a fresh `ArrayBuffer` + four typed-array views), isolated by requesting a monotonically larger size every call so it always fires |
+| `_pool_node_t.resize` — forced every call | The rare path (a fresh `ArrayBuffer` + four typed-array views), isolated by calling `resize()` directly with a fixed target size on one node borrowed once outside the timed region |
 
 Unlike every other file in this suite, this one uses the real global
 singletons rather than fresh instances — `jsfeat.cache` is a single
@@ -331,41 +336,39 @@ IIFE-closure object, not a constructor, so there is no `new jsfeat.cache()`
 to fall back on. Both sides pre-allocate identically at module load
 (`allocate(30, 640 * 4)`), so this isn't a compromise: it's the more
 faithful bench, given jsfeatNext's shared-cache design (#41) exists
-specifically to mirror jsfeat's one-pool-per-process model. Every
-`get_buffer` is paired with a `put_buffer` before the next iteration, so the
-pool's size never drifts; the only side effect is that resized nodes stay
-larger for the rest of the process, which is harmless by the pool's own
-"at least this size" contract. See the file's docstring for the full
-reasoning, including why it's a different risk category from the
-`Math.random` leak fixed in `motion_estimator.bench.ts`.
+specifically to mirror jsfeat's one-pool-per-process model. The steady-state
+case pairs every `get_buffer` with a `put_buffer` before the next iteration,
+so the pool's size never drifts; the only side effect anywhere in this file
+is that the one node the resize case borrows stays permanently larger, which
+is harmless by the pool's own "at least this size" contract. See the file's
+docstring for the full reasoning, including why an earlier version of the
+resize case (growing the requested size every call) made the workload
+depend on how many iterations each side completed, and why it was
+redesigned around `resize()`'s own no-guard behaviour instead (caught in
+review).
 
-Five runs on an idle machine (one extra beyond the usual four, because the
-first four disagreed sharply enough to want another data point):
+Four runs on an idle machine, discarding a warm-up:
 
-| case | r1 | r2 | r3 | r4 | r5 | verdict |
-| --- | --- | --- | --- | --- | --- | --- |
-| steady state | 1.05 | 1.04 | 1.01 | 1.86\* | 1.16 | **not measurable this way** |
-| forced resize | — | 1.17 | 1.29 | 1.04 | 1.06 | weak, consistent direction, small magnitude |
+| case | r1 | r2 | r3 | r4 | verdict |
+| --- | --- | --- | --- | --- | --- |
+| steady state | 1.07 | 1.17 | 1.14 | 1.14\* | borderline, one flip |
+| `resize` | 1.08\* | 1.05 | 1.04 | 1.06 | noise, close to 1.0x |
 
-\* = jsfeatNext faster that run; every other steady-state figure favours
-jsfeat.
+\* = jsfeatNext faster that run; every other figure favours jsfeat.
 
-**Steady state is not a finding — it's an instrument limit.** At 11+ million
-operations/second, each call is under 100 nanoseconds, close to what
-`performance.now()`'s resolution can distinguish at all. The sign flips
-repeatedly and one run swings to 1.86x in jsfeatNext's favour — a magnitude
-this suite has never seen anywhere else, immediately followed by a run
-favouring jsfeat by 1.16x. Read as noise, not parity and not a slowdown; the
-honest conclusion is that pure pointer-shuffling is currently below what this
-harness can resolve, not that the two implementations are equally fast.
+**Steady state sits right at the noise floor**, not clearly a finding: three
+of four samples cluster at 1.07–1.17x (jsfeat), the fourth flips to
+jsfeatNext at the same 1.14x magnitude. At 11+ million operations/second each
+call is under 100 nanoseconds, close to what `performance.now()`'s
+resolution can distinguish — read this as inconclusive rather than as either
+parity or a slowdown, not confidently either way.
 
-**Forced resize is a real but small signal**: jsfeat wins all four samples,
-never flipping, but two of the four (1.04, 1.06) sit close enough to the
-~1.15x noise floor that this is weaker evidence than `svd_invert` or
-`ransac`. Recorded rather than promoted to an open finding — consistent
-direction across four runs is suggestive, not yet the kind of tight,
-above-floor signal this file otherwise requires before calling something a
-finding.
+**`resize` is clean noise** after the redesign — 1.04–1.08x, flipping once,
+none of it above the ~1.15x floor. Unlike the abandoned growing-size design
+(which mixed workload asymmetry into whatever it was measuring), a plain
+`ArrayBuffer` + typed-array-view allocation is generic V8 machinery on both
+sides, not algorithm-specific code — a real difference here would have been
+the surprise, not its absence.
 
 ## Notes on the inputs
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -248,7 +248,7 @@ Four runs on an idle machine, discarding a warm-up:
 | **`svd_invert`** | **1.31** | **1.33** | **1.32** | **1.34** | **real, very tight** |
 | `eigenVV` | 1.45 | 1.41 | 1.25 | 1.23 | **real** |
 
-\* = jsfeatNext was faster that run.
+\* = jsfeatNext was faster in that run.
 
 jsfeat is faster in every sample of five of the six cases — `svd_invert`
 reproduces to within ±0.02 across all four runs, tighter than anything else
@@ -354,7 +354,7 @@ Four runs on an idle machine, discarding a warm-up:
 | steady state | 1.07 | 1.17 | 1.14 | 1.14\* | borderline, one flip |
 | `resize` | 1.08\* | 1.05 | 1.04 | 1.06 | noise, close to 1.0x |
 
-\* = jsfeatNext faster that run; every other figure favours jsfeat.
+\* = jsfeatNext was faster in that run; every other figure favours jsfeat.
 
 **Steady state sits right at the noise floor**, not clearly a finding: three
 of four samples cluster at 1.07–1.17x (jsfeat), the fourth flips to

--- a/bench/README.md
+++ b/bench/README.md
@@ -193,7 +193,7 @@ A second comparison comes free here: all four run over the same image in the
 same process, so their `hz` are comparable **to each other** within a run.
 "yape06 costs N× fast_corners" is as portable as the jsfeat ratio.
 
-Later phases fill in the remaining modules (the cache pool) one PR at a time.
+Phase 2 covers every module this way, one PR at a time.
 
 ## Phase 2, continued: optical_flow_lk
 
@@ -317,6 +317,55 @@ Not yet profiled. Given `ransac`'s magnitude and tightness closely match
 once it lands, is a plausible candidate to shrink this finding too, but that
 is a hypothesis to check by re-running this bench after #159, not a claim
 made now.
+
+## Phase 2, continued: the cache pool — last module of this phase
+
+| Case | Why it is here |
+| --- | --- |
+| `cache.get_buffer` + `put_buffer` — steady state | The overwhelmingly common path: real callers request the same size call after call for the life of a session, so a node almost never needs to grow |
+| `cache.get_buffer` — forced resize every call | The rare path (`_pool_node_t.resize`: a fresh `ArrayBuffer` + four typed-array views), isolated by requesting a monotonically larger size every call so it always fires |
+
+Unlike every other file in this suite, this one uses the real global
+singletons rather than fresh instances — `jsfeat.cache` is a single
+IIFE-closure object, not a constructor, so there is no `new jsfeat.cache()`
+to fall back on. Both sides pre-allocate identically at module load
+(`allocate(30, 640 * 4)`), so this isn't a compromise: it's the more
+faithful bench, given jsfeatNext's shared-cache design (#41) exists
+specifically to mirror jsfeat's one-pool-per-process model. Every
+`get_buffer` is paired with a `put_buffer` before the next iteration, so the
+pool's size never drifts; the only side effect is that resized nodes stay
+larger for the rest of the process, which is harmless by the pool's own
+"at least this size" contract. See the file's docstring for the full
+reasoning, including why it's a different risk category from the
+`Math.random` leak fixed in `motion_estimator.bench.ts`.
+
+Five runs on an idle machine (one extra beyond the usual four, because the
+first four disagreed sharply enough to want another data point):
+
+| case | r1 | r2 | r3 | r4 | r5 | verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| steady state | 1.05 | 1.04 | 1.01 | 1.86\* | 1.16 | **not measurable this way** |
+| forced resize | — | 1.17 | 1.29 | 1.04 | 1.06 | weak, consistent direction, small magnitude |
+
+\* = jsfeatNext faster that run; every other steady-state figure favours
+jsfeat.
+
+**Steady state is not a finding — it's an instrument limit.** At 11+ million
+operations/second, each call is under 100 nanoseconds, close to what
+`performance.now()`'s resolution can distinguish at all. The sign flips
+repeatedly and one run swings to 1.86x in jsfeatNext's favour — a magnitude
+this suite has never seen anywhere else, immediately followed by a run
+favouring jsfeat by 1.16x. Read as noise, not parity and not a slowdown; the
+honest conclusion is that pure pointer-shuffling is currently below what this
+harness can resolve, not that the two implementations are equally fast.
+
+**Forced resize is a real but small signal**: jsfeat wins all four samples,
+never flipping, but two of the four (1.04, 1.06) sit close enough to the
+~1.15x noise floor that this is weaker evidence than `svd_invert` or
+`ransac`. Recorded rather than promoted to an open finding — consistent
+direction across four runs is suggestive, not yet the kind of tight,
+above-floor signal this file otherwise requires before calling something a
+finding.
 
 ## Notes on the inputs
 

--- a/bench/cache.bench.ts
+++ b/bench/cache.bench.ts
@@ -1,0 +1,138 @@
+/*
+ *  cache.bench.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { bench, describe } from "vitest";
+import jsfeatNext from "../src/jsfeatNext";
+import jsfeat from "../tests/vendor/oracle.cjs";
+
+/**
+ * Throughput benchmarks for the shared buffer pool, `cache.get_buffer` /
+ * `.put_buffer` (issue #86, phase 2 — the last module of this phase).
+ *
+ * Read the RATIO, not the `hz` — see bench/README.md for why, and for the
+ * measured noise floor (ignore anything under ~1.15x).
+ *
+ * ## Why this file uses the real global singletons, not fresh instances
+ *
+ * Every other file in this suite constructs isolated inputs so nothing
+ * leaks between benches. This one can't: `jsfeatNext.cache` is a class
+ * (`src/cache/cache.ts`), but jsfeat's `cache` is a single IIFE-closure
+ * object (`tests/vendor/jsfeat-master.js`), not a constructor — there is no
+ * `new jsfeat.cache()` to fall back on. Both sides pre-allocate the SAME
+ * global singleton at module load with identical parameters
+ * (`allocate(30, 640 * 4)` — 31 nodes of 2560 bytes each), so using the
+ * singletons directly is not a compromise here: it's the more faithful
+ * bench, since jsfeatNext's whole shared-cache design (#41) exists
+ * specifically to mirror jsfeat's one-pool-per-process model.
+ *
+ * The only side effect is that a `get_buffer` call requesting more than a
+ * node's current size grows that node permanently (see `_pool_node_t.resize`)
+ * — after this file runs, whichever nodes the "resize" case below touched
+ * stay larger for the rest of the process. That's harmless by the pool's own
+ * contract (`get_buffer` promises "at least" the requested size, so a larger
+ * buffer still satisfies any future caller), unlike the `Math.random` leak
+ * fixed in `motion_estimator.bench.ts` — that one changed *what value* every
+ * future caller saw, not just how much memory sat behind it.
+ *
+ * Every `get_buffer` in both cases below is paired with a `put_buffer` before
+ * the next timed iteration, so the pool's size (31 nodes) never drifts.
+ *
+ * ## Two cases: the common path and the rare one
+ *
+ * Real callers overwhelmingly request the *same* size call after call — a
+ * fixed image/matrix dimension for the life of an AR session — so
+ * `get_buffer` almost never needs to grow a node. That steady-state path is
+ * pure pointer bookkeeping (pop the head, push the tail). The resize path
+ * (`_pool_node_t.resize`: a fresh `ArrayBuffer` plus four new typed-array
+ * views) is rare in practice but real, and costs something different enough
+ * to deserve its own measurement rather than being averaged into the common
+ * case.
+ */
+
+const STEADY_SIZE = 2048; // <= the pool's pre-allocated 2560B, so resize never fires
+
+describe("cache.get_buffer + put_buffer — steady state (no resize)", () => {
+    bench("jsfeatNext", () => {
+        const node = jsfeatNext.cache.get_buffer(STEADY_SIZE);
+        jsfeatNext.cache.put_buffer(node);
+    });
+
+    bench("jsfeat (reference)", () => {
+        const node = jsfeat.cache.get_buffer(STEADY_SIZE);
+        jsfeat.cache.put_buffer(node);
+    });
+});
+
+describe("cache.get_buffer — forced resize every call", () => {
+    // A monotonically growing request size guarantees the node handed back by
+    // get_buffer is always smaller than what's asked for, so resize fires on
+    // every single call rather than only the first lap around the pool.
+    let sizeN = 4096;
+    let sizeO = 4096;
+
+    bench(
+        "jsfeatNext",
+        () => {
+            const node = jsfeatNext.cache.get_buffer(sizeN);
+            jsfeatNext.cache.put_buffer(node);
+            sizeN += 8;
+        },
+        {
+            // Reset between modes (warmup, then run) so the "run" mode's
+            // measurement isn't starting from whatever huge size the warmup
+            // phase grew to.
+            setup: () => {
+                sizeN = 4096;
+            },
+        }
+    );
+
+    bench(
+        "jsfeat (reference)",
+        () => {
+            const node = jsfeat.cache.get_buffer(sizeO);
+            jsfeat.cache.put_buffer(node);
+            sizeO += 8;
+        },
+        {
+            setup: () => {
+                sizeO = 4096;
+            },
+        }
+    );
+});

--- a/bench/cache.bench.ts
+++ b/bench/cache.bench.ts
@@ -50,10 +50,13 @@ import jsfeat from "../tests/vendor/oracle.cjs";
  * ## Why this file uses the real global singletons, not fresh instances
  *
  * Every other file in this suite constructs isolated inputs so nothing
- * leaks between benches. This one can't: `jsfeatNext.cache` is a class
- * (`src/cache/cache.ts`), but jsfeat's `cache` is a single IIFE-closure
- * object (`tests/vendor/jsfeat-master.js`), not a constructor — there is no
- * `new jsfeat.cache()` to fall back on. Both sides pre-allocate the SAME
+ * leaks between benches. This one can't: `jsfeatNext.cache` is a
+ * class-backed singleton *instance* (`shared_cache` in `src/core/core.ts`,
+ * assigned onto the namespace in `src/jsfeatNext.ts` — never construct a
+ * second one with `new`), but jsfeat's `cache` is a single IIFE-closure
+ * object (`tests/vendor/jsfeat-master.js`), not a constructor at all — there
+ * is no `new jsfeat.cache()` to fall back on either way. Both sides
+ * pre-allocate the SAME
  * global singleton at module load with identical parameters
  * (`allocate(30, 640 * 4)` — 31 nodes of 2560 bytes each), so using the
  * singletons directly is not a compromise here: it's the more faithful
@@ -120,9 +123,17 @@ describe("_pool_node_t.resize — forced every call", () => {
     // timed region, isolates exactly the cost this case is named for: one
     // node, one fixed size, every call, both sides doing identical work
     // regardless of how many iterations either completes.
+    //
+    // The node is borrowed in `setup` rather than the `describe` body.
+    // `describe` bodies run during collection, unconditionally, even for a
+    // `bench()` task a name filter (`--testNamePattern`) later excludes from
+    // actually running -- a borrow there would never be matched by this
+    // task's own `teardown`, which only fires for tasks that run. `setup`
+    // only fires for a task that is actually about to execute, so a filtered
+    // out task borrows nothing and leaks nothing (verified empirically).
     const RESIZE_TARGET = 65536;
-    const nodeN = jsfeatNext.cache.get_buffer(1);
-    const nodeO = jsfeat.cache.get_buffer(1);
+    let nodeN: ReturnType<typeof jsfeatNext.cache.get_buffer>;
+    let nodeO: ReturnType<typeof jsfeat.cache.get_buffer>;
 
     bench(
         "jsfeatNext",
@@ -130,10 +141,15 @@ describe("_pool_node_t.resize — forced every call", () => {
             nodeN.resize(RESIZE_TARGET);
         },
         {
-            // teardown fires after both the warmup and the run mode; only
-            // return the node once, after the run mode is the last one, so
-            // it isn't back in the pool (and available to some other caller)
-            // while this case's own "run" iterations are still mutating it.
+            // setup/teardown fire for both the warmup and the run mode; only
+            // borrow once (warmup, the first phase) and only return once
+            // (run, the last phase, proven to fire after warmup), so the
+            // node isn't back in the pool -- available to some other
+            // caller -- while this case's own iterations are still mutating
+            // it.
+            setup: (_task, mode) => {
+                if (mode === "warmup") nodeN = jsfeatNext.cache.get_buffer(1);
+            },
             teardown: (_task, mode) => {
                 if (mode === "run") jsfeatNext.cache.put_buffer(nodeN);
             },
@@ -146,6 +162,9 @@ describe("_pool_node_t.resize — forced every call", () => {
             nodeO.resize(RESIZE_TARGET);
         },
         {
+            setup: (_task, mode) => {
+                if (mode === "warmup") nodeO = jsfeat.cache.get_buffer(1);
+            },
             teardown: (_task, mode) => {
                 if (mode === "run") jsfeat.cache.put_buffer(nodeO);
             },

--- a/bench/cache.bench.ts
+++ b/bench/cache.bench.ts
@@ -60,17 +60,16 @@ import jsfeat from "../tests/vendor/oracle.cjs";
  * bench, since jsfeatNext's whole shared-cache design (#41) exists
  * specifically to mirror jsfeat's one-pool-per-process model.
  *
- * The only side effect is that a `get_buffer` call requesting more than a
- * node's current size grows that node permanently (see `_pool_node_t.resize`)
- * — after this file runs, whichever nodes the "resize" case below touched
- * stay larger for the rest of the process. That's harmless by the pool's own
- * contract (`get_buffer` promises "at least" the requested size, so a larger
- * buffer still satisfies any future caller), unlike the `Math.random` leak
- * fixed in `motion_estimator.bench.ts` — that one changed *what value* every
- * future caller saw, not just how much memory sat behind it.
- *
- * Every `get_buffer` in both cases below is paired with a `put_buffer` before
- * the next timed iteration, so the pool's size (31 nodes) never drifts.
+ * The only side effect is that any node this file's "resize" case touches
+ * ends up permanently larger (see `_pool_node_t.resize`) — harmless by the
+ * pool's own contract (`get_buffer` promises "at least" the requested size,
+ * so a larger buffer still satisfies any future caller), unlike the
+ * `Math.random` leak fixed in `motion_estimator.bench.ts`, which changed
+ * *what value* every future caller saw rather than just how much memory sat
+ * behind it. The steady-state case never touches a node's size at all — it
+ * requests less than the pool's pre-allocated 2560B — and every `get_buffer`
+ * it makes is paired with a `put_buffer` before the next timed iteration, so
+ * the pool's size (31 nodes) never drifts there either.
  *
  * ## Two cases: the common path and the rare one
  *
@@ -80,8 +79,13 @@ import jsfeat from "../tests/vendor/oracle.cjs";
  * pure pointer bookkeeping (pop the head, push the tail). The resize path
  * (`_pool_node_t.resize`: a fresh `ArrayBuffer` plus four new typed-array
  * views) is rare in practice but real, and costs something different enough
- * to deserve its own measurement rather than being averaged into the common
- * case.
+ * to deserve its own measurement — see that case's own comment for why it
+ * borrows a single node directly rather than cycling through `get_buffer`.
+ *
+ * Unlike every other case in this suite, the "resize" case's cost is
+ * unavoidably paid *inside* the timed region — that's the entire point of
+ * the measurement — which is an exception to bench/README.md's general
+ * claim that these benches allocate their buffers outside the timed region.
  */
 
 const STEADY_SIZE = 2048; // <= the pool's pre-allocated 2560B, so resize never fires
@@ -98,26 +102,40 @@ describe("cache.get_buffer + put_buffer — steady state (no resize)", () => {
     });
 });
 
-describe("cache.get_buffer — forced resize every call", () => {
-    // A monotonically growing request size guarantees the node handed back by
-    // get_buffer is always smaller than what's asked for, so resize fires on
-    // every single call rather than only the first lap around the pool.
-    let sizeN = 4096;
-    let sizeO = 4096;
+describe("_pool_node_t.resize — forced every call", () => {
+    // `get_buffer(size)` only resizes when `size > node.size`, and a node
+    // that has already grown to a given size satisfies every later request
+    // at or below it -- so once every node in the (finite, non-shrinking)
+    // pool has grown to a target size, get_buffer stops triggering resize
+    // for that target. An earlier version of this case tried to force
+    // resize on every call by growing the requested size every iteration,
+    // but that makes the workload depend on how many iterations each side
+    // completes: the faster side reaches larger sizes than the slower one
+    // in the same time budget, so the two sides no longer do equal work
+    // (caught in review).
+    //
+    // `resize()` itself has no such guard -- it unconditionally reallocates
+    // regardless of the node's current size -- so calling it directly, with
+    // a FIXED target every time, on a single node borrowed once outside the
+    // timed region, isolates exactly the cost this case is named for: one
+    // node, one fixed size, every call, both sides doing identical work
+    // regardless of how many iterations either completes.
+    const RESIZE_TARGET = 65536;
+    const nodeN = jsfeatNext.cache.get_buffer(1);
+    const nodeO = jsfeat.cache.get_buffer(1);
 
     bench(
         "jsfeatNext",
         () => {
-            const node = jsfeatNext.cache.get_buffer(sizeN);
-            jsfeatNext.cache.put_buffer(node);
-            sizeN += 8;
+            nodeN.resize(RESIZE_TARGET);
         },
         {
-            // Reset between modes (warmup, then run) so the "run" mode's
-            // measurement isn't starting from whatever huge size the warmup
-            // phase grew to.
-            setup: () => {
-                sizeN = 4096;
+            // teardown fires after both the warmup and the run mode; only
+            // return the node once, after the run mode is the last one, so
+            // it isn't back in the pool (and available to some other caller)
+            // while this case's own "run" iterations are still mutating it.
+            teardown: (_task, mode) => {
+                if (mode === "run") jsfeatNext.cache.put_buffer(nodeN);
             },
         }
     );
@@ -125,13 +143,11 @@ describe("cache.get_buffer — forced resize every call", () => {
     bench(
         "jsfeat (reference)",
         () => {
-            const node = jsfeat.cache.get_buffer(sizeO);
-            jsfeat.cache.put_buffer(node);
-            sizeO += 8;
+            nodeO.resize(RESIZE_TARGET);
         },
         {
-            setup: () => {
-                sizeO = 4096;
+            teardown: (_task, mode) => {
+                if (mode === "run") jsfeat.cache.put_buffer(nodeO);
             },
         }
     );


### PR DESCRIPTION
## Summary

Phase 2 of #86: `cache.get_buffer`/`.put_buffer` — steady-state reuse (the common path, no resize) and a forced-resize case (`_pool_node_t.resize`, the rare path). No changes to `src/`.

**This is not the last phase-2 module.** An earlier version of this description claimed it was; that was wrong. `math`, `matmath` and `transform` have no bench file yet, and there is no standalone `motion_model` case (only `motion_estimator`, which exercises it indirectly via `homography2d`). `bench/README.md` now states exactly what's covered instead of overclaiming completeness.

## Why this file uses the real global singletons, not fresh instances

Every other file in this suite constructs isolated inputs so nothing leaks between benches. This one can't: `jsfeatNext.cache` is a class-backed singleton *instance* (`shared_cache` in `src/core/core.ts`), but jsfeat's `cache` is a single IIFE-closure object, not a constructor at all — there's no `new jsfeat.cache()` to fall back on either way.

Both sides pre-allocate identically at module load (`allocate(30, 640 * 4)` — 31 nodes of 2560 bytes each), so using the singletons directly isn't a compromise: it's the *more faithful* bench, since jsfeatNext's whole shared-cache design (#41) exists specifically to mirror jsfeat's one-pool-per-process model.

## Three rounds of review, three real bugs

**Round 1 — the resize case's workload was asymmetric.** It grew the requested size by 8 bytes inside the timed callback. `setup` reset the local counter but not the pool nodes' actual grown sizes from warmup, and the faster side reached larger sizes than the slower one in the same time budget — the two implementations weren't doing equal work. Redesigned around `resize()`'s own behavior instead: it has no size-comparison guard, unconditionally reallocating regardless of current size, so the case now borrows a single node once and calls `resize()` on it directly with a **fixed** target every call — deterministic, symmetric regardless of iteration count.

**Round 2 — the README overstated coverage and contradicted its own methodology note.** "Every module" wasn't true (see above); "buffers allocated outside the timed region" wasn't true for this file's own resize case, which measures an allocation that has to happen inside the timed region by design. Both narrowed/qualified.

**Round 3 — the node borrow happened at collection time, not run time.** `describe` bodies run unconditionally during collection, so a name-filtered-out `bench()` task's node was still borrowed but its `teardown` (tied to that same excluded task) never fired to return it — a real, if narrow, leak. Verified empirically both ways: moved the borrow into `setup`, which only fires for a task actually about to run, and confirmed a filtered-out task now borrows nothing.

Also fixed: `jsfeatNext.cache is a class` was imprecise (the property holds an *instance*, not the class), and a grammar nit ("faster that run" → "faster in that run").

## Result

Four runs on an idle machine, discarding a warm-up:

| case | r1 | r2 | r3 | r4 | verdict |
| --- | --- | --- | --- | --- | --- |
| steady state | 1.07 | 1.17 | 1.14 | 1.14* | borderline, one flip |
| `resize` | 1.08* | 1.05 | 1.04 | 1.06 | noise, close to 1.0x |

\* = jsfeatNext was faster in that run; every other figure favours jsfeat.

**Steady state sits right at the noise floor** — three of four samples cluster at 1.07–1.17x (jsfeat), the fourth flips to jsfeatNext at the same 1.14x magnitude. At 11M+ ops/sec each call is under 100ns, close to `performance.now()`'s resolution — read as inconclusive, not as parity or a slowdown.

**`resize` is clean noise** after the redesign — 1.04–1.08x, flipping once, nothing above the ~1.15x floor. Makes sense in hindsight: a plain `ArrayBuffer` + typed-array-view allocation is generic V8 machinery on both sides, not algorithm-specific code — a real difference here would have been the surprise.

## Verification

`npm test`: **265 passed**. `tsc --noEmit` against a scope that actually includes `bench/**/*` (#157). `prettier --check`, `license-check` (91 files) all clean. Bench re-measured on an idle machine after each redesign, warm-up discarded.

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
