### PR TITLE
perf(yape): alias imported helpers to module-scope consts

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -88,7 +88,45 @@ Judged **against the noise floor above**, not in isolation:
 
 Since jsfeatNext is a port of jsfeat, ratios near **1.0× are the expected, healthy state** — the two are doing the same arithmetic. A *sustained* move is interesting; a single-run move is not.
 
-## Open finding: the YAPE detectors are consistently slower
+## YAPE detectors: `yape` RESOLVED, `yape06` still open
+
+> **Partly resolved, and the original hypothesis was wrong.**
+>
+> This section long carried the theory that importing
+> `hessian_min_eigen_value` across modules blocked V8 inlining. Profiling
+> `yape06.detect` refuted it: **96.6% of the time is in `detect` itself and
+> ~0.6% in the helpers**, and the two implementations' inner loops are
+> character-for-character identical.
+>
+> A structural probe then replicated `detect`'s body verbatim under four
+> shapes, verified to find identical corner counts. Across three clean runs,
+> two effects reproduced — a class method is slower than an object-literal
+> property, and calling an ESM **imported binding** from a hot loop is slower
+> than calling a plain module-scope `const` holding the same function
+> (imported bindings are live, so each access carries an indirection). The
+> second gained 12–28% every run, and is a one-line change.
+>
+> Aliasing the helpers to module-scope consts in `yape06.ts` and `yape.ts`
+> gave a **split result**:
+>
+> | case | before (8 samples) | after (4 samples) | status |
+> | --- | --- | --- | --- |
+> | **`yape`** | 8/8 jsfeat, 1.23–1.53 | 1.02\* / 1.05\* / 1.14 / 1.06\* | **resolved** — sign now flips |
+> | `yape06` | 8/8 jsfeat, 1.11–1.45 | 1.14 / 1.47 / 1.41 / 1.24 | **unchanged, still open** |
+>
+> \* = jsfeatNext faster in that run.
+>
+> The split is consistent with the profile rather than at odds with it:
+> `yape06` calls `compute_laplacian` **once per frame** and
+> `hessian_min_eigen_value` only for candidate pixels — which is exactly why
+> the helpers showed 0.6%. `yape`'s helpers sit in the per-pixel loop, so
+> aliasing them matters there. `yape06`'s alias is kept for consistency but
+> measured no benefit; **its cause remains unknown**, and the class-vs-object
+> effect the probe also showed is the remaining untested candidate.
+>
+> The measurements below are the pre-fix record.
+
+### Original finding (pre-fix record)
 
 The first real signal this harness produced. Eight samples, pooled from two
 separate sessions on an idle machine (power connected, browser and editor

--- a/src/yape/yape.ts
+++ b/src/yape/yape.ts
@@ -41,6 +41,11 @@
  */
 
 import { third_check, is_local_maxima, perform_one_point, lev_table_t } from "./yape_utils";
+
+/** Module-scope aliases for the per-pixel helpers -- see the note in `yape06.ts`. */
+const thirdCheck = third_check;
+const isLocalMaxima = is_local_maxima;
+const performOnePoint = perform_one_point;
 import { matrix_t } from "../matrix_t/matrix_t";
 import { keypoint_t } from "../keypoint_t/keypoint_t";
 
@@ -129,7 +134,7 @@ export class yape {
                 if (im < img[rowx + R] && img[rowx + R] < ip && im < img[rowx - R] && img[rowx - R] < ip) {
                     scores[rowx] = 0;
                 } else {
-                    perform_one_point(img, rowx, scores, im, ip, dirs, opposite, dirs_count);
+                    performOnePoint(img, rowx, scores, im, ip, dirs, opposite, dirs_count);
                 }
             }
         }
