### PR TITLE
feat(bench): add math, matmath and transform benchmarks, completing phase 2

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -376,7 +376,7 @@ the surprise, not its absence.
 | `math.get_gaussian_kernel` — size 7 / size 9 | `imgproc.gaussian_blur`'s kernel build. Split because `size <= 7 && odd && sigma <= 0` takes a hardcoded coefficient table and anything else falls through to a `Math.exp` loop — two different cost profiles, like imgproc's U8/F32 split |
 | `math.qsort` (2048 floats) | Public API with no in-tree caller, but the one genuinely algorithmic routine in `math` (hybrid quicksort/insertion sort) — the kind of code a port drifts on |
 | `math.median` (512 floats) | `motion_estimator.lmeds`'s residual median |
-| `matmath.transpose` — 9x9 | `linalg.svd_decompose` calls it five times per decomposition, at the size `motion_model`'s homography DLT uses |
+| `matmath.transpose` — 9x9 | `linalg.svd_decompose` has five transpose call sites, in mutually exclusive/optional branches — at most 3 run per decomposition, and only 1 with `SVD_U_T\|SVD_V_T` set. Benched at the size `motion_model`'s homography DLT uses |
 | `matmath.invert_3x3` / `multiply_3x3` | `motion_model`, per frame |
 | `transform.invert_affine_transform` / `invert_perspective_transform` | Public API, no in-tree caller — see the calling-convention note below |
 
@@ -389,51 +389,71 @@ the sorted-input case.
 `math.perspective_4point_transform` is deliberately not benched: it is
 deprecated and logs a console warning on every call.
 
-Six runs on an idle machine, discarding a warm-up:
+Two series were needed here, because review found two cases were measuring
+the wrong thing (details below). The authoritative numbers are the post-fix
+series — four runs on an idle machine, discarding a warm-up:
 
-| case | r1 | r2 | r3 | r4 | r5 | r6 | verdict |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `get_gaussian_kernel` size 7 | 1.18 | 1.08\* | 1.02\* | 1.19 | 1.43 | 1.21 | flips twice — noise |
-| `get_gaussian_kernel` size 9 | 1.03 | 2.24 | 1.10 | 1.13 | 1.19 | 1.04 | 6/6 jsfeat, below floor |
-| `qsort` | 1.07\* | 1.01 | 1.06\* | 1.04 | 1.07\* | 1.05 | 3/3 — noise |
-| `median` | 1.01 | 1.01 | 1.03 | 1.18\* | 1.10 | 1.02 | noise |
-| `transpose` 9x9 | 1.09 | 1.03 | 1.01\* | 1.05\* | 1.07\* | 1.01 | flips — noise |
-| **`invert_3x3`** | **1.31** | **1.29** | **1.36** | **1.39** | **1.31** | **1.40** | **real** |
-| `multiply_3x3` | 1.88 | 1.08 | 1.09 | 1.04 | 1.07 | 1.09 | 6/6 jsfeat, below floor |
-| `invert_affine_transform` | 1.02\* | 1.05\* | 1.03\* | 1.06\* | 1.00 | 1.02 | noise |
-| `invert_perspective_transform` | 1.03 | 1.93 | 1.00\* | 1.05 | 1.45 | 1.12 | noise |
+| case | r1 | r2 | r3 | r4 | verdict |
+| --- | --- | --- | --- | --- | --- |
+| `get_gaussian_kernel` size 7 | 1.15 | 1.08 | 1.03 | 1.34 | 4/4 jsfeat, mostly below floor |
+| `get_gaussian_kernel` size 9 | 1.08 | 1.12 | 1.12 | 1.03\* | below floor |
+| `qsort` | 1.05 | 1.02\* | 1.08 | 1.18\* | flips — noise |
+| `median` | 1.09\* | 1.05\* | 1.00\* | 1.11\* | 4/4 jsfeatNext, below floor |
+| `transpose` 9x9 | 1.04\* | 1.09 | 1.19\* | 1.20 | flips — noise |
+| **`invert_3x3`** | **1.24** | **1.18** | **1.36** | **1.34** | **real** |
+| `multiply_3x3` | 1.11 | 1.03\* | 1.12 | 1.06 | below floor |
+| `invert_affine_transform` | 1.09\* | 1.23\* | 1.02\* | 1.01 | 3/4 jsfeatNext |
+| `invert_perspective_transform` | 1.12 | 1.05 | 1.00\* | 1.05 | below floor |
 
 \* = jsfeatNext was faster in that run; every other figure favours jsfeat.
 
