### PR TITLE
feat(bench): add motion_model kernel benchmarks, surfacing a per-call allocation

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -196,8 +196,10 @@ same process, so their `hz` are comparable **to each other** within a run.
 Phase 2 covers each module this way, one PR at a time. As of this PR every
 module has a bench file: `imgproc`, `orb`, `fast_corners`, `yape06`, `yape`,
 `optical_flow_lk`, `linalg`, `motion_estimator`, the `cache` pool, and
-`math`/`matmath`/`transform`. There is still no standalone `motion_model`
-case — it is exercised indirectly through the `motion_estimator` benches.
+`math`/`matmath`/`transform` and `motion_model`. Within `imgproc` only
+`gaussian_blur` and `resample` are benched — the other ~12 public methods
+(`grayscale`, `pyrdown`, the derivative filters, the warps, `canny`, …) are
+not yet covered.
 
 ## Phase 2, continued: optical_flow_lk
 
@@ -454,6 +456,81 @@ operations. Across both series neither transform case clears the noise floor
 in jsfeat's favour. The `matrix_t` calling convention has no throughput cost
 this harness can detect; the docstring now states that null result instead of
 the prediction.
+
+## Open finding: motion_model allocates per call, and it dominates small fits
+
+`bench/motion_estimator.bench.ts` measures `ransac`/`lmeds` end to end, so the
+kernel's own cost is mixed with the estimator's loop. This file calls the
+kernel methods directly, which is what makes the following attributable.
+
+| Case | Why it is here |
+| --- | --- |
+| `homography2d.run` / `affine2d.run` — 4 / 3 points | The per-iteration hypothesis fit: RANSAC calls `run` on a minimal sample every iteration |
+| `homography2d.run` / `affine2d.run` — 40 points | The final refit on the full inlier set |
+| `homography2d.error` / `affine2d.error` — 40 points | The per-iteration scoring pass over all correspondences |
+| `homography2d.check_subset` — 4 points | Called once per RANSAC iteration. `affine2d.check_subset` is a bare `return true` on both sides, so there is nothing to compare |
+
+Correspondences are clean (no outliers), unlike `motion_estimator.bench.ts`'s
+fixture: these kernels are called directly, with no outlier rejection in play,
+so gross outliers would only make `run` fit a meaningless model without
+changing what it costs.
+
+Eight samples, pooled from two idle-machine sessions, each discarding a
+warm-up:
+
+| case | session A | session B | allocates? | verdict |
+| --- | --- | --- | --- | --- |
+| **`affine2d.run` 3 pts** | 3.28 / 3.47 / 3.70 / 3.15 | 3.34 / 3.45 / 3.47 / 3.87 | yes | **real — largest in suite** |
+| **`affine2d.run` 40 pts** | 1.69 / 1.54 / 1.46 / 1.51 | 1.44 / 1.63 / 1.60 / 1.53 | yes | **real** |
+| **`homography2d.run` 4 pts** | 1.22 / 1.31 / 1.33 / 1.51 | 1.26 / 1.73 / 1.32 / 1.34 | yes | **real** |
+| **`homography2d.run` 40 pts** | 1.15 / 1.31 / 1.33 / 1.24 | 1.30 / 1.26 / 1.18 / 1.38 | yes | **real** |
+| **`homography2d.check_subset`** | 1.35 / 1.45 / 1.32 / 1.36 | 1.15 / 2.11 / 1.36 / 1.11 | yes | **real, but wide** |
+| `homography2d.error` 40 pts | 1.03 / 1.11 / 1.06 / 1.05 | 1.02 / 1.16\* / 2.91\* / 1.18 | no | noise |
+| `affine2d.error` 40 pts | 1.09 / 1.10 / 1.05 / 1.05 | 1.07 / 1.06 / 1.01\* / 1.09\* | no | noise |
+
+\* = jsfeatNext was faster in that run.
+
+**Direction is the evidence, and it is unanimous**: the five allocating cases
+favour jsfeat in **all eight** samples without a single flip. Magnitudes vary
+much more — quote `affine2d.run` at 3 points as "roughly 3.5x", not to two
+decimals, and see the caveat below on `check_subset`.
+
+**The cause is visible in the code, and the shape of the result fits it.**
+jsfeatNext constructs a `matmath` instance *inside* three per-call methods —
+`affine2d.run` (`motion_model.ts:212`), `homography2d.run` (line 352) and
+`homography2d.check_subset` (line 541). Original jsfeat does not: its
+equivalents call module-scope functions.
+
+- `affine2d.run` at **3 points** — where the real arithmetic is nearly
+  nothing — runs **~3.5x** slower. A fixed per-call cost dominates entirely.
+- The same method at **40 points** drops to **~1.5x**: identical overhead,
+  amortised over ~13x more real work.
+- `error`, the only pair of methods that **allocates nothing**, is the only
+  pair that flips sign and sits in the noise floor — an unplanned but
+  decisive control.
+
+"Huge ratio on tiny inputs, shrinking as the input grows, absent where there
+is no allocation" is the signature of a fixed per-call allocation, and it is
+what these numbers show.
+
+### A caveat, and a repeated mistake worth recording
+
+An earlier four-sample series put `check_subset` at 1.32–1.45 and this file
+called it "tight". Four more samples widened it to **1.11–2.11**. The
+direction survived; the precision claim did not.
+
+That is the *same* error this file already documents for the YAPE finding —
+"four samples are not enough to characterise a spread, only a direction" —
+made again, one section later, on a different case. Treat every
+tightness claim in this document as provisional until it has eight or more
+samples behind it.
+
+This is the same class of defect as
+[#159](https://github.com/webarkit/jsfeatNext/issues/159) (`matrix_t`
+re-allocating a `data_type` table on every construction) — and note the two
+compound: each `new matmath()` here is itself cheap, but `matmath`'s methods
+build `matrix_t` instances, which is where #159 bites. Measurement only here,
+per #86; the fix belongs in its own PR against `src/`.
 
 ## Notes on the inputs
 