@@ -144,7 +149,7 @@ export class yape {
                     // if this pixel is 0, the next one will not be good enough. Skip it.
                     (++x, ++rowx);
                 } else {
-                    if (third_check(scores, rowx, w) >= 3 && is_local_maxima(scores, rowx, score, hw, R)) {
+                    if (thirdCheck(scores, rowx, w) >= 3 && isLocalMaxima(scores, rowx, score, hw, R)) {
                         pt = points[number_of_points];
                         ((pt.x = x), (pt.y = y), (pt.score = abs_score));
                         ++number_of_points;

--- a/src/yape/yape.ts
+++ b/src/yape/yape.ts
@@ -41,13 +41,19 @@
  */
 
 import { third_check, is_local_maxima, perform_one_point, lev_table_t } from "./yape_utils";
+import { matrix_t } from "../matrix_t/matrix_t";
+import { keypoint_t } from "../keypoint_t/keypoint_t";
 
-/** Module-scope aliases for the per-pixel helpers -- see the note in `yape06.ts`. */
+/**
+ * Module-scope aliases for the three helpers `detect` calls in its per-pixel
+ * loop. Calling an ESM imported binding is slower than calling a plain
+ * `const` holding the same function -- imported bindings are live, so each
+ * access carries an indirection. Measured under #86; see `bench/README.md`
+ * for the numbers, which are deliberately not repeated here.
+ */
 const thirdCheck = third_check;
 const isLocalMaxima = is_local_maxima;
 const performOnePoint = perform_one_point;
-import { matrix_t } from "../matrix_t/matrix_t";
-import { keypoint_t } from "../keypoint_t/keypoint_t";
 
 /**
  * YAPE ("Yet Another Point Extractor") interest-point detector: scores each

--- a/src/yape06/yape06.ts
+++ b/src/yape06/yape06.ts
@@ -46,13 +46,17 @@ import { keypoint_t } from "../keypoint_t/keypoint_t";
 import { compute_laplacian, hessian_min_eigen_value } from "./yape06_utils";
 
 /**
- * Module-scope aliases for the two per-pixel helpers.
+ * Module-scope aliases for the two helpers, mirroring `yape.ts`.
  *
- * Calling an ESM *imported binding* directly from a hot loop measured
- * consistently slower than calling a plain module-scope `const` holding the
- * same function -- imported bindings are live, so each access carries an
- * indirection a `const` does not. Measured under #86 across three runs: the
- * alias form gained 12-28% every time. See `bench/README.md`.
+ * Calling an ESM imported binding is slower than calling a plain `const`
+ * holding the same function -- imported bindings are live, so each access
+ * carries an indirection. That effect is real and measurable where a helper
+ * runs per pixel (it resolved the `yape` finding), but it did **not** measure
+ * any benefit here: `compute_laplacian` runs once per frame and
+ * `hessian_min_eigen_value` only for candidate pixels, so neither is called
+ * often enough for the indirection to matter. Kept for consistency with
+ * `yape.ts`, not because it speeds this module up. `yape06`'s own gap against
+ * original jsfeat is still unexplained -- see `bench/README.md`.
  */
 const computeLaplacian = compute_laplacian;
 const hessianMinEigenValue = hessian_min_eigen_value;

--- a/src/yape06/yape06.ts
+++ b/src/yape06/yape06.ts
@@ -46,6 +46,18 @@ import { keypoint_t } from "../keypoint_t/keypoint_t";
 import { compute_laplacian, hessian_min_eigen_value } from "./yape06_utils";
 
 /**
+ * Module-scope aliases for the two per-pixel helpers.
+ *
+ * Calling an ESM *imported binding* directly from a hot loop measured
+ * consistently slower than calling a plain module-scope `const` holding the
+ * same function -- imported bindings are live, so each access carries an
+ * indirection a `const` does not. Measured under #86 across three runs: the
+ * alias form gained 12-28% every time. See `bench/README.md`.
+ */
+const computeLaplacian = compute_laplacian;
+const hessianMinEigenValue = hessian_min_eigen_value;
+
+/**
  * YAPE06 interest-point detector: thresholds a Laplacian response map, then
  * rejects edge-like responses via the minimum eigenvalue of the local
  * Hessian, followed by 3×3 non-maximum suppression.
@@ -109,7 +121,7 @@ export class yape06 extends jsfeatNext {
         while (--x >= 0) {
             laplacian[x] = 0;
         }
-        compute_laplacian(srd_d, laplacian, w, Dxx, Dyy, sx, sy, ex, ey);
+        computeLaplacian(srd_d, laplacian, w, Dxx, Dyy, sx, sy, ex, ey);
 
         row = (sy * w + sx) | 0;
         for (y = sy; y < ey; ++y, row += w) {
@@ -135,7 +147,7 @@ export class yape06 extends jsfeatNext {
                         lv > laplacian[rowx - w + 1] &&
                         lv > laplacian[rowx + w + 1])
                 ) {
-                    min_eigen_value = hessian_min_eigen_value(srd_d, rowx, lv, Dxx, Dyy, Dxy, Dyx);
+                    min_eigen_value = hessianMinEigenValue(srd_d, rowx, lv, Dxx, Dyy, Dxy, Dyx);
                     if (min_eigen_value > eigen_thresh) {
                         pt = points[number_of_points];
                         ((pt.x = x), (pt.y = y), (pt.score = min_eigen_value));


### PR DESCRIPTION
## Summary

`bench/README.md` carried the YAPE detectors as an open finding — 8/8 samples favouring jsfeat, roughly 1.3x — with the standing hypothesis that importing `hessian_min_eigen_value` across modules blocked V8 inlining.

**That hypothesis was wrong.** This PR replaces it with a measured cause, fixes half the finding, and says plainly which half is still open.

## The hypothesis was refuted, not confirmed

Profiling `yape06.detect` (300 iterations over a 640×480 frame, after warm-up):

- **96.6%** of self-time is in `detect` itself
- **~0.6%** in the imported helpers

and the two implementations' inner scan loops are **character-for-character identical**. If cross-module imports were blocking inlining, the helpers would dominate. They don't.

## What the probe actually found

A throwaway probe replicated `detect`'s body **verbatim** under four shapes — asserting all four produced identical corner counts before timing anything:

| variant | typical hz |
| --- | --- |
| 1. jsfeatNext class method (shipped) | 167 / 157 / 131 |
| 3. object literal, imported helpers | 196 / 161 / 169 |
| 4. object literal, **local const** helper refs | 220 / 206 / 206 |
| 2. jsfeat (object literal + closure helpers) | 246 / 192 / 236 |

Two effects reproduced across three clean runs (one further run was discarded — every value roughly halved, the signature of CPU contention):

1. **Class method is slower than an object-literal property** (variant 1 → 3).
2. **Calling an ESM *imported binding* from a hot loop is slower than calling a plain module-scope `const`** holding the same function (variant 3 → 4) — **+12–28%, every run**. Imported bindings are live, so each access carries an indirection a `const` does not.

The second is a one-line change. This PR applies it to `yape06.ts` and `yape.ts`.

## Result: a split, and only half is fixed

| case | before (8 samples) | after (4 samples) | status |
| --- | --- | --- | --- |
| **`yape`** | 8/8 jsfeat, 1.23–1.53 | 1.02* / 1.05* / 1.14 / 1.06* | **resolved** — sign now flips |
| `yape06` | 8/8 jsfeat, 1.11–1.45 | 1.14 / 1.47 / 1.41 / 1.24 | **unchanged, still open** |

\* = jsfeatNext faster in that run.

**The split agrees with the profile rather than contradicting it.** `yape06` calls `compute_laplacian` **once per frame** and `hessian_min_eigen_value` only for candidate pixels — which is exactly why the helpers measured 0.6% there. `yape`'s helpers sit in the per-pixel loop, so aliasing them matters.

`yape06`'s alias is kept for consistency and costs nothing, but **it measured no benefit and is not claimed to help**. Its cause remains unknown; the class-vs-object-literal effect the probe also showed is the untested candidate — and testing it means changing module structure, which is a bigger decision than a one-line alias.

## Verification

`npm test`: **265 passed**, unchanged — the aliases are pure references, no behavior change. `tsc --noEmit`, `prettier --check`, `license-check` (93 files) all clean. Benches measured on an idle machine, warm-up discarded.

Refs #86.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
