### PR TITLE
perf(core): share one data_type instance instead of one per matrix_t

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -223,7 +223,7 @@ then 1.05x jsfeat — the sign flips and stays close to the noise floor.
 (both sides share the same pyramidal-search structure), so parity here is the
 expected result, not a surprise worth investigating.
 
-## Phase 2, continued: linalg — RESOLVED by #159
+## Phase 2, continued: linalg — RESOLVED (issue #159)
 
 > **Resolved.** The fix for
 > [#159](https://github.com/webarkit/jsfeatNext/issues/159) (`matrix_t` no

--- a/bench/README.md
+++ b/bench/README.md
@@ -223,7 +223,33 @@ then 1.05x jsfeat — the sign flips and stays close to the noise floor.
 (both sides share the same pyramidal-search structure), so parity here is the
 expected result, not a surprise worth investigating.
 
-## Phase 2, continued: linalg — a second, larger open finding
+## Phase 2, continued: linalg — RESOLVED by #159
+
+> **Resolved.** The fix for
+> [#159](https://github.com/webarkit/jsfeatNext/issues/159) (`matrix_t` no
+> longer re-allocates a `data_type` table per construction) removed this
+> finding. Post-fix, four idle-machine runs:
+>
+> | case | before | after | status |
+> | --- | --- | --- | --- |
+> | `svd_invert` | 1.29–1.40 (4/4 jsfeat, tight) | 1.07 / 1.19 / 1.17 / 1.12 | below floor |
+> | `eigenVV` | 1.23–1.45 (4/4 jsfeat) | 1.15\* / 1.22 / 1.04 / 1.02 | flips — noise |
+> | `svd_decompose` | 1.31–2.75 | 1.12 / 1.04 / 1.01 / 1.15 | below floor |
+> | `svd_solve` | 1.29–1.44 | 1.06 / 1.09 / 1.13 / 1.07 | below floor |
+> | `lu_solve` | 1.34–1.88 | 1.34 / 1.55 / 1.24 / 1.43 | **still a finding** |
+> | `cholesky_solve` | noisy | 1.07\* / 1.36 / 1.22 / 1.04\* | still noisy |
+>
+> \* = jsfeatNext faster in that run.
+>
+> The four cases that construct internal `matrix_t` instances all dropped to
+> or below the noise floor. `lu_solve` did **not** improve — and #159's own
+> "What this does NOT explain" section predicted exactly that, since it
+> constructs no internal `matrix_t`. It remains open and unexplained.
+>
+> The analysis below is kept as the record of how the finding was found and
+> diagnosed.
+
+### Original finding (now resolved)
 
 | Case | Why it is here |
 | --- | --- |
@@ -317,12 +343,12 @@ outlier in the `linalg` section above, discarding it without a stated cause
 (unlike the CPU-contention runs discarded elsewhere in this file, which had
 one) would be cherry-picking.
 
-Not yet profiled. Given `ransac`'s magnitude and tightness closely match
-`svd_invert`'s, and `motion_estimator.ransac`/`lmeds` call `homography2d.run`
-(`motion_model.ts`), which in turn calls `linalg.eigenVV` — the #159 fix,
-once it lands, is a plausible candidate to shrink this finding too, but that
-is a hypothesis to check by re-running this bench after #159, not a claim
-made now.
+**Hypothesis confirmed.** This section originally predicted that #159's fix
+was "a plausible candidate to shrink this finding too", to be checked by
+re-running after it landed. It was: post-fix, `ransac` measured 1.31 and 1.03
+(against a pre-fix 1.41–1.44 that never flipped) and `lmeds` 1.14 / 1.15
+(against 1.23–1.53). Both are now at or below the noise floor. The chain was
+`ransac` → `homography2d.run` → `linalg.eigenVV` → `matrix_t` construction.
 
 ## Phase 2, continued: the cache pool
 
@@ -457,7 +483,34 @@ in jsfeat's favour. The `matrix_t` calling convention has no throughput cost
 this harness can detect; the docstring now states that null result instead of
 the prediction.
 
-## Open finding: motion_model allocates per call, and it dominates small fits
+## motion_model: per-call allocation — largely RESOLVED by #159
+
+> **Largely resolved.** #159's fix cascaded here, as predicted: `new matmath()`
+> is cheap in itself, but `matmath`'s methods construct `matrix_t`, which is
+> where #159 bit. Post-fix, four idle-machine runs:
+>
+> | case | before | after | status |
+> | --- | --- | --- | --- |
+> | **`affine2d.run` 3 pts** | **3.15–3.87** | 1.40 / 1.09 / 1.41 / 1.18 | **collapsed** |
+> | `affine2d.run` 40 pts | 1.44–1.69 | 1.22 / 1.04 / 1.11\* / 1.12 | below floor |
+> | `homography2d.run` 4 pts | 1.22–1.73 | 1.25 / 1.01\* / 1.11 / 1.19 | below floor |
+> | `homography2d.run` 40 pts | 1.15–1.38 | 1.08 / 1.05 / 1.08 / 1.09 | below floor |
+> | `homography2d.check_subset` | 1.11–2.11 | 1.24 / 1.34 / 1.01\* / 1.30 | improved, still directional |
+> | `error` (both) | noise | noise | unchanged, as expected |
+>
+> \* = jsfeatNext faster in that run.
+>
+> `affine2d.run` at 3 points — the largest ratio this suite ever measured —
+> went from ~3.5x to ~1.27x. The `error` cases, which never allocated, are
+> unchanged: the control behaved as a control should.
+>
+> `check_subset` still leans jsfeat's way. The three `new matmath()` sites in
+> `motion_model.ts` (lines 212, 352, 541) are still there — #159 made each one
+> much cheaper, it did not remove them.
+>
+> The analysis below is kept as the record of how the finding was diagnosed.
+
+### Original finding (now largely resolved)
 
 `bench/motion_estimator.bench.ts` measures `ransac`/`lmeds` end to end, so the
 kernel's own cost is mixed with the estimator's loop. This file calls the

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -40,7 +40,7 @@
  *
  */
 
-import { IData_Type, data_type } from "../data_type/data_type";
+import { IData_Type, shared_data_type } from "../data_type/data_type";
 import { cache } from "../cache/cache";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import pkg from "../../package.json";
@@ -110,7 +110,7 @@ export default class jsfeatNext {
     static orb: orb;
 
     constructor() {
-        this.dt = new data_type();
+        this.dt = shared_data_type;
         this.cache = shared_cache;
     }
 

--- a/src/data_type/data_type.ts
+++ b/src/data_type/data_type.ts
@@ -94,3 +94,17 @@ export class data_type implements IData_Type {
         return this._data_type_size[(type & 0xff00) >> 8];
     }
 }
+
+/**
+ * The library-wide `data_type` instance.
+ *
+ * `data_type` is stateless after construction — its lookup table is
+ * `readonly` and never mutated — so a single shared instance serves every
+ * caller. Constructing one per `matrix_t` allocated a fresh `Int32Array(17)`
+ * on every matrix, which CPU profiling attributed 16.6% of `linalg.svd_invert`
+ * to (see issue #159). Original jsfeat keeps the equivalent table as a single
+ * module-scope constant; this restores that.
+ *
+ * Mirrors the `shared_cache` pattern in `src/core/core.ts`.
+ */
+export const shared_data_type = new data_type();

--- a/src/matrix_t/matrix_t.ts
+++ b/src/matrix_t/matrix_t.ts
@@ -40,7 +40,7 @@
  *
  */
 
-import { IData_Type, data_type } from "../data_type/data_type";
+import { IData_Type, shared_data_type } from "../data_type/data_type";
 import { data_t } from "../node_utils/data_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import type { TypedArray } from "../types";
@@ -115,7 +115,7 @@ export class matrix_t implements IMatrix_T {
      *                     allocating a new one (used with cache-pool buffers).
      */
     constructor(c: number, r: number, _data_type: number, _data_buffer?: data_t) {
-        this.dt = new data_type();
+        this.dt = shared_data_type;
         this.type = this.dt._get_data_type(_data_type) | 0;
         this.channel = this.dt._get_channel(_data_type) | 0;
         this.cols = c | 0;


### PR DESCRIPTION
Closes #159.

## The change

`matrix_t`'s constructor called `new data_type()` on **every** construction, and `data_type`'s constructor allocates a fresh `Int32Array(17)` lookup table. That table is a constant — it never depends on the matrix being built — and `data_type` is stateless afterwards (the field is `readonly`, never mutated). Original jsfeat keeps the equivalent table as a single module-scope constant.

Replaced with a `shared_data_type` singleton exported from `data_type.ts`, in the same spirit as `shared_cache` in `core.ts`. Both construction sites use it: `matrix_t.ts:118` (the hot one) and `core.ts:113`.

**No behavior change** — identical lookup values, just not reallocated. The 265 parity/property tests stay green, unchanged.

## Verification: the profile that diagnosed it, re-run

Same workload as #159 (1.5M `svd_invert` calls after a 50k warm-up):

| | before | after |
| --- | --- | --- |
| wall time | 45.7s | **35.2s** |
| **`data_type` ctor** | **16.6%** | **absent from the profile** |
| `JacobiSVDImpl` (the real kernel) | 68.4% | **85.1%** |
| garbage collector | 1.0% | **0.3%** |

The math kernel now dominates the profile, as it should.

## Effect on the benchmarks

Four idle-machine runs each, warm-up discarded.

**`linalg`** — the module the finding came from:

| case | before | after | status |
| --- | --- | --- | --- |
| `svd_invert` | 1.29–1.40 (4/4 jsfeat, tightest signal in the suite) | 1.07 / 1.19 / 1.17 / 1.12 | below floor |
| `eigenVV` | 1.23–1.45 (4/4 jsfeat) | 1.15* / 1.22 / 1.04 / 1.02 | flips — noise |
| `svd_decompose` | 1.31–2.75 | 1.12 / 1.04 / 1.01 / 1.15 | below floor |
| `svd_solve` | 1.29–1.44 | 1.06 / 1.09 / 1.13 / 1.07 | below floor |
| `lu_solve` | 1.34–1.88 | 1.34 / 1.55 / 1.24 / 1.43 | **still a finding** |
| `cholesky_solve` | noisy | 1.07* / 1.36 / 1.22 / 1.04* | still noisy |

\* = jsfeatNext faster in that run.

**`lu_solve` not improving is the predicted result, not an anomaly.** #159's own "What this does NOT explain" section called it out, because `lu_solve` constructs no internal `matrix_t`. It stays open and unexplained — worth its own investigation.

**`motion_model` / `motion_estimator`** — the cascade [#163](https://github.com/webarkit/jsfeatNext/pull/163) predicted, since `new matmath()` is cheap by itself but `matmath`'s methods construct `matrix_t`:

| case | before | after |
| --- | --- | --- |
| **`affine2d.run` 3 pts** | **3.15–3.87** (largest ratio ever measured here) | **1.09–1.41** |
| `homography2d.run` | 1.15–1.73 | 1.01–1.25 |
| `motion_estimator.ransac` | 1.41–1.44 (never flipped) | 1.03 / 1.31 |
| `error()` — *never allocated* | noise | noise, unchanged |

The `error()` cases being unchanged is the control behaving as a control: they were the only `motion_model` methods that allocated nothing, and they are the only ones the fix did not touch.

`bench/README.md`'s affected sections now carry before/after tables; the original analyses are kept as the record of how each was diagnosed rather than deleted.

## What this does *not* fix

The three `new matmath()` sites in `motion_model.ts` (lines 212, 352, 541) still exist — this made each one much cheaper, it did not remove them. `check_subset` still leans jsfeat's way (1.24 / 1.34 / 1.01* / 1.30). Worth a follow-up issue if you want it tracked.

## Verification

`npm test`: **265 passed**, unchanged. `tsc --noEmit`, `prettier --check`, `license-check` (93 files) all clean. Profile and benches measured on an idle machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