--- a/bench/motion_model.bench.ts
+++ b/bench/motion_model.bench.ts
@@ -1,0 +1,235 @@
+/*
+ *  motion_model.bench.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { bench, describe } from "vitest";
+import jsfeatNext from "../src/jsfeatNext";
+import jsfeat from "../tests/vendor/oracle.cjs";
+import { point_t } from "../src/point_t/point_t";
+import { rng } from "../tests/properties/helpers";
+
+/**
+ * Throughput benchmarks for the motion-model kernels themselves (issue #86).
+ *
+ * Read the RATIO, not the `hz` — see bench/README.md for why, and for the
+ * measured noise floor (ignore anything under ~1.15x).
+ *
+ * ## Why this file exists when motion_estimator.bench.ts already covers RANSAC
+ *
+ * `bench/motion_estimator.bench.ts` measures `ransac`/`lmeds` end to end, so
+ * the kernel's cost is mixed in with the estimator's own loop, subset drawing
+ * and inlier bookkeeping. This file calls the kernel methods directly, which
+ * is what makes a kernel-level regression attributable rather than merely
+ * visible.
+ *
+ * ## The counts are the two RANSAC actually uses
+ *
+ * Every RANSAC iteration calls `run` on a MINIMAL sample (4 points for
+ * homography, 3 for affine) and then `error` on ALL correspondences, and the
+ * winning model is finally refit on the full inlier set. So both the minimal
+ * and the full-count cases below are real workloads, not round numbers:
+ *
+ *   - `run` at 4 / 3 points   — the per-iteration hypothesis fit
+ *   - `run` at 40 points      — the final refit
+ *   - `error` at 40 points    — the per-iteration scoring pass
+ *
+ * ## `check_subset`: a known asymmetry, benched deliberately
+ *
+ * jsfeatNext's `homography2d.check_subset` constructs a `matmath` instance on
+ * every call (`motion_model.ts:541`); original jsfeat's does not. RANSAC calls
+ * it once per iteration, so this is a per-frame allocation jsfeatNext adds and
+ * jsfeat does not have. `affine2d.check_subset` is a bare `return true` on
+ * both sides and is not benched — there would be nothing to compare.
+ *
+ * The same `new matmath()` pattern also appears in `affine2d.run` (line 212)
+ * and `homography2d.run` (line 352), so the `run` cases below carry it too.
+ * This is the same class of issue as #159 (`matrix_t` re-allocating a
+ * `data_type` table per construction) — measurement only here, per #86.
+ */
+
+const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
+const OF32C1 = jsfeat.F32_t | jsfeat.C1_t;
+
+const FULL = 40;
+/** Ground-truth homography used to synthesize correspondences. */
+const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+
+function point(x: number, y: number) {
+    const p = new point_t();
+    p.x = x;
+    p.y = y;
+    p.level = 0;
+    p.score = 0;
+    p.angle = -1;
+    return p;
+}
+
+/**
+ * Clean correspondences from a fixed ground-truth homography — no outliers,
+ * unlike `motion_estimator.bench.ts`'s fixture. The kernels here are called
+ * directly rather than through RANSAC, so there is no outlier rejection in
+ * play; feeding them gross outliers would just make `run` fit a meaningless
+ * model without changing what it costs.
+ */
+function correspondences(seed: number) {
+    const rand = rng(seed);
+    const from: ReturnType<typeof point>[] = [];
+    const to: ReturnType<typeof point>[] = [];
+    for (let i = 0; i < FULL; i++) {
+        const x = 10 + rand() * 300;
+        const y = 10 + rand() * 220;
+        const wsc = 1.0 / (GT[6] * x + GT[7] * y + GT[8]);
+        from.push(point(x, y));
+        to.push(point((GT[0] * x + GT[1] * y + GT[2]) * wsc, (GT[3] * x + GT[4] * y + GT[5]) * wsc));
+    }
+    return { from, to };
+}
+
+const { from, to } = correspondences(4242);
+
+/** Both sides get their own 3x3 output, never shared. */
+function models() {
+    return {
+        model: new jsfeatNext.matrix_t(3, 3, F32C1),
+        modelO: new jsfeat.matrix_t(3, 3, OF32C1),
+    };
+}
+
+// -------------------------------------------------------- homography2d
+
+describe("homography2d.run — 4 points (RANSAC minimal sample)", () => {
+    const { model, modelO } = models();
+    const kernelO = new jsfeat.motion_model.homography2d();
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.homography2d.run(from, to, model, 4);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.run(from, to, modelO, 4);
+    });
+});
+
+describe("homography2d.run — 40 points (final refit)", () => {
+    const { model, modelO } = models();
+    const kernelO = new jsfeat.motion_model.homography2d();
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.homography2d.run(from, to, model, FULL);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.run(from, to, modelO, FULL);
+    });
+});
+
+describe("homography2d.error — 40 points (per-iteration scoring)", () => {
+    const { model, modelO } = models();
+    const kernelO = new jsfeat.motion_model.homography2d();
+    // Fit once, outside the timed region: error() reads the model, never writes it.
+    jsfeatNext.homography2d.run(from, to, model, FULL);
+    kernelO.run(from, to, modelO, FULL);
+    const err = new Float32Array(FULL);
+    const errO = new Float32Array(FULL);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.homography2d.error(from, to, model, err, FULL);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.error(from, to, modelO, errO, FULL);
+    });
+});
+
+describe("homography2d.check_subset — 4 points (allocates matmath in jsfeatNext)", () => {
+    // See the module docstring: jsfeatNext constructs a matmath per call here,
+    // jsfeat does not. RANSAC calls this once per iteration.
+    const kernelO = new jsfeat.motion_model.homography2d();
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.homography2d.check_subset(from, to, 4);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.check_subset(from, to, 4);
+    });
+});
+
+// ------------------------------------------------------------ affine2d
+
+describe("affine2d.run — 3 points (RANSAC minimal sample)", () => {
+    const { model, modelO } = models();
+    const kernelO = new jsfeat.motion_model.affine2d();
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.affine2d.run(from, to, model, 3);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.run(from, to, modelO, 3);
+    });
+});
+
+describe("affine2d.run — 40 points (final refit)", () => {
+    const { model, modelO } = models();
+    const kernelO = new jsfeat.motion_model.affine2d();
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.affine2d.run(from, to, model, FULL);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.run(from, to, modelO, FULL);
+    });
+});
+
+describe("affine2d.error — 40 points (per-iteration scoring)", () => {
+    const { model, modelO } = models();
+    const kernelO = new jsfeat.motion_model.affine2d();
+    jsfeatNext.affine2d.run(from, to, model, FULL);
+    kernelO.run(from, to, modelO, FULL);
+    const err = new Float32Array(FULL);
+    const errO = new Float32Array(FULL);
+
+    bench("jsfeatNext", () => {
+        jsfeatNext.affine2d.error(from, to, model, err, FULL);
+    });
+
+    bench("jsfeat (reference)", () => {
+        kernelO.error(from, to, modelO, errO, FULL);
+    });
+});


