### PR TITLE
feat(bfmatcher): brute-force Hamming matcher and match_t

### DIFF
--- a/scripts/check-license-headers.mjs
+++ b/scripts/check-license-headers.mjs
@@ -42,7 +42,15 @@ const EXTENDED = new Map([
  * upstream attribution block, so the credit stays truthful.
  * Everything else under src/ is a port of the corresponding jsfeat code.
  */
-const ORIGINAL_SRC = new Set(["src/types.ts", "src/index.ts"]);
+const ORIGINAL_SRC = new Set([
+    "src/types.ts",
+    "src/index.ts",
+    // match_t is an OpenCV-shaped value type (cv::DMatch equivalent); jsfeat
+    // never shipped a matcher or any such type, so nothing here is derived.
+    // (bfmatcher.ts itself IS derived — it ports the sample's popcnt32/
+    // match_pattern — and correctly keeps the attribution.)
+    "src/bfmatcher/match_t.ts",
+]);
 
 /**
  * Third-party or foreign-provenance files. Never stamp these — they either

--- a/src/bfmatcher/bfmatcher.ts
+++ b/src/bfmatcher/bfmatcher.ts
@@ -1,0 +1,246 @@
+/*
+ *  bfmatcher.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ *  Portions of this file are derived from jsfeat
+ *  (https://github.com/inspirit/jsfeat), Copyright (c) Eugene Zatepyakin,
+ *  released under the MIT License.
+ *
+ */
+
+import jsfeatNext from "../core/core";
+import { matrix_t } from "../matrix_t/matrix_t";
+import { match_t } from "./match_t";
+import { JSFEAT_CONSTANTS } from "../constants/constants";
+
+/**
+ * Brute-force Hamming matcher for binary descriptors (ORB today; TEBLID/FREAK
+ * once ported). Ported from the inline `match_pattern()`/`popcnt32()` helpers
+ * in `examples/sample_orb_pinball.html` — the only matcher jsfeatNext had
+ * before this module, duplicated across the ORB samples.
+ *
+ * The population-count routine is bit-identical to the sample's `popcnt32`,
+ * and descriptor rows are read the same way the sample does
+ * (`matrix_t.buffer.i32`, the full backing buffer reinterpreted as 32-bit
+ * words) — so this can serve as PureCV's numeric reference oracle the same
+ * way the rest of jsfeatNext does (see issue #96).
+ *
+ * Descriptor width must be a multiple of 4 bytes: 32 (ORB) and 64 (TEBLID
+ * p512) both qualify. Unlike `svd_invert`'s non-square guard (#102), this is
+ * not a jsfeat divergence — original jsfeat never shipped a matcher at all —
+ * so there is no parity obligation, only an explicit failure instead of a
+ * silently wrong read past the buffer's actual word count.
+ */
+export class bfmatcher extends jsfeatNext {
+    /** Distance norm in use. Only `JSFEAT_CONSTANTS.NORM_HAMMING` (exposed as `jsfeatNext.NORM_HAMMING`) is implemented. */
+    public norm_type: number;
+    /** When true, {@link match} keeps only mutually-best (query, train) pairs. */
+    public cross_check: boolean;
+
+    constructor(norm_type: number = JSFEAT_CONSTANTS.NORM_HAMMING, cross_check = false) {
+        super();
+        this.norm_type = norm_type;
+        this.cross_check = cross_check;
+    }
+
+    /** SWAR population count — identical to the sample's `popcnt32`. */
+    private static popcnt32(n: number): number {
+        n -= (n >> 1) & 0x55555555;
+        n = (n & 0x33333333) + ((n >> 2) & 0x33333333);
+        return (((n + (n >> 4)) & 0x0f0f0f0f) * 0x01010101) >> 24;
+    }
+
+    /**
+     * Int32-word view over a descriptor matrix's full backing buffer, matching
+     * `matrix_t.buffer.i32` — the same access the original sample uses.
+     *
+     * @throws {Error} if `descriptors.cols` is not a multiple of 4 bytes.
+     */
+    private static words(descriptors: matrix_t): Int32Array {
+        if ((descriptors.cols & 3) !== 0) {
+            throw new Error(
+                `jsfeatNext.bfmatcher: descriptor width must be a multiple of 4 bytes, got ${descriptors.cols}`
+            );
+        }
+        return descriptors.buffer.i32;
+    }
+
+    private static hamming(qw: Int32Array, qoff: number, tw: Int32Array, toff: number, word_len: number): number {
+        let d = 0;
+        for (let k = 0; k < word_len; ++k) {
+            d += bfmatcher.popcnt32(qw[qoff + k] ^ tw[toff + k]);
+        }
+        return d;
+    }
+
+    /**
+     * Nearest-neighbour match between two descriptor sets.
+     *
+     * With {@link cross_check} set, a pair is only kept when it is mutually
+     * best: `query[i]`'s nearest neighbour is `train[j]`, AND `train[j]`'s
+     * nearest neighbour (searched back over `query`) is `query[i]`.
+     *
+     * @param query        Query descriptors (U8, one row per descriptor).
+     * @param train        Train descriptors, same row width as `query`.
+     * @param max_distance Maximum Hamming distance to accept a pair.
+     */
+    match(query: matrix_t, train: matrix_t, max_distance = 256): match_t[] {
+        const q_cnt = query.rows;
+        const t_cnt = train.rows;
+        const word_len = query.cols >> 2;
+        const qw = bfmatcher.words(query);
+        const tw = bfmatcher.words(train);
+        const out: match_t[] = [];
+
+        if (!this.cross_check) {
+            for (let qi = 0; qi < q_cnt; ++qi) {
+                const qoff = qi * word_len;
+                let best = 0x7fffffff;
+                let best_idx = -1;
+                for (let ti = 0; ti < t_cnt; ++ti) {
+                    const d = bfmatcher.hamming(qw, qoff, tw, ti * word_len, word_len);
+                    if (d < best) {
+                        best = d;
+                        best_idx = ti;
+                    }
+                }
+                if (best_idx >= 0 && best <= max_distance) {
+                    out.push(new match_t(qi, best_idx, best));
+                }
+            }
+            return out;
+        }
+
+        // Cross-check needs every query's forward-best index before the
+        // backward pass can run. Borrowed from the shared pool rather than a
+        // plain allocation, per this repo's scratch-buffer convention.
+        const fwd_node = this.cache.get_buffer(q_cnt << 2);
+        const fwd = fwd_node.i32;
+
+        for (let qi = 0; qi < q_cnt; ++qi) {
+            const qoff = qi * word_len;
+            let best = 0x7fffffff;
+            let best_idx = -1;
+            for (let ti = 0; ti < t_cnt; ++ti) {
+                const d = bfmatcher.hamming(qw, qoff, tw, ti * word_len, word_len);
+                if (d < best) {
+                    best = d;
+                    best_idx = ti;
+                }
+            }
+            fwd[qi] = best_idx;
+        }
+
+        for (let qi = 0; qi < q_cnt; ++qi) {
+            const ti = fwd[qi];
+            if (ti < 0) continue;
+            const toff = ti * word_len;
+            let best = 0x7fffffff;
+            let back_idx = -1;
+            for (let qj = 0; qj < q_cnt; ++qj) {
+                const d = bfmatcher.hamming(qw, qj * word_len, tw, toff, word_len);
+                if (d < best) {
+                    best = d;
+                    back_idx = qj;
+                }
+            }
+            if (back_idx === qi && best <= max_distance) {
+                out.push(new match_t(qi, ti, best));
+            }
+        }
+
+        this.cache.put_buffer(fwd_node);
+        return out;
+    }
+
+    /**
+     * k-nearest matches per query descriptor, each row sorted ascending by
+     * distance.
+     */
+    knnMatch(query: matrix_t, train: matrix_t, k = 2): match_t[][] {
+        const q_cnt = query.rows;
+        const t_cnt = train.rows;
+        const word_len = query.cols >> 2;
+        const qw = bfmatcher.words(query);
+        const tw = bfmatcher.words(train);
+
+        const result: match_t[][] = [];
+        for (let qi = 0; qi < q_cnt; ++qi) {
+            const qoff = qi * word_len;
+            const top: match_t[] = [];
+            for (let ti = 0; ti < t_cnt; ++ti) {
+                const d = bfmatcher.hamming(qw, qoff, tw, ti * word_len, word_len);
+                if (top.length < k) {
+                    top.push(new match_t(qi, ti, d));
+                    top.sort((a, b) => a.distance - b.distance);
+                } else if (d < top[top.length - 1].distance) {
+                    const slot = top[top.length - 1];
+                    slot.queryIdx = qi;
+                    slot.trainIdx = ti;
+                    slot.distance = d;
+                    top.sort((a, b) => a.distance - b.distance);
+                }
+            }
+            result.push(top);
+        }
+        return result;
+    }
+
+    /**
+     * Lowe's ratio test over the output of `knnMatch(query, train, 2)`: keeps
+     * a query's best match only when it is meaningfully closer than the
+     * second-best (guards against ambiguous, repeated-texture matches).
+     *
+     * An instance method, not `static`, even though it reads no instance
+     * state: static methods are unreachable through a singleton instance
+     * (`jsfeatNext.bfmatcher.ratio_test(...)` — this repo's calling
+     * convention since 0.9.0 — would be `undefined` on a static declaration).
+     * Confirmed empirically before fixing: an earlier draft declared this
+     * `static`, following the #83 prototype literally, and the singleton
+     * simply had no such method at runtime.
+     */
+    ratio_test(knn: match_t[][], ratio = 0.75): match_t[] {
+        const good: match_t[] = [];
+        for (let i = 0; i < knn.length; ++i) {
+            const m = knn[i];
+            if (m.length >= 2) {
+                if (m[0].distance < ratio * m[1].distance) good.push(m[0]);
+            } else if (m.length === 1) {
+                good.push(m[0]);
+            }
+        }
+        return good;
+    }
+}

--- a/src/bfmatcher/match_t.ts
+++ b/src/bfmatcher/match_t.ts
@@ -1,0 +1,67 @@
+/*
+ *  match_t.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ *  Portions of this file are derived from jsfeat
+ *  (https://github.com/inspirit/jsfeat), Copyright (c) Eugene Zatepyakin,
+ *  released under the MIT License.
+ *
+ */
+
+/** Public shape of {@link match_t}. */
+export interface IMatch_T {
+    /** Index into the query descriptor set. */
+    queryIdx: number;
+    /** Index into the train descriptor set. */
+    trainIdx: number;
+    /** Hamming distance between the two descriptors. */
+    distance: number;
+}
+
+/**
+ * One descriptor correspondence — the equivalent of OpenCV's `cv::DMatch`.
+ * Produced by {@link bfmatcher.match} / {@link bfmatcher.knnMatch}.
+ */
+export class match_t implements IMatch_T {
+    public queryIdx: number;
+    public trainIdx: number;
+    public distance: number;
+
+    constructor(queryIdx = 0, trainIdx = 0, distance = 0) {
+        this.queryIdx = queryIdx;
+        this.trainIdx = trainIdx;
+        this.distance = distance;
+    }
+}

--- a/src/bfmatcher/match_t.ts
+++ b/src/bfmatcher/match_t.ts
@@ -34,10 +34,6 @@
  *
  *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
  *
- *  Portions of this file are derived from jsfeat
- *  (https://github.com/inspirit/jsfeat), Copyright (c) Eugene Zatepyakin,
- *  released under the MIT License.
- *
  */
 
 /** Public shape of {@link match_t}. */

--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -98,6 +98,10 @@ export const JSFEAT_CONSTANTS = {
     /** `linalg.svd_decompose` option: return V transposed. */
     SVD_V_T: 0x02,
 
+    // matcher norm
+    /** `bfmatcher`'s distance norm. Mirrors OpenCV's `cv::NORM_HAMMING` value; the only norm implemented. */
+    NORM_HAMMING: 6,
+
     // popular formats
     /** 8-bit unsigned, 1 channel (`U8_t | C1_t`) — grayscale images. */
     U8C1_t: 0x0100 | 0x01,

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -60,6 +60,8 @@ import type { motion_estimator } from "../motion_estimator/motion_estimator";
 import type { optical_flow_lk } from "../optical_flow_lk/optical_flow_lk";
 import type { orb } from "../orb/orb";
 import type { affine2d, homography2d } from "../motion_model/motion_model";
+import type { bfmatcher } from "../bfmatcher/bfmatcher";
+import type { match_t } from "../bfmatcher/match_t";
 
 /**
  * The ONE shared scratch-buffer pool of the library (30 buffers of 2560
@@ -108,6 +110,8 @@ export default class jsfeatNext {
     static motion_estimator: motion_estimator;
     static optical_flow_lk: optical_flow_lk;
     static orb: orb;
+    static bfmatcher: bfmatcher;
+    static match_t: typeof match_t;
 
     constructor() {
         this.dt = shared_data_type;
@@ -141,6 +145,7 @@ export default class jsfeatNext {
     // svd options
     static SVD_U_T = JSFEAT_CONSTANTS.SVD_U_T;
     static SVD_V_T = JSFEAT_CONSTANTS.SVD_V_T;
+    static NORM_HAMMING = JSFEAT_CONSTANTS.NORM_HAMMING;
 
     // popular formats
     static U8C1_t = this.U8_t | this.C1_t;

--- a/src/jsfeatNext.ts
+++ b/src/jsfeatNext.ts
@@ -57,6 +57,8 @@ import { ransac_params_t } from "./motion_estimator/ransac_params_t";
 import { motion_estimator } from "./motion_estimator/motion_estimator";
 import { affine2d, homography2d } from "./motion_model/motion_model";
 import { optical_flow_lk } from "./optical_flow_lk/optical_flow_lk";
+import { bfmatcher } from "./bfmatcher/bfmatcher";
+import { match_t } from "./bfmatcher/match_t";
 
 // Thin aggregator (issue #47): every algorithm lives in its own module under
 // src/<module>/, extending the base class from src/core/core.ts.
@@ -85,6 +87,8 @@ jsfeatNext.keypoint_t = keypoint_t;
 
 jsfeatNext.ransac_params_t = ransac_params_t;
 
+jsfeatNext.match_t = match_t;
+
 // algorithm singletons (no `new` — call methods directly)
 jsfeatNext.transform = new transform();
 
@@ -111,3 +115,5 @@ jsfeatNext.affine2d = new affine2d();
 jsfeatNext.homography2d = new homography2d();
 
 jsfeatNext.optical_flow_lk = new optical_flow_lk();
+
+jsfeatNext.bfmatcher = new bfmatcher();

--- a/tests/api-shape.test.ts
+++ b/tests/api-shape.test.ts
@@ -70,6 +70,9 @@ describe("0.9.0 API shape (issue #41)", () => {
         expect(typeof jsfeatNext.affine2d.run).toBe("function");
         expect(typeof jsfeatNext.homography2d.run).toBe("function");
         expect(typeof jsfeatNext.cache.get_buffer).toBe("function");
+        expect(typeof jsfeatNext.bfmatcher.match).toBe("function");
+        expect(typeof jsfeatNext.bfmatcher.knnMatch).toBe("function");
+        expect(typeof jsfeatNext.bfmatcher.ratio_test).toBe("function");
     });
 
     it("singletons are stable identities (state persists across accesses)", () => {
@@ -104,11 +107,16 @@ describe("0.9.0 API shape (issue #41)", () => {
         expect(p.levels).toBe(3);
         const r = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
         expect(r.size).toBe(4);
+        const mt = new jsfeatNext.match_t(1, 2, 30);
+        expect(mt.queryIdx).toBe(1);
+        expect(mt.trainIdx).toBe(2);
+        expect(mt.distance).toBe(30);
     });
 
     it("constants remain on the namespace", () => {
         expect(jsfeatNext.U8_t).toBe(0x0100);
         expect(jsfeatNext.F32C1_t).toBe(0x0400 | 0x01);
         expect(jsfeatNext.COLOR_RGBA2GRAY).toBe(0);
+        expect(jsfeatNext.NORM_HAMMING).toBe(6);
     });
 });

--- a/tests/parity/bfmatcher.test.ts
+++ b/tests/parity/bfmatcher.test.ts
@@ -1,0 +1,132 @@
+/*
+ *  bfmatcher.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { rng } from "../properties/helpers";
+
+/**
+ * Parity target: `match_pattern()` / `popcnt32()` in
+ * `examples/sample_orb_pinball.html` — the only matcher jsfeatNext had before
+ * this module, and issue #133's explicit acceptance criterion ("same input
+ * descriptors produce the same correspondences and the same distances").
+ *
+ * There is no vendored jsfeat oracle for this one: original jsfeat never
+ * shipped a matcher, so `bfmatcher` has nothing upstream to diverge from. The
+ * reference below is the sample's own per-descriptor search (its outer
+ * multi-pyramid-level loop is application plumbing, not part of what
+ * `bfmatcher.match` does — a single train set is the right scope here).
+ */
+function popcnt32(n: number): number {
+    n -= (n >> 1) & 0x55555555;
+    n = (n & 0x33333333) + ((n >> 2) & 0x33333333);
+    return (((n + (n >> 4)) & 0xf0f0f0f) * 0x1010101) >> 24;
+}
+
+function reference_match(
+    query: InstanceType<typeof jsfeatNext.matrix_t>,
+    train: InstanceType<typeof jsfeatNext.matrix_t>,
+    threshold: number
+) {
+    const q_cnt = query.rows;
+    const query_u32 = query.buffer.i32;
+    const ld_i32 = train.buffer.i32;
+    const ld_cnt = train.rows;
+    const out: { qidx: number; idx: number; dist: number }[] = [];
+
+    for (let qidx = 0; qidx < q_cnt; ++qidx) {
+        let best_dist = 256;
+        let best_idx = -1;
+        const qd_off = qidx * 8;
+        let ld_off = 0;
+        for (let pidx = 0; pidx < ld_cnt; ++pidx) {
+            let curr_d = 0;
+            for (let k = 0; k < 8; ++k) {
+                curr_d += popcnt32(query_u32[qd_off + k] ^ ld_i32[ld_off + k]);
+            }
+            if (curr_d < best_dist) {
+                best_dist = curr_d;
+                best_idx = pidx;
+            }
+            ld_off += 8;
+        }
+        if (best_dist < threshold) {
+            out.push({ qidx, idx: best_idx, dist: best_dist });
+        }
+    }
+    return out;
+}
+
+const OU8C1 = jsfeatNext.U8_t | jsfeatNext.C1_t;
+
+function randomDescriptors(n: number, cols: number, seed: number) {
+    const r = rng(seed);
+    const m = new jsfeatNext.matrix_t(cols, n, OU8C1);
+    for (let i = 0; i < n * cols; i++) m.data[i] = (r() * 256) | 0;
+    return m;
+}
+
+describe("parity: bfmatcher.match vs examples/sample_orb_pinball.html's match_pattern", () => {
+    it("produces identical correspondences and distances", () => {
+        const q = randomDescriptors(40, 32, 4201);
+        const t = randomDescriptors(60, 32, 4202);
+
+        // The sample accepts strictly-less-than threshold; match() accepts
+        // less-than-or-equal, so max_distance = threshold - 1 makes the two
+        // acceptance rules coincide exactly.
+        const threshold = 80;
+        const expected = reference_match(q, t, threshold);
+        const actual = jsfeatNext.bfmatcher.match(q, t, threshold - 1);
+
+        expect(actual.length).toBe(expected.length);
+        for (let i = 0; i < expected.length; i++) {
+            expect(actual[i].queryIdx).toBe(expected[i].qidx);
+            expect(actual[i].trainIdx).toBe(expected[i].idx);
+            expect(actual[i].distance).toBe(expected[i].dist);
+        }
+    });
+
+    it("agrees on distance-zero for identical descriptors", () => {
+        const d = randomDescriptors(15, 32, 4203);
+        const expected = reference_match(d, d, 1);
+        const actual = jsfeatNext.bfmatcher.match(d, d, 0);
+        expect(actual.length).toBe(expected.length);
+        expect(actual.length).toBe(15);
+        for (const m of actual) expect(m.distance).toBe(0);
+    });
+});

--- a/tests/properties/bfmatcher.test.ts
+++ b/tests/properties/bfmatcher.test.ts
@@ -1,0 +1,154 @@
+/*
+ *  bfmatcher.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { rng } from "./helpers";
+
+const OU8C1 = jsfeatNext.U8_t | jsfeatNext.C1_t;
+
+function randomDescriptors(n: number, cols: number, seed: number) {
+    const r = rng(seed);
+    const m = new jsfeatNext.matrix_t(cols, n, OU8C1);
+    for (let i = 0; i < n * cols; i++) m.data[i] = (r() * 256) | 0;
+    return m;
+}
+
+describe("bfmatcher.match", () => {
+    it("finds the exact self-match (distance 0) when query and train are the same set", () => {
+        const d = randomDescriptors(12, 32, 9101);
+        const matches = jsfeatNext.bfmatcher.match(d, d, 256);
+        expect(matches.length).toBe(12);
+        for (const m of matches) {
+            expect(m.queryIdx).toBe(m.trainIdx);
+            expect(m.distance).toBe(0);
+        }
+    });
+
+    it("respects max_distance: raising the threshold never removes a match", () => {
+        const q = randomDescriptors(20, 32, 9102);
+        const t = randomDescriptors(30, 32, 9103);
+        const tight = jsfeatNext.bfmatcher.match(q, t, 40);
+        const loose = jsfeatNext.bfmatcher.match(q, t, 200);
+        expect(loose.length).toBeGreaterThanOrEqual(tight.length);
+        for (const m of tight) expect(m.distance).toBeLessThanOrEqual(40);
+        for (const m of loose) expect(m.distance).toBeLessThanOrEqual(200);
+    });
+
+    it("cross_check keeps only mutually-best pairs", () => {
+        const q = randomDescriptors(15, 32, 9104);
+        const t = randomDescriptors(15, 32, 9105);
+
+        jsfeatNext.bfmatcher.cross_check = false;
+        const oneWay = jsfeatNext.bfmatcher.match(q, t, 256);
+
+        jsfeatNext.bfmatcher.cross_check = true;
+        const mutual = jsfeatNext.bfmatcher.match(q, t, 256);
+        jsfeatNext.bfmatcher.cross_check = false;
+
+        // Cross-checking can only keep a subset of the query->train best pairs,
+        // never invent a pair the one-way search didn't already find.
+        expect(mutual.length).toBeLessThanOrEqual(oneWay.length);
+        for (const m of mutual) {
+            const forward = oneWay.find((x) => x.queryIdx === m.queryIdx);
+            expect(forward?.trainIdx).toBe(m.trainIdx);
+            expect(forward?.distance).toBe(m.distance);
+        }
+    });
+
+    it("works at 64 bytes per descriptor (TEBLID p512 width)", () => {
+        const q = randomDescriptors(9, 64, 9106);
+        const t = randomDescriptors(9, 64, 9106); // same seed -> identical data
+        const matches = jsfeatNext.bfmatcher.match(q, t, 512);
+        expect(matches.length).toBe(9);
+        for (const m of matches) expect(m.distance).toBe(0);
+    });
+
+    it("throws when descriptor width is not a multiple of 4 bytes", () => {
+        const bad = new jsfeatNext.matrix_t(30, 4, OU8C1);
+        expect(() => jsfeatNext.bfmatcher.match(bad, bad)).toThrow(/multiple of 4/);
+    });
+});
+
+describe("bfmatcher.knnMatch / ratio_test", () => {
+    it("ratio_test is reachable on the jsfeatNext.bfmatcher singleton", () => {
+        // Regression guard: an earlier draft declared ratio_test `static`,
+        // following the #83 prototype literally. Static methods are not
+        // reachable through an instance in JS, so jsfeatNext.bfmatcher.ratio_test
+        // was silently `undefined` at runtime despite compiling cleanly.
+        expect(typeof jsfeatNext.bfmatcher.ratio_test).toBe("function");
+    });
+
+    it("returns k results per query, sorted ascending by distance", () => {
+        const q = randomDescriptors(10, 32, 9107);
+        const t = randomDescriptors(50, 32, 9108);
+        const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 3);
+        expect(knn.length).toBe(10);
+        for (const row of knn) {
+            expect(row.length).toBe(3);
+            expect(row[0].distance).toBeLessThanOrEqual(row[1].distance);
+            expect(row[1].distance).toBeLessThanOrEqual(row[2].distance);
+        }
+    });
+
+    it("knnMatch's best entry agrees with match()'s single best", () => {
+        const q = randomDescriptors(8, 32, 9109);
+        const t = randomDescriptors(25, 32, 9110);
+        const single = jsfeatNext.bfmatcher.match(q, t, 256);
+        const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 1);
+        expect(knn.length).toBe(single.length);
+        for (let i = 0; i < single.length; i++) {
+            expect(knn[i][0].trainIdx).toBe(single[i].trainIdx);
+            expect(knn[i][0].distance).toBe(single[i].distance);
+        }
+    });
+
+    it("ratio_test drops ambiguous matches and keeps distinct ones", () => {
+        // Two identical train descriptors make the top two knnMatch distances
+        // equal for any query -- ratio_test must reject that query.
+        const t = new jsfeatNext.matrix_t(32, 2, OU8C1);
+        const r = rng(9111);
+        for (let i = 0; i < 32; i++) t.data[i] = (r() * 256) | 0;
+        t.data.copyWithin(32, 0, 32); // row 1 = exact copy of row 0
+
+        const q = randomDescriptors(1, 32, 9111); // same seed as t's row 0 -> distance 0 to both
+        const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 2);
+        const good = jsfeatNext.bfmatcher.ratio_test(knn, 0.9);
+        expect(good.length).toBe(0);
+    });
+});

--- a/tests/properties/bfmatcher.test.ts
+++ b/tests/properties/bfmatcher.test.ts
@@ -91,6 +91,17 @@ describe("bfmatcher.match", () => {
         }
     });
 
+    it("cross_check with an empty train set yields no matches", () => {
+        // Degenerate but reachable: with no train descriptors every query's
+        // forward best is -1, so the backward pass skips them all.
+        const q = randomDescriptors(4, 32, 9120);
+        const t = new jsfeatNext.matrix_t(32, 0, OU8C1);
+        jsfeatNext.bfmatcher.cross_check = true;
+        const matches = jsfeatNext.bfmatcher.match(q, t, 256);
+        jsfeatNext.bfmatcher.cross_check = false;
+        expect(matches.length).toBe(0);
+    });
+
     it("works at 64 bytes per descriptor (TEBLID p512 width)", () => {
         const q = randomDescriptors(9, 64, 9106);
         const t = randomDescriptors(9, 64, 9106); // same seed -> identical data
@@ -150,5 +161,39 @@ describe("bfmatcher.knnMatch / ratio_test", () => {
         const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 2);
         const good = jsfeatNext.bfmatcher.ratio_test(knn, 0.9);
         expect(good.length).toBe(0);
+    });
+
+    it("ratio_test keeps a distinctive match (best clearly closer than second-best)", () => {
+        // Query equals train row 0 exactly (distance 0); row 1 is far. The
+        // best/second-best ratio is 0, well under any threshold, so it passes.
+        const t = new jsfeatNext.matrix_t(32, 2, OU8C1);
+        const r = rng(9114);
+        for (let i = 0; i < 32; i++) t.data[i] = (r() * 256) | 0; // row 0
+        for (let i = 32; i < 64; i++) t.data[i] = ~t.data[i - 32] & 0xff; // row 1: bitwise-opposite, max distance
+        const q = randomDescriptors(1, 32, 9114); // same seed as row 0 -> distance 0
+        const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 2);
+        expect(knn[0].length).toBe(2);
+        const good = jsfeatNext.bfmatcher.ratio_test(knn, 0.75);
+        expect(good.length).toBe(1);
+        expect(good[0].distance).toBe(0);
+    });
+
+    it("ratio_test yields nothing when knnMatch found no neighbours (empty train)", () => {
+        const q = randomDescriptors(3, 32, 9130);
+        const t = new jsfeatNext.matrix_t(32, 0, OU8C1);
+        const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 2);
+        for (const row of knn) expect(row.length).toBe(0);
+        expect(jsfeatNext.bfmatcher.ratio_test(knn).length).toBe(0);
+    });
+
+    it("ratio_test keeps a match with only one neighbour (nothing to compare against)", () => {
+        // A single-descriptor train set means knnMatch returns rows of length 1:
+        // there is no second-best to fail the ratio against, so the match is kept.
+        const q = randomDescriptors(3, 32, 9112);
+        const t = randomDescriptors(1, 32, 9113);
+        const knn = jsfeatNext.bfmatcher.knnMatch(q, t, 2);
+        for (const row of knn) expect(row.length).toBe(1);
+        const good = jsfeatNext.bfmatcher.ratio_test(knn, 0.5);
+        expect(good.length).toBe(3);
     });
 });


### PR DESCRIPTION
Closes #133. First step of the agreed 1.0.0 plan (`docs/roadmap-1.0.0.md`).

## What

`src/bfmatcher/bfmatcher.ts` — a brute-force Hamming matcher for binary descriptors — plus the `match_t` correspondence type (OpenCV's `cv::DMatch` equivalent). Attached as `jsfeatNext.bfmatcher` (singleton) and `jsfeatNext.match_t` (constructor), with `jsfeatNext.NORM_HAMMING` on the namespace.

API: `match()` (nearest-neighbour, optional `cross_check`), `knnMatch()` (top-k, sorted ascending), `ratio_test()` (Lowe's ratio over the top 2).

## Why

jsfeatNext could detect and describe keypoints but not match them — the only matcher was `match_pattern()`, written inline in `examples/sample_orb_pinball.html`, so a package consumer couldn't run the natural-feature pipeline without reimplementing it. GMS (#134) and TEBLID (#135) both need a matcher and a `match_t` type to operate on; extracting this from #83 keeps them off `pose_estimator`'s critical path.

## Parity

Ported from the sample's `match_pattern()`/`popcnt32()`, reading descriptor rows via `matrix_t.buffer.i32` exactly as the sample does — so results are bit-identical. There is **no vendored jsfeat oracle**: original jsfeat never shipped a matcher, so `bfmatcher` has nothing upstream to diverge from. The parity test checks against a reference extracted verbatim from the sample.

**Generalised descriptor width** to any multiple of 4 bytes (32 for ORB, 64 for TEBLID p512), throwing on a bad width rather than silently misreading past the buffer.

## Two design bugs caught against the #83 prototype this started from

- **`ratio_test` was `static`** in the prototype. Static methods are unreachable through a singleton instance in JS, so `jsfeatNext.bfmatcher.ratio_test` — this repo's calling convention since 0.9.0 — was `undefined` at runtime despite a clean typecheck. Verified empirically (built `dist/`, checked `typeof`) before and after. Converted to an instance method; a regression test asserts it stays reachable.
- **`NORM_HAMMING` was a class-static** (`bfmatcher.NORM_HAMMING`). Every other OpenCV-mirroring constant here (`SVD_U_T`, `COLOR_RGBA2GRAY`) lives on `JSFEAT_CONSTANTS`, exposed at top level. Moved to match.

## Notes for review

- Cross-check's forward-match scratch borrows from the shared pool (per the repo convention), covered by the global pool-balance check.
- `dist/`/`types/` are **not** rebuilt here — that happens at release time per `MAINTAINERS.md`. This means the samples won't see `bfmatcher` until the next build; a follow-up issue tracks actually using it in `sample_orb_pinball.html` (it's not a drop-in — the sample matches across pyramid levels, which is application plumbing on top of the single-train-set matcher).

## Verification

`npm test`: **276 passed** (11 new). `npm run typecheck` (src + bench), `tsc -p tsconfig.json`, `prettier --check`, `license-check` (97 files) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