-**`matmath.invert_3x3` is the one real signal here**: jsfeat faster in all six
-samples, 1.29–1.40, never flipping, comfortably above the ~1.15x floor. It is
-called once per model fit in `motion_model` (`motion_model.ts:262`), so it is
-on the per-frame path, not incidental. Same shape as the YAPE and `linalg`
-findings — recorded as an open finding, not acted on here.
+**`matmath.invert_3x3` is the one real signal here.** jsfeat is faster in all
+four post-fix samples (1.18–1.36) and in all six of the earlier series
+(1.29–1.40) — **ten out of ten**, never once flipping. It is called per model
+fit in `motion_model` (`motion_model.ts:262`), so it is on the per-frame path.
+Same shape as the YAPE and `linalg` findings; recorded as an open finding, not
+acted on here.
 
-`get_gaussian_kernel` size 9 and `multiply_3x3` also favour jsfeat 6/6, but at
-1.03–1.19 and 1.04–1.09 respectively (setting aside one outlier each) — below
-the floor, so directional-but-not-a-finding, the same category as
-`fast_corners` thr 60 above.
+Everything else is at or below the ~1.15x floor. `get_gaussian_kernel` size 7
+favours jsfeat 4/4 and `median` favours jsfeatNext 4/4, but both sit low
+enough to be directional-at-best, the same category as `fast_corners` thr 60.
 
-### Two corrections this file's own measurements forced
+### Three corrections this file's own measurements forced
 
-An earlier series for these cases was taken while the machine was busy, and it
-supported **three conclusions that the idle-machine re-run dismantled**:
-`get_gaussian_kernel` size 7 looked like a clean 6/6 directional result and now
-flips twice; `transpose` looked 6/6 and now flips; `qsort` looked like the one
-case where jsfeatNext consistently won (5/6) and is now an even 3/3 split. Only
-`invert_3x3` survived — and it got *tighter* (1.29–1.40 versus 1.01–1.48 on the
-busy machine), the same signature the YAPE finding showed. A reminder that
-contention does not just add scatter: it manufactures apparent direction.
+**The `qsort` case was not sorting.** `math.qsort` takes a *less-than
+predicate* and uses it in boolean contexts (`if (cmp(a, b))`, ternaries). The
+bench originally passed a conventional three-way `-1/0/1` comparator — which
+returns a **truthy** value for both orderings, so the algorithm saw "a < b" as
+true in either direction. Verified with a probe: sorting `[5,3,9,1,7,2,8,4,6,0]`
+returned `8,4,6,0,5,3,9,1,7,2`, completely unordered. The case was timing a
+non-sort. Fixed to the same predicate shape `tests/parity/math.test.ts` uses;
+the verdict happens to be unchanged (noise either way), but it now measures
+sorting.
 
-A prediction also failed. The module docstring originally argued that
-`transform` should measurably favour jsfeat, because jsfeatNext's methods take
-`matrix_t` and unwrap `.data` while jsfeat's take raw arrays — two extra
-property loads on a function that is only a dozen float operations. Across six
-runs neither transform case clears the noise floor and both flip sign. The
-matrix_t calling convention has no throughput cost this harness can detect;
-the docstring now says so instead of the prediction.
+**The `transform` comparison confounded two variables.** It passed jsfeat a
+packed JS array (`Array.from`) while jsfeatNext used a `Float32Array` — V8
+stores and optimises those very differently, so the ratio mixed the
+calling-convention question with an element-storage difference. Both sides now
+use `Float32Array`, leaving `matrix_t`-vs-raw as the only difference. This
+strengthened rather than overturned the conclusion: with the confound removed,
+`invert_affine_transform` favours *jsfeatNext* in 3 of 4 runs.
+
+**An earlier series ran while the machine was busy**, and it supported three
+conclusions the idle re-run dismantled: `get_gaussian_kernel` size 7 looked
+like a clean 6/6 directional result and then flipped twice, `transpose`
+likewise, and `qsort` looked like the one case jsfeatNext consistently won
+(5/6) before becoming an even split. Only `invert_3x3` survived — and it got
+*tighter*, the same signature the YAPE finding showed. Contention does not
+just add scatter; it manufactures apparent direction.
+
+A prediction also failed, and is worth recording as such. The module docstring
+originally argued `transform` *should* measurably favour jsfeat, since
+jsfeatNext's methods take `matrix_t` and unwrap `.data` while jsfeat's take
+raw arrays — two extra property loads on a function that is a dozen float
+operations. Across both series neither transform case clears the noise floor
+in jsfeat's favour. The `matrix_t` calling convention has no throughput cost
+this harness can detect; the docstring now states that null result instead of
+the prediction.
 
 ## Notes on the inputs
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -193,12 +193,11 @@ A second comparison comes free here: all four run over the same image in the
 same process, so their `hz` are comparable **to each other** within a run.
 "yape06 costs N× fast_corners" is as portable as the jsfeat ratio.
 
