### PR TITLE
perf(matmath): hoist EPSILON out of invert_3x3's per-call path

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -435,7 +435,33 @@ series — four runs on an idle machine, discarding a warm-up:
 
 \* = jsfeatNext was faster in that run; every other figure favours jsfeat.
 
-**`matmath.invert_3x3` is the one real signal here.** jsfeat is faster in all
+> **Resolved.** Profiling attributed this finding entirely to the singular-matrix
+> check that #120 *added* to `invert_3x3` — a line original jsfeat does not
+> have at all. Isolating the two halves of it:
+>
+> | variant | ops/s |
+> | --- | --- |
+> | jsfeatNext as written (`Math.abs(det) < JSFEAT_CONSTANTS.EPSILON`) | 9.35M |
+> | drop `Math.abs` only | 10.01M (+7%) |
+> | hoist `EPSILON` to module scope only | 13.36M (**+43%**) |
+> | both | 14.57M |
+> | jsfeat (no check at all) | 12.47M |
+>
+> The **object property load dominates**, not `Math.abs` — for a function whose
+> arithmetic is only ~30 float operations, one property read per call is not
+> negligible. With both fixed, the standalone form is faster than jsfeat while
+> keeping #120's semantics exactly (verified identical for `NaN` and `-0`).
+>
+> After the fix, eight idle-machine runs: 1.03 / 2.20 / 1.01 / 1.09 / 1.15\* /
+> 1.14 / 1.09 / 1.04 — seven of eight at or below the noise floor, and the sign
+> now flips, where before it was 10/10 jsfeat and never below 1.18. The 2.20 is
+> a single outlier, reported rather than discarded.
+>
+> The remaining ~1.05x is method-dispatch overhead the standalone probe did not
+> have: the probe measured a plain function, the real path goes through
+> `jsfeatNext.matmath.invert_3x3`.
+
+**`matmath.invert_3x3` (now resolved — see above) was the one real signal here.** jsfeat is faster in all
 four post-fix samples (1.18–1.36) and in all six of the earlier series
 (1.29–1.40) — **ten out of ten**, never once flipping. It is called per model
 fit in `motion_model` (`motion_model.ts:262`), so it is on the per-frame path.

--- a/bench/README.md
+++ b/bench/README.md
@@ -418,8 +418,10 @@ the sorted-input case.
 deprecated and logs a console warning on every call.
 
 Two series were needed here, because review found two cases were measuring
-the wrong thing (details below). The authoritative numbers are the post-fix
-series — four runs on an idle machine, discarding a warm-up:
+the wrong thing (details below). The numbers here are from the second series,
+after those harness fixes — four runs on an idle machine, discarding a
+warm-up. **They predate the `invert_3x3` fix**; that row's current status is
+in the box below the table.
 
 | case | r1 | r2 | r3 | r4 | verdict |
 | --- | --- | --- | --- | --- | --- |
@@ -428,7 +430,7 @@ series — four runs on an idle machine, discarding a warm-up:
 | `qsort` | 1.05 | 1.02\* | 1.08 | 1.18\* | flips — noise |
 | `median` | 1.09\* | 1.05\* | 1.00\* | 1.11\* | 4/4 jsfeatNext, below floor |
 | `transpose` 9x9 | 1.04\* | 1.09 | 1.19\* | 1.20 | flips — noise |
-| **`invert_3x3`** | **1.24** | **1.18** | **1.36** | **1.34** | **real** |
+| `invert_3x3` | 1.24 | 1.18 | 1.36 | 1.34 | was real — **now fixed, see below** |
 | `multiply_3x3` | 1.11 | 1.03\* | 1.12 | 1.06 | below floor |
 | `invert_affine_transform` | 1.09\* | 1.23\* | 1.02\* | 1.01 | 3/4 jsfeatNext |
 | `invert_perspective_transform` | 1.12 | 1.05 | 1.00\* | 1.05 | below floor |
@@ -461,12 +463,12 @@ series — four runs on an idle machine, discarding a warm-up:
 > have: the probe measured a plain function, the real path goes through
 > `jsfeatNext.matmath.invert_3x3`.
 
-**`matmath.invert_3x3` (now resolved — see above) was the one real signal here.** jsfeat is faster in all
-four post-fix samples (1.18–1.36) and in all six of the earlier series
-(1.29–1.40) — **ten out of ten**, never once flipping. It is called per model
-fit in `motion_model` (`motion_model.ts:262`), so it is on the per-frame path.
-Same shape as the YAPE and `linalg` findings; recorded as an open finding, not
-acted on here.
+**`matmath.invert_3x3` was the one real signal here, and it has since been
+fixed.** Across the two series above it favoured jsfeat in **ten out of ten**
+samples (1.18–1.40) without once flipping. It is called per model fit in
+`motion_model` (`motion_model.ts:262`), so it sits on the per-frame path. The
+cause and the fix are in the box above; post-fix it no longer clears the noise
+floor and the sign flips.
 
 Everything else is at or below the ~1.15x floor. `get_gaussian_kernel` size 7
 favours jsfeat 4/4 and `median` favours jsfeatNext 4/4, but both sit low