### PR DESCRIPTION
## Summary

Benchmarks for the motion-model kernels themselves — the submodule `bench/README.md` flagged as uncovered (#86). `bench/motion_estimator.bench.ts` measures `ransac`/`lmeds` end to end, so the kernel's own cost is mixed with the estimator loop; this file calls `run`/`error`/`check_subset` directly, which is what makes the result attributable. No changes to `src/`.

## Case selection

The counts are the two RANSAC actually uses: a **minimal sample** per iteration (4 points for homography, 3 for affine) and the **full set** for the final refit and per-iteration scoring.

Correspondences are clean — no outliers, unlike `motion_estimator.bench.ts`'s fixture. These kernels are called directly with no outlier rejection in play, so gross outliers would only make `run` fit a meaningless model without changing what it costs.

`affine2d.check_subset` is a bare `return true` on both sides and is not benched — there would be nothing to compare.

## ⚠️ Finding: a per-call allocation, and it dominates small fits

Eight samples, pooled from two idle-machine sessions, each discarding a warm-up:

| case | session A | session B | allocates? | verdict |
| --- | --- | --- | --- | --- |
| **`affine2d.run` 3 pts** | 3.28 / 3.47 / 3.70 / 3.15 | 3.34 / 3.45 / 3.47 / 3.87 | yes | **real — largest in suite** |
| **`affine2d.run` 40 pts** | 1.69 / 1.54 / 1.46 / 1.51 | 1.44 / 1.63 / 1.60 / 1.53 | yes | **real** |
| **`homography2d.run` 4 pts** | 1.22 / 1.31 / 1.33 / 1.51 | 1.26 / 1.73 / 1.32 / 1.34 | yes | **real** |
| **`homography2d.run` 40 pts** | 1.15 / 1.31 / 1.33 / 1.24 | 1.30 / 1.26 / 1.18 / 1.38 | yes | **real** |
| **`homography2d.check_subset`** | 1.35 / 1.45 / 1.32 / 1.36 | 1.15 / 2.11 / 1.36 / 1.11 | yes | **real, but wide** |
| `homography2d.error` 40 pts | 1.03 / 1.11 / 1.06 / 1.05 | 1.02 / 1.16* / 2.91* / 1.18 | no | noise |
| `affine2d.error` 40 pts | 1.09 / 1.10 / 1.05 / 1.05 | 1.07 / 1.06 / 1.01* / 1.09* | no | noise |

\* = jsfeatNext was faster in that run.

The five allocating cases favour jsfeat in **all eight samples, without a single flip**.

### The cause is in the code, and the shape of the result fits it

jsfeatNext constructs a `matmath` instance **inside three per-call methods** — `affine2d.run` ([`motion_model.ts:212`](https://github.com/webarkit/jsfeatNext/blob/dev/src/motion_model/motion_model.ts#L212)), `homography2d.run` (line 352) and `homography2d.check_subset` (line 541). Original jsfeat does not: its equivalents call module-scope functions.

What makes this more than a plausible story is the shape:

- `affine2d.run` at **3 points** — where the real arithmetic is nearly nothing — runs **~3.5x** slower. A fixed per-call cost dominates entirely.
- The same method at **40 points** drops to **~1.5x**: identical overhead, amortised over ~13x more real work.
- `error`, the only pair of methods that **allocates nothing**, is the only pair that flips sign and sits in the noise floor — an unplanned but decisive control.

"Huge ratio on tiny inputs, shrinking as the input grows, absent where there is no allocation" is the signature of a fixed per-call allocation.

This is the same class of defect as #159 (`matrix_t` re-allocating a `data_type` table per construction) — and the two **compound**: each `new matmath()` is cheap by itself, but `matmath`'s methods construct `matrix_t`, which is where #159 bites. Measurement only here, per #86; the fix belongs in its own PR against `src/`.

### A repeated mistake, recorded rather than quietly fixed

A first four-sample series put `check_subset` at 1.32–1.45 and this file called it "tight". Four more samples widened it to **1.11–2.11** — direction held, precision did not.

That is the *same* error `bench/README.md` already documents for the YAPE finding ("four samples are not enough to characterise a spread, only a direction"), made again one section later on a different case. The README now flags every tightness claim in it as provisional until eight or more samples back it.

## Also corrected

`bench/README.md` claimed `motion_model` was the only remaining gap. It isn't: **`imgproc` has ~12 unbenched public methods** (`grayscale`, `pyrdown`, the derivative filters, the warps, `canny`, …) beyond the `gaussian_blur` and `resample` cases from phase 1. The coverage note now says so.

## Verification

`npm test`: **265 passed**. `tsc --noEmit` against a scope that includes `bench/**/*` (#157). `prettier --check`, `license-check` (93 files) all clean. Benches measured on an idle machine, warm-up discarded, eight samples across two sessions.

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