-Phase 2 covers each module this way, one PR at a time. As of this PR:
-`imgproc`, `orb`, `fast_corners`, `yape06`, `yape`, `optical_flow_lk`,
-`linalg`, `motion_estimator` and the `cache` pool have a bench file.
-`math`, `matmath` and `transform` do not yet, and there is no standalone
-`motion_model` case (only the `motion_estimator` benches that exercise it
-indirectly via `homography2d`).
+Phase 2 covers each module this way, one PR at a time. As of this PR every
+module has a bench file: `imgproc`, `orb`, `fast_corners`, `yape06`, `yape`,
+`optical_flow_lk`, `linalg`, `motion_estimator`, the `cache` pool, and
+`math`/`matmath`/`transform`. There is still no standalone `motion_model`
+case — it is exercised indirectly through the `motion_estimator` benches.
 
 ## Phase 2, continued: optical_flow_lk
 
@@ -369,6 +368,72 @@ none of it above the ~1.15x floor. Unlike the abandoned growing-size design
 `ArrayBuffer` + typed-array-view allocation is generic V8 machinery on both
 sides, not algorithm-specific code — a real difference here would have been
 the surprise, not its absence.
+
+## Phase 2, continued: math, matmath and transform
+
+| Case | Why it is here |
+| --- | --- |
+| `math.get_gaussian_kernel` — size 7 / size 9 | `imgproc.gaussian_blur`'s kernel build. Split because `size <= 7 && odd && sigma <= 0` takes a hardcoded coefficient table and anything else falls through to a `Math.exp` loop — two different cost profiles, like imgproc's U8/F32 split |
+| `math.qsort` (2048 floats) | Public API with no in-tree caller, but the one genuinely algorithmic routine in `math` (hybrid quicksort/insertion sort) — the kind of code a port drifts on |
+| `math.median` (512 floats) | `motion_estimator.lmeds`'s residual median |
+| `matmath.transpose` — 9x9 | `linalg.svd_decompose` calls it five times per decomposition, at the size `motion_model`'s homography DLT uses |
+| `matmath.invert_3x3` / `multiply_3x3` | `motion_model`, per frame |
+| `transform.invert_affine_transform` / `invert_perspective_transform` | Public API, no in-tree caller — see the calling-convention note below |
+
+`qsort` and `median` rewrite the array they are given, so both restore fresh
+input via `setup` (once per mode). That is not a complete fix — within a mode,
+iterations 2..N still work on already-processed data — but it applies equally
+to both sides, so the ratio stays fair even though the absolute `hz` reflects
+the sorted-input case.
+
+`math.perspective_4point_transform` is deliberately not benched: it is
+deprecated and logs a console warning on every call.
+
+Six runs on an idle machine, discarding a warm-up:
+
+| case | r1 | r2 | r3 | r4 | r5 | r6 | verdict |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `get_gaussian_kernel` size 7 | 1.18 | 1.08\* | 1.02\* | 1.19 | 1.43 | 1.21 | flips twice — noise |
+| `get_gaussian_kernel` size 9 | 1.03 | 2.24 | 1.10 | 1.13 | 1.19 | 1.04 | 6/6 jsfeat, below floor |
+| `qsort` | 1.07\* | 1.01 | 1.06\* | 1.04 | 1.07\* | 1.05 | 3/3 — noise |
+| `median` | 1.01 | 1.01 | 1.03 | 1.18\* | 1.10 | 1.02 | noise |
+| `transpose` 9x9 | 1.09 | 1.03 | 1.01\* | 1.05\* | 1.07\* | 1.01 | flips — noise |
+| **`invert_3x3`** | **1.31** | **1.29** | **1.36** | **1.39** | **1.31** | **1.40** | **real** |
+| `multiply_3x3` | 1.88 | 1.08 | 1.09 | 1.04 | 1.07 | 1.09 | 6/6 jsfeat, below floor |
+| `invert_affine_transform` | 1.02\* | 1.05\* | 1.03\* | 1.06\* | 1.00 | 1.02 | noise |
+| `invert_perspective_transform` | 1.03 | 1.93 | 1.00\* | 1.05 | 1.45 | 1.12 | noise |
+
+\* = jsfeatNext was faster in that run; every other figure favours jsfeat.
+
+**`matmath.invert_3x3` is the one real signal here**: jsfeat faster in all six
+samples, 1.29–1.40, never flipping, comfortably above the ~1.15x floor. It is
+called once per model fit in `motion_model` (`motion_model.ts:262`), so it is
+on the per-frame path, not incidental. Same shape as the YAPE and `linalg`
+findings — recorded as an open finding, not acted on here.
+
+`get_gaussian_kernel` size 9 and `multiply_3x3` also favour jsfeat 6/6, but at
+1.03–1.19 and 1.04–1.09 respectively (setting aside one outlier each) — below
+the floor, so directional-but-not-a-finding, the same category as
+`fast_corners` thr 60 above.
+
+### Two corrections this file's own measurements forced
+
+An earlier series for these cases was taken while the machine was busy, and it
+supported **three conclusions that the idle-machine re-run dismantled**:
+`get_gaussian_kernel` size 7 looked like a clean 6/6 directional result and now
+flips twice; `transpose` looked 6/6 and now flips; `qsort` looked like the one
+case where jsfeatNext consistently won (5/6) and is now an even 3/3 split. Only
+`invert_3x3` survived — and it got *tighter* (1.29–1.40 versus 1.01–1.48 on the
+busy machine), the same signature the YAPE finding showed. A reminder that
+contention does not just add scatter: it manufactures apparent direction.
+
+A prediction also failed. The module docstring originally argued that
+`transform` should measurably favour jsfeat, because jsfeatNext's methods take
+`matrix_t` and unwrap `.data` while jsfeat's take raw arrays — two extra
+property loads on a function that is only a dozen float operations. Across six
+runs neither transform case clears the noise floor and both flip sign. The
+matrix_t calling convention has no throughput cost this harness can detect;
+the docstring now says so instead of the prediction.
 
 ## Notes on the inputs
 