--- a/src/matmath/matmath.ts
+++ b/src/matmath/matmath.ts
@@ -364,9 +364,10 @@ export default class matmath {
 
         // Two-sided compare rather than Math.abs(det) < EPSILON: identical for
         // every input including NaN (both yield 1) and -0 (both yield 0), and
-        // it avoids a call. Together with the hoisted EPSILON above this makes
-        // invert_3x3 faster than original jsfeat, which performs no singular
-        // check at all -- the check itself was this port's addition (#120).
+        // it avoids a call. With the hoisted EPSILON above, this removes the
+        // per-call property load and function call that the singular check
+        // (added by #120 -- original jsfeat has no such check) was costing.
+        // See bench/README.md for the measured effect.
         return det < EPSILON && det > -EPSILON ? 0 : 1;
     }
 

--- a/src/matmath/matmath.ts
+++ b/src/matmath/matmath.ts
@@ -44,6 +44,16 @@ import { matrix_t } from "../matrix_t/matrix_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 
 /**
+ * `JSFEAT_CONSTANTS.EPSILON` hoisted to module scope.
+ *
+ * Reading it as a property inside {@link matmath.invert_3x3} cost ~43% of that
+ * function's throughput: the arithmetic around it is only ~30 float ops, so a
+ * single object property load per call is not negligible. Measured under #86;
+ * see `bench/README.md`.
+ */
+const EPSILON = JSFEAT_CONSTANTS.EPSILON;
+
+/**
  * General matrix arithmetic on {@link matrix_t} operands: transpose,
  * several multiplication variants optimized for common shapes, and small
  * fixed-size 3×3 helpers used by the geometric-transform code.
@@ -352,7 +362,12 @@ export default class matmath {
         invA[7] = -(t8 * t5 - t21) * t26;
         invA[8] = (t9 - t15) * t26;
 
-        return Math.abs(det) < JSFEAT_CONSTANTS.EPSILON ? 0 : 1;
+        // Two-sided compare rather than Math.abs(det) < EPSILON: identical for
+        // every input including NaN (both yield 1) and -0 (both yield 0), and
+        // it avoids a call. Together with the hoisted EPSILON above this makes
+        // invert_3x3 faster than original jsfeat, which performs no singular
+        // check at all -- the check itself was this port's addition (#120).
+        return det < EPSILON && det > -EPSILON ? 0 : 1;
     }
 
     /**


### PR DESCRIPTION
## Summary

`bench/README.md` carried **`matmath.invert_3x3`** as an open finding: jsfeat faster in **10 of 10** samples, 1.18–1.40x, never flipping. Profiling attributed it *entirely* to the singular-matrix check that **#120 added** — a line original jsfeat does not have at all, so this was never porting drift.

## Attribution

Isolating the two halves of `return Math.abs(det) < JSFEAT_CONSTANTS.EPSILON ? 0 : 1;`:

| variant | ops/s | |
| --- | --- | --- |
| jsfeatNext as written | 9.35M | — |
| drop `Math.abs` only | 10.01M | +7% |
| hoist `EPSILON` to module scope only | 13.36M | **+43%** |
| both | 14.57M | +56% |
| jsfeat (no check at all) | 12.47M | reference |

**The object property load dominates, not `Math.abs`.** The surrounding arithmetic is only ~30 float operations, so one property read per call is not negligible — and with both fixed the standalone form is *faster than jsfeat*, which does no singular check at all.

## The fix

`EPSILON` hoisted to a module-scope `const`, and `Math.abs(det) < EPSILON` replaced by the two-sided compare `det < EPSILON && det > -EPSILON`.

**Semantics unchanged, edge cases included:** `NaN` yields `1` under both forms (all NaN comparisons are false), `-0` yields `0` under both. The 265 parity/property tests stay green, unchanged.

## Result

Eight idle-machine runs after the fix:

`1.03 / 2.20 / 1.01 / 1.09 / 1.15* / 1.14 / 1.09 / 1.04`  (\* = jsfeatNext faster)

Seven of eight sit at or below the ~1.15x noise floor, and **the sign now flips** — where before it was 10/10 jsfeat and never below 1.18. The 2.20 is a single outlier, reported rather than discarded.

The residual ~1.05x is method-dispatch overhead the standalone probe didn't have: the probe timed a plain function, the shipped path goes through `jsfeatNext.matmath.invert_3x3`.

## Two things this investigation also established

**A hypothesis was disproven, not confirmed.** The same profiling session tested `bench/README.md`'s long-standing YAPE hypothesis — that importing `hessian_min_eigen_value` across modules blocks V8 inlining. The profile shows **96.6% of `yape06.detect`'s time in `detect` itself and ~0.6% in the helpers**, and the two implementations' inner loops are character-for-character identical. The hypothesis does not hold; YAPE's cause is still unknown. (Not changed in this PR — flagging it so the README's wording gets revisited.)

**A misattribution was caught.** `linalg.lu_solve` — the finding #159 explicitly did not explain — also reads `JSFEAT_CONSTANTS.EPSILON` inside a loop, which looked like the same bug. It isn't: jsfeat's equivalent reads `jsfeat.EPSILON`, also a property load. **Both sides pay the same cost there**, so it explains nothing. `lu_solve` remains open.

## Verification

`npm test`: **265 passed**, unchanged. `tsc --noEmit`, `prettier --check`, `license-check` (93 files) all clean. Benches measured on an idle machine, warm-up discarded, eight samples.

Refs #86, #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