--- a/bench/math_matmath_transform.bench.ts
+++ b/bench/math_matmath_transform.bench.ts
@@ -1,0 +1,316 @@
+/*
+ *  math_matmath_transform.bench.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { bench, describe } from "vitest";
+import jsfeatNext from "../src/jsfeatNext";
+import jsfeat from "../tests/vendor/oracle.cjs";
+import { rng } from "../tests/properties/helpers";
+
+/**
+ * Throughput benchmarks for `math`, `matmath` and `transform` (issue #86,
+ * phase 2 — the three modules the earlier phase-2 PRs left uncovered).
+ *
+ * Read the RATIO, not the `hz` — see bench/README.md for why, and for the
+ * measured noise floor (ignore anything under ~1.15x).
+ *
+ * ## Case selection: real callers, not every public method
+ *
+ * These three modules expose ~19 methods between them. Benching all of them
+ * would mostly time arithmetic nobody runs in a frame loop, so the cases
+ * below are the ones with an actual in-tree caller:
+ *
+ *   - `math.get_gaussian_kernel` — `imgproc.gaussian_blur` (imgproc.ts:277)
+ *   - `math.median`              — `motion_estimator.lmeds` (motion_estimator.ts:378)
+ *   - `matmath.transpose`        — `linalg.svd_decompose`, five call sites
+ *   - `matmath.invert_3x3` / `multiply_3x3` — `motion_model`, per frame
+ *
+ * `math.qsort` is included despite having no in-tree caller: it is public
+ * API, it is the one genuinely algorithmic routine in `math` (a hybrid
+ * quicksort/insertion sort), and it is the kind of code where a port is most
+ * likely to drift. `transform`'s two inverses are likewise public API with no
+ * in-tree caller — see the note on that module below.
+ *
+ * `math.perspective_4point_transform` is deliberately NOT benched: it is
+ * deprecated and logs a console warning on every call, so benching it would
+ * both flood the output and time a path no one should be on.
+ *
+ * ## In-place mutation: qsort and median rewrite their input
+ *
+ * Both sort/partition the array they are given, so a naive bench would
+ * measure "sort an already-sorted array" from the second iteration onward —
+ * a different (and much easier) workload than the first call. Both cases
+ * below restore fresh unsorted input via `bench()`'s `setup` option, which
+ * runs once per mode (warmup, then run) rather than per iteration, so the
+ * restore cost stays outside the timed region.
+ *
+ * This is not a complete fix and the numbers should be read with it in mind:
+ * within a single mode, iterations 2..N still operate on already-processed
+ * data. It applies identically to both sides, so the ratio stays fair, but
+ * the absolute `hz` for these two cases reflects the sorted-input case far
+ * more than the unsorted one.
+ *
+ * ## `transform`: the one case that is NOT strictly like-for-like
+ *
+ * jsfeatNext's `transform` methods take `matrix_t`; original jsfeat's take
+ * RAW ARRAYS (documented divergence — see `tests/vendor/oracle.cjs` and
+ * AGENTS.md). The arithmetic is identical, but jsfeatNext additionally does
+ * two property loads (`src.data`, `dst.data`) that jsfeat does not.
+ *
+ * For a function this small — `invert_affine_transform` is about a dozen
+ * float operations — two extra property loads might plausibly have shown up
+ * as a measurable cost. They did not: across six idle-machine runs both
+ * transform cases sit at the noise floor with the sign flipping, so the
+ * matrix_t calling convention has no throughput cost this harness can
+ * detect. That is worth knowing, but it is a null result, not a finding —
+ * and it means these two cases are the least informative in this file.
+ *
+ * Note also that jsfeat's `transform` module ships only in `src/`, never in
+ * the distributed build — `tests/vendor/oracle.cjs` loads it separately.
+ */
+
+const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
+const OF32C1 = jsfeat.F32_t | jsfeat.C1_t;
+
+/** Matching `matrix_t` pair, filled with the same deterministic values. */
+function matPair(cols: number, rows: number, seed: number) {
+    const rand = rng(seed);
+    const next = new jsfeatNext.matrix_t(cols, rows, F32C1);
+    const orig = new jsfeat.matrix_t(cols, rows, OF32C1);
+    for (let i = 0; i < cols * rows; i++) {
+        const v = rand() * 4 - 2;
+        next.data[i] = v;
+        orig.data[i] = v;
+    }
+    return { next, orig };
+}
+
+/** A well-conditioned 3x3 (diagonally dominant), so invert_3x3 never hits a singular matrix. */
+function mat3x3Pair(seed: number) {
+    const rand = rng(seed);
+    const next = new jsfeatNext.matrix_t(3, 3, F32C1);
+    const orig = new jsfeat.matrix_t(3, 3, OF32C1);
+    for (let r = 0; r < 3; r++) {
+        for (let c = 0; c < 3; c++) {
+            const v = rand() * 2 - 1 + (r === c ? 4 : 0);
+            next.data[r * 3 + c] = v;
+            orig.data[r * 3 + c] = v;
+        }
+    }
+    return { next, orig };
+}
+
+// ---------------------------------------------------------------- math
+
+describe("math.get_gaussian_kernel — size 7, sigma 0 (hardcoded table)", () => {
+    // size <= 7, odd, sigma <= 0 hits the hardcoded coefficient switch rather
+    // than the Math.exp loop -- the branch imgproc.gaussian_blur takes at its
+    // default kernel sizes.
+    const kernelN = new Float32Array(7);
+    const kernelO = new Float32Array(7);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.math.get_gaussian_kernel(7, 0, kernelN, F32C1);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.math.get_gaussian_kernel(7, 0, kernelO, OF32C1);
+    });
+});
+
+describe("math.get_gaussian_kernel — size 9, sigma 0 (computed, Math.exp)", () => {
+    // size > 7 falls through to the exp() loop: a genuinely different cost
+    // profile from the case above, the same way imgproc's U8 and F32 paths are.
+    const kernelN = new Float32Array(9);
+    const kernelO = new Float32Array(9);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.math.get_gaussian_kernel(9, 0, kernelN, F32C1);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.math.get_gaussian_kernel(9, 0, kernelO, OF32C1);
+    });
+});
+
+describe("math.qsort — 2048 floats", () => {
+    const N = 2048;
+    const pristine = Array.from({ length: N }, rng(9001));
+    const arrN: number[] = new Array(N);
+    const arrO: number[] = new Array(N);
+    const cmp = (a: number, b: number) => (a < b ? -1 : a > b ? 1 : 0);
+
+    bench(
+        "jsfeatNext",
+        () => {
+            jsfeatNext.math.qsort(arrN, 0, N - 1, cmp);
+        },
+        {
+            setup: () => {
+                for (let i = 0; i < N; i++) arrN[i] = pristine[i];
+            },
+        }
+    );
+
+    bench(
+        "jsfeat (reference)",
+        () => {
+            jsfeat.math.qsort(arrO, 0, N - 1, cmp);
+        },
+        {
+            setup: () => {
+                for (let i = 0; i < N; i++) arrO[i] = pristine[i];
+            },
+        }
+    );
+});
+
+describe("math.median — 512 floats (lmeds inlier residuals)", () => {
+    // 512 is the order of magnitude motion_estimator.lmeds works at: one
+    // residual per correspondence.
+    const N = 512;
+    const pristine = Float32Array.from({ length: N }, rng(9002));
+    const arrN = new Float32Array(N);
+    const arrO = new Float32Array(N);
+
+    bench(
+        "jsfeatNext",
+        () => {
+            jsfeatNext.math.median(arrN, 0, N - 1);
+        },
+        {
+            setup: () => {
+                arrN.set(pristine);
+            },
+        }
+    );
+
+    bench(
+        "jsfeat (reference)",
+        () => {
+            jsfeat.math.median(arrO, 0, N - 1);
+        },
+        {
+            setup: () => {
+                arrO.set(pristine);
+            },
+        }
+    );
+});
+
+// ------------------------------------------------------------- matmath
+
+describe("matmath.transpose — 9x9 (linalg SVD's own size)", () => {
+    // linalg.svd_decompose calls transpose five times per decomposition, at
+    // the 9x9 size motion_model's homography DLT uses (#158).
+    const { next: A, orig: Ao } = matPair(9, 9, 9003);
+    const At = new jsfeatNext.matrix_t(9, 9, F32C1);
+    const Ato = new jsfeat.matrix_t(9, 9, OF32C1);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.matmath.transpose(At, A);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.matmath.transpose(Ato, Ao);
+    });
+});
+
+describe("matmath.invert_3x3", () => {
+    const { next: A, orig: Ao } = mat3x3Pair(9004);
+    const inv = new jsfeatNext.matrix_t(3, 3, F32C1);
+    const invO = new jsfeat.matrix_t(3, 3, OF32C1);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.matmath.invert_3x3(A, inv);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.matmath.invert_3x3(Ao, invO);
+    });
+});
+
+describe("matmath.multiply_3x3", () => {
+    // motion_model calls this twice per model fit, per frame.
+    const { next: A, orig: Ao } = mat3x3Pair(9005);
+    const { next: B, orig: Bo } = mat3x3Pair(9006);
+    const C = new jsfeatNext.matrix_t(3, 3, F32C1);
+    const Co = new jsfeat.matrix_t(3, 3, OF32C1);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.matmath.multiply_3x3(C, A, B);
+    });
+
+    bench("jsfeat (reference)", () => {
+        jsfeat.matmath.multiply_3x3(Co, Ao, Bo);
+    });
+});
+
+// ----------------------------------------------------------- transform
+
+describe("transform.invert_affine_transform (matrix_t vs raw array)", () => {
+    // NOT strictly like-for-like: jsfeatNext takes matrix_t and unwraps
+    // .data internally; jsfeat takes the raw arrays directly. See the module
+    // docstring -- a small ratio in jsfeat's favour is expected here.
+    const { next: src } = matPair(3, 2, 9007);
+    const dst = new jsfeatNext.matrix_t(3, 2, F32C1);
+    const srcRaw = Array.from(src.data);
+    const dstRaw = new Array(6).fill(0);
+
+    bench("jsfeatNext (matrix_t)", () => {
+        jsfeatNext.transform.invert_affine_transform(src, dst);
+    });
+
+    bench("jsfeat (reference, raw array)", () => {
+        jsfeat.transform.invert_affine_transform(srcRaw, dstRaw);
+    });
+});
+
+describe("transform.invert_perspective_transform (matrix_t vs raw array)", () => {
+    const { next: src } = mat3x3Pair(9008);
+    const dst = new jsfeatNext.matrix_t(3, 3, F32C1);
+    const srcRaw = Array.from(src.data);
+    const dstRaw = new Array(9).fill(0);
+
+    bench("jsfeatNext (matrix_t)", () => {
+        jsfeatNext.transform.invert_perspective_transform(src, dst);
+    });
+
+    bench("jsfeat (reference, raw array)", () => {
+        jsfeat.transform.invert_perspective_transform(srcRaw, dstRaw);
+    });
+});

--- a/bench/math_matmath_transform.bench.ts
+++ b/bench/math_matmath_transform.bench.ts
@@ -56,7 +56,8 @@ import { rng } from "../tests/properties/helpers";
  *
  *   - `math.get_gaussian_kernel` — `imgproc.gaussian_blur` (imgproc.ts:277)
  *   - `math.median`              — `motion_estimator.lmeds` (motion_estimator.ts:378)
- *   - `matmath.transpose`        — `linalg.svd_decompose`, five call sites
+ *   - `matmath.transpose`        — `linalg.svd_decompose` (5 call sites, at
+ *                                  most 3 taken per call, usually 1)
  *   - `matmath.invert_3x3` / `multiply_3x3` — `motion_model`, per frame
  *
  * `math.qsort` is included despite having no in-tree caller: it is public
@@ -172,7 +173,14 @@ describe("math.qsort — 2048 floats", () => {
     const pristine = Array.from({ length: N }, rng(9001));
     const arrN: number[] = new Array(N);
     const arrO: number[] = new Array(N);
-    const cmp = (a: number, b: number) => (a < b ? -1 : a > b ? 1 : 0);
+    // qsort uses `cmp` in BOOLEAN contexts (`if (cmp(a,b))`, ternaries), so it
+    // needs a "less-than" predicate, not a three-way -1/0/1 comparator: the
+    // latter returns a truthy value for BOTH orderings, making the algorithm
+    // see "a < b" as true in either direction. An earlier version of this
+    // bench used the three-way shape and produced a completely unsorted array
+    // -- i.e. it was not measuring sorting at all (caught in review). Same
+    // predicate shape as tests/parity/math.test.ts.
+    const cmp = (a: number, b: number) => (a < b ? 1 : 0);
 
     bench(
         "jsfeatNext",
@@ -235,8 +243,11 @@ describe("math.median — 512 floats (lmeds inlier residuals)", () => {
 // ------------------------------------------------------------- matmath
 
 describe("matmath.transpose — 9x9 (linalg SVD's own size)", () => {
-    // linalg.svd_decompose calls transpose five times per decomposition, at
-    // the 9x9 size motion_model's homography DLT uses (#158).
+    // linalg.svd_decompose has five transpose call sites, but they sit in
+    // mutually exclusive / optional branches (linalg.ts:676-742): at most 3
+    // run per decomposition, and with SVD_U_T|SVD_V_T set -- what
+    // motion_model and bench/linalg.bench.ts both use -- only 1 does.
+    // Benched at the 9x9 size motion_model's homography DLT uses (#158).
     const { next: A, orig: Ao } = matPair(9, 9, 9003);
     const At = new jsfeatNext.matrix_t(9, 9, F32C1);
     const Ato = new jsfeat.matrix_t(9, 9, OF32C1);
@@ -288,8 +299,13 @@ describe("transform.invert_affine_transform (matrix_t vs raw array)", () => {
     // docstring -- a small ratio in jsfeat's favour is expected here.
     const { next: src } = matPair(3, 2, 9007);
     const dst = new jsfeatNext.matrix_t(3, 2, F32C1);
-    const srcRaw = Array.from(src.data);
-    const dstRaw = new Array(6).fill(0);
+    // Float32Array on BOTH sides: an earlier version passed jsfeat a packed
+    // JS array (Array.from), which V8 stores and optimises very differently
+    // from a Float32Array -- that confounded the calling-convention question
+    // with an element-storage difference (caught in review). Now the ONLY
+    // difference is matrix_t-vs-raw, which is what this case is about.
+    const srcRaw = Float32Array.from(src.data);
+    const dstRaw = new Float32Array(6);
 
     bench("jsfeatNext (matrix_t)", () => {
         jsfeatNext.transform.invert_affine_transform(src, dst);
@@ -303,8 +319,8 @@ describe("transform.invert_affine_transform (matrix_t vs raw array)", () => {
 describe("transform.invert_perspective_transform (matrix_t vs raw array)", () => {
     const { next: src } = mat3x3Pair(9008);
     const dst = new jsfeatNext.matrix_t(3, 3, F32C1);
-    const srcRaw = Array.from(src.data);
-    const dstRaw = new Array(9).fill(0);
+    const srcRaw = Float32Array.from(src.data);
+    const dstRaw = new Float32Array(9);
 
     bench("jsfeatNext (matrix_t)", () => {
         jsfeatNext.transform.invert_perspective_transform(src, dst);


### PR DESCRIPTION
## Summary

The three modules earlier phase-2 PRs left uncovered (#86): **`math`**, **`matmath`** and **`transform`**. With this, every module has a bench file. No changes to `src/`.

## Case selection: by caller, not by enumeration

These three modules expose ~19 public methods between them. Benching all of them would mostly time arithmetic nobody runs in a frame loop, so the nine cases are the ones with a real in-tree caller:

| Case | Caller |
| --- | --- |
| `math.get_gaussian_kernel` — size 7 / size 9 | `imgproc.gaussian_blur`. Split because `size <= 7 && odd && sigma <= 0` takes a hardcoded coefficient table and anything else falls through to a `Math.exp` loop — two cost profiles, like imgproc's U8/F32 split |
| `math.median` (512 floats) | `motion_estimator.lmeds` |
| `matmath.transpose` — 9x9 | `linalg.svd_decompose`, five call sites, at the DLT's size |
| `matmath.invert_3x3` / `multiply_3x3` | `motion_model`, per frame |
| `math.qsort` (2048 floats) | No in-tree caller, but public API and the one genuinely algorithmic routine in `math` |
| `transform.invert_affine_transform` / `invert_perspective_transform` | Public API — see the calling-convention note below |

`math.perspective_4point_transform` is deliberately **not** benched: it is deprecated and logs a console warning on every call.

`qsort` and `median` rewrite their input, so both restore fresh data via `setup` (once per mode, outside the timed region). Not a complete fix — within a mode, iterations 2..N still work on already-processed data — but it applies equally to both sides, so the ratio stays fair.

## Result: one real finding

Review found two cases were measuring the wrong thing, so there are two series. The **post-fix** numbers are authoritative — four runs on an idle machine, discarding a warm-up:

| case | r1 | r2 | r3 | r4 | verdict |
| --- | --- | --- | --- | --- | --- |
| `get_gaussian_kernel` size 7 | 1.15 | 1.08 | 1.03 | 1.34 | 4/4 jsfeat, mostly below floor |
| `get_gaussian_kernel` size 9 | 1.08 | 1.12 | 1.12 | 1.03* | below floor |
| `qsort` | 1.05 | 1.02* | 1.08 | 1.18* | flips — noise |
| `median` | 1.09* | 1.05* | 1.00* | 1.11* | 4/4 jsfeatNext, below floor |
| `transpose` 9x9 | 1.04* | 1.09 | 1.19* | 1.20 | flips — noise |
| **`invert_3x3`** | **1.24** | **1.18** | **1.36** | **1.34** | **real** |
| `multiply_3x3` | 1.11 | 1.03* | 1.12 | 1.06 | below floor |
| `invert_affine_transform` | 1.09* | 1.23* | 1.02* | 1.01 | 3/4 jsfeatNext |
| `invert_perspective_transform` | 1.12 | 1.05 | 1.00* | 1.05 | below floor |

\* = jsfeatNext was faster in that run.

**`matmath.invert_3x3` is the one real signal.** jsfeat faster in all four post-fix samples (1.18–1.36) and all six of the earlier series (1.29–1.40) — **ten out of ten, never once flipping**. Called per model fit in `motion_model` (`motion_model.ts:262`), so it's on the per-frame path. Same shape as the YAPE and `linalg` findings; recorded as an open finding, not acted on here.

Everything else sits at or below the ~1.15x floor.

## ⚠️ Corrections forced by review and by the measurements themselves

All recorded in `bench/README.md` rather than quietly fixed.

**The `qsort` case was not sorting** (found in review). `math.qsort` takes a *less-than predicate* and uses it in boolean contexts (`if (cmp(a,b))`, ternaries); the bench passed a conventional three-way `-1/0/1` comparator, which is **truthy for both orderings**, so the algorithm saw `a < b` as true in either direction. Verified with a probe: sorting `[5,3,9,1,7,2,8,4,6,0]` returned `8,4,6,0,5,3,9,1,7,2` — completely unordered. It was timing a non-sort. Fixed to the parity test's predicate shape; the verdict happens to be unchanged (noise either way), but it now measures sorting.

**The `transform` comparison confounded two variables** (found in review). It passed jsfeat a packed JS array (`Array.from`) while jsfeatNext used a `Float32Array` — V8 optimises those very differently, mixing the calling-convention question with element storage. Both sides now use `Float32Array`. This *strengthened* the conclusion: with the confound removed, `invert_affine_transform` favours jsfeatNext in 3 of 4 runs.

**`transpose` call frequency was overstated** (found in review). `svd_decompose` has five call sites but they sit in mutually exclusive/optional branches (`linalg.ts:676-742`) — at most 3 run per decomposition, and only 1 with `SVD_U_T|SVD_V_T` set, which is what `motion_model` and `bench/linalg.bench.ts` both pass.

**An earlier series ran while the machine was busy, and it manufactured three conclusions the idle re-run dismantled.** `get_gaussian_kernel` size 7 looked like a clean 6/6 directional result and now flips twice; `transpose` looked 6/6 and now flips; `qsort` looked like the one case where jsfeatNext consistently won (5/6) and is now an even 3/3 split. Only `invert_3x3` survived — and it got *tighter* (1.29–1.40 vs 1.01–1.48 on the busy machine), the same signature YAPE showed. Worth stating plainly: contention doesn't just add scatter, it manufactures apparent direction.

**A prediction also failed.** The module docstring originally argued `transform` should measurably favour jsfeat, since jsfeatNext's methods take `matrix_t` and unwrap `.data` while jsfeat's take raw arrays — two extra property loads on a function that's a dozen float ops. Across six runs neither transform case clears the noise floor and both flip sign. The `matrix_t` calling convention has no throughput cost this harness can detect. The docstring now states the null result instead of the prediction.

## Verification

`npm test`: **265 passed**. `tsc --noEmit` against a scope that actually includes `bench/**/*` (#157). `prettier --check`, `license-check` (92 files) all clean. Benches measured on an idle machine, warm-up discarded, six samples.

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

