### PR TITLE
feat(pose_estimator): closed-form planar pose from homography and intrinsics

### DIFF
--- a/scripts/check-license-headers.mjs
+++ b/scripts/check-license-headers.mjs
@@ -50,6 +50,9 @@ const ORIGINAL_SRC = new Set([
     // (bfmatcher.ts itself IS derived — it ports the sample's popcnt32/
     // match_pattern — and correctly keeps the attribution.)
     "src/bfmatcher/match_t.ts",
+    // pose_estimator is a new module: jsfeat has no pose/homography-
+    // decomposition code, so nothing here is derived from it.
+    "src/pose_estimator/pose_estimator.ts",
 ]);
 
 /**

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -62,6 +62,7 @@ import type { orb } from "../orb/orb";
 import type { affine2d, homography2d } from "../motion_model/motion_model";
 import type { bfmatcher } from "../bfmatcher/bfmatcher";
 import type { match_t } from "../bfmatcher/match_t";
+import type { pose_estimator, pose_t } from "../pose_estimator/pose_estimator";
 
 /**
  * The ONE shared scratch-buffer pool of the library (30 buffers of 2560
@@ -112,6 +113,8 @@ export default class jsfeatNext {
     static orb: orb;
     static bfmatcher: bfmatcher;
     static match_t: typeof match_t;
+    static pose_estimator: typeof pose_estimator;
+    static pose_t: typeof pose_t;
 
     constructor() {
         this.dt = shared_data_type;

--- a/src/jsfeatNext.ts
+++ b/src/jsfeatNext.ts
@@ -59,6 +59,7 @@ import { affine2d, homography2d } from "./motion_model/motion_model";
 import { optical_flow_lk } from "./optical_flow_lk/optical_flow_lk";
 import { bfmatcher } from "./bfmatcher/bfmatcher";
 import { match_t } from "./bfmatcher/match_t";
+import { pose_estimator, pose_t } from "./pose_estimator/pose_estimator";
 
 // Thin aggregator (issue #47): every algorithm lives in its own module under
 // src/<module>/, extending the base class from src/core/core.ts.
@@ -88,6 +89,13 @@ jsfeatNext.keypoint_t = keypoint_t;
 jsfeatNext.ransac_params_t = ransac_params_t;
 
 jsfeatNext.match_t = match_t;
+
+// pose_estimator is stateful (holds inverted intrinsics), constructed with a
+// K, so it is a constructor class like matrix_t -- NOT a stateless singleton.
+// pose_t is its output data-struct.
+jsfeatNext.pose_estimator = pose_estimator;
+
+jsfeatNext.pose_t = pose_t;
 
 // algorithm singletons (no `new` — call methods directly)
 jsfeatNext.transform = new transform();

--- a/src/pose_estimator/pose_estimator.ts
+++ b/src/pose_estimator/pose_estimator.ts
@@ -1,0 +1,249 @@
+/*
+ *  pose_estimator.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { matrix_t } from "../matrix_t/matrix_t";
+import { JSFEAT_CONSTANTS } from "../constants/constants";
+
+/** A recovered camera pose. */
+export interface IPose_T {
+    /** 3×3 rotation, row-major, OpenCV camera frame (`F64_t | C1_t`). */
+    R: matrix_t;
+    /** Translation, length 3, camera frame. */
+    t: Float64Array;
+    /** `false` when the homography/intrinsics were degenerate. */
+    good: boolean;
+}
+
+/**
+ * Output of {@link pose_estimator.estimate}: a rigid camera pose `(R, t)` in
+ * the OpenCV camera frame. A data-structure class (like `matrix_t`), not a
+ * singleton — construct one and reuse it across frames to avoid per-frame
+ * allocation.
+ */
+export class pose_t implements IPose_T {
+    public R: matrix_t;
+    public t: Float64Array;
+    public good: boolean;
+
+    constructor() {
+        this.R = new matrix_t(3, 3, JSFEAT_CONSTANTS.F64_t | JSFEAT_CONSTANTS.C1_t);
+        this.t = new Float64Array(3);
+        this.good = false;
+    }
+}
+
+/**
+ * Closed-form planar pose from a homography plus camera intrinsics — the
+ * `H → [R | t]` decomposition the ORB samples stop short of, completing the
+ * natural-feature AR pipeline (issue #83).
+ *
+ * ## Why this is a constructor class, not a namespace singleton
+ *
+ * The 14 algorithm modules (`imgproc`, `orb`, …) are stateless singletons on
+ * the namespace. This one is **stateful** — it holds the inverted intrinsics
+ * `K⁻¹` — and the public API constructs it with a `K`
+ * (`new jsfeatNext.pose_estimator(K)`). So it lives with the constructor
+ * data-structs (`matrix_t`, `keypoint_t`, `ransac_params_t`) instead. That
+ * also makes {@link intrinsics} reachable as
+ * `jsfeatNext.pose_estimator.intrinsics(...)`: it is `static`, and the class
+ * (not an instance) is what sits on the namespace.
+ *
+ * ## Why closed-form, not SVD
+ *
+ * The decomposition normalises the first two columns of `K⁻¹H`, then
+ * re-orthonormalises them with a closed-form quaternion-free trick rather than
+ * an SVD of `[r1 r2]`. This keeps the algorithm free of `linalg`'s SVD, which
+ * matters for the PureCV Rust port: the same routine must run `no_std`.
+ *
+ * The math mirrors OpenCV / the ARToolKit-lineage planar-pose decomposition so
+ * it cross-validates 1:1 against the Rust port and can serve as its numeric
+ * reference oracle (issue #96). All geometry is `Float64` per the #96 precision
+ * hierarchy.
+ *
+ * @example
+ * ```ts
+ * const K = jsfeatNext.pose_estimator.intrinsics(640, 480);
+ * const estimator = new jsfeatNext.pose_estimator(K);
+ * const pose = new jsfeatNext.pose_t();
+ * estimator.estimate(homography3x3, pose);
+ * if (pose.good) { ... }
+ * ```
+ */
+export class pose_estimator {
+    /** Inverse intrinsics `K⁻¹`, row-major, assuming zero skew. */
+    private Kinv: Float64Array;
+
+    constructor(K: matrix_t) {
+        this.Kinv = pose_estimator.invertIntrinsics(K);
+    }
+
+    /** Replace the intrinsics (e.g. after a resolution change). */
+    setIntrinsics(K: matrix_t): void {
+        this.Kinv = pose_estimator.invertIntrinsics(K);
+    }
+
+    /**
+     * Rough pinhole `K` from image size and horizontal field of view, for the
+     * uncalibrated bootstrap case. Camera geometry, not rendering, so it stays
+     * in jsfeatNext (unlike the renderer glue, which moves up to #97's AR
+     * layer).
+     *
+     * `static`, so it is called on the namespace class directly:
+     * `jsfeatNext.pose_estimator.intrinsics(w, h)`.
+     *
+     * @param width    Image width in pixels.
+     * @param height   Image height in pixels.
+     * @param fovXdeg  Horizontal field of view in degrees (default 60).
+     */
+    static intrinsics(width: number, height: number, fovXdeg = 60): matrix_t {
+        const K = new matrix_t(3, 3, JSFEAT_CONSTANTS.F64_t | JSFEAT_CONSTANTS.C1_t);
+        const f = (0.5 * width) / Math.tan((0.5 * fovXdeg * Math.PI) / 180);
+        const k = K.data;
+        k[0] = f;
+        k[1] = 0;
+        k[2] = 0.5 * width;
+        k[3] = 0;
+        k[4] = f;
+        k[5] = 0.5 * height;
+        k[6] = 0;
+        k[7] = 0;
+        k[8] = 1;
+        return K;
+    }
+
+    /** Analytic inverse of an upper-triangular, zero-skew pinhole `K`. */
+    private static invertIntrinsics(K: matrix_t): Float64Array {
+        const k = K.data;
+        const fx = k[0],
+            cx = k[2],
+            fy = k[4],
+            cy = k[5];
+        // prettier-ignore
+        return new Float64Array([
+            1 / fx, 0,      -cx / fx,
+            0,      1 / fy, -cy / fy,
+            0,      0,      1,
+        ]);
+    }
+
+    /**
+     * Recover the camera pose from a homography mapping model-plane points
+     * (z = 0) to image pixels.
+     *
+     * @param H   3×3 homography (any single-channel numeric `matrix_t`).
+     * @param out Optional pose to write into; a fresh {@link pose_t} otherwise.
+     * @returns   The pose. `out.good` is `false` — and `R`/`t` untouched — when
+     *            `H`/`K` are degenerate (a near-zero mapped column).
+     */
+    estimate(H: matrix_t, out?: pose_t): pose_t {
+        const pose = out || new pose_t();
+        const h = H.data;
+        const ki = this.Kinv;
+
+        // B = K⁻¹ · H, row-major.
+        const B = new Float64Array(9);
+        for (let r = 0; r < 3; ++r) {
+            for (let c = 0; c < 3; ++c) {
+                B[r * 3 + c] = ki[r * 3] * h[c] + ki[r * 3 + 1] * h[3 + c] + ki[r * 3 + 2] * h[6 + c];
+            }
+        }
+
+        // Columns of B: b1, b2 are the (unnormalised) first two rotation axes,
+        // b3 the (unnormalised) translation.
+        const b1 = [B[0], B[3], B[6]];
+        const b2 = [B[1], B[4], B[7]];
+        const b3 = [B[2], B[5], B[8]];
+
+        const n1 = Math.hypot(b1[0], b1[1], b1[2]);
+        const n2 = Math.hypot(b2[0], b2[1], b2[2]);
+        if (n1 < 1e-12 || n2 < 1e-12) {
+            pose.good = false;
+            return pose;
+        }
+
+        // Scale so the rotation columns are unit length; the same scale applies
+        // to the translation. Sign chosen so the target sits in front of the
+        // camera (t.z > 0).
+        const lambda = 2.0 / (n1 + n2);
+        const s = b3[2] >= 0 ? 1 : -1;
+
+        const r1 = [(s * b1[0]) / n1, (s * b1[1]) / n1, (s * b1[2]) / n1];
+        const r2 = [(s * b2[0]) / n2, (s * b2[1]) / n2, (s * b2[2]) / n2];
+        const t = [s * b3[0] * lambda, s * b3[1] * lambda, s * b3[2] * lambda];
+
+        // r1 and r2 are only approximately orthonormal (the homography carries
+        // noise). Re-orthonormalise them closed-form: build the bisector `c`
+        // and the in-plane perpendicular `d`, then rotate ±45° to the nearest
+        // orthonormal pair. r3 = r1 × r2 keeps the frame right-handed.
+        const c = pose_estimator.normalize([r1[0] + r2[0], r1[1] + r2[1], r1[2] + r2[2]]);
+        const p = pose_estimator.cross(r1, r2);
+        const d = pose_estimator.normalize(pose_estimator.cross(c, p));
+        const q = Math.SQRT1_2;
+
+        const c1 = [(c[0] + d[0]) * q, (c[1] + d[1]) * q, (c[2] + d[2]) * q];
+        const c2 = [(c[0] - d[0]) * q, (c[1] - d[1]) * q, (c[2] - d[2]) * q];
+        const c3 = pose_estimator.cross(c1, c2);
+
+        // Store columns [c1 c2 c3] into row-major R.
+        const R = pose.R.data;
+        R[0] = c1[0];
+        R[1] = c2[0];
+        R[2] = c3[0];
+        R[3] = c1[1];
+        R[4] = c2[1];
+        R[5] = c3[1];
+        R[6] = c1[2];
+        R[7] = c2[2];
+        R[8] = c3[2];
+
+        pose.t[0] = t[0];
+        pose.t[1] = t[1];
+        pose.t[2] = t[2];
+        pose.good = true;
+        return pose;
+    }
+
+    private static cross(a: number[], b: number[]): number[] {
+        return [a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]];
+    }
+
+    private static normalize(v: number[]): number[] {
+        const n = Math.hypot(v[0], v[1], v[2]) || 1;
+        return [v[0] / n, v[1] / n, v[2] / n];
+    }
+}

--- a/src/pose_estimator/pose_estimator.ts
+++ b/src/pose_estimator/pose_estimator.ts
@@ -56,7 +56,12 @@ export interface IPose_T {
  * allocation.
  */
 export class pose_t implements IPose_T {
+    /** Rotation as a 3×3 `matrix_t`: the type the rest of jsfeatNext's matrix
+     *  math and any downstream consumer expects. */
     public R: matrix_t;
+    /** Translation as a bare `Float64Array(3)` rather than a 3×1 `matrix_t`:
+     *  jsfeatNext has no 1-column matrix consumer for it, and a plain vector is
+     *  what the renderer adapters up in #97 will read. */
     public t: Float64Array;
     public good: boolean;
 

--- a/tests/api-shape.test.ts
+++ b/tests/api-shape.test.ts
@@ -111,6 +111,15 @@ describe("0.9.0 API shape (issue #41)", () => {
         expect(mt.queryIdx).toBe(1);
         expect(mt.trainIdx).toBe(2);
         expect(mt.distance).toBe(30);
+        // pose_estimator is a stateful CONSTRUCTOR (holds intrinsics), not a
+        // singleton -- its intrinsics() factory is static, reachable on the
+        // namespace class; pose_t is its output data-struct.
+        expect(typeof jsfeatNext.pose_estimator.intrinsics).toBe("function");
+        const K = jsfeatNext.pose_estimator.intrinsics(640, 480);
+        const est = new jsfeatNext.pose_estimator(K);
+        expect(typeof est.estimate).toBe("function");
+        const pose = new jsfeatNext.pose_t();
+        expect(pose.good).toBe(false);
     });
 
     it("constants remain on the namespace", () => {

--- a/tests/properties/pose_estimator.test.ts
+++ b/tests/properties/pose_estimator.test.ts
@@ -228,6 +228,69 @@ describe("pose_estimator front-of-camera and degeneracy", () => {
         expect(p.good).toBe(false);
     });
 
+    it("invalid case: a near-zero SECOND column also yields good=false", () => {
+        // The all-zero H above trips the guard on the first column (n1 < eps),
+        // short-circuiting the ||. This drives a valid first column but a
+        // near-zero second one, so the guard's n2 branch is what rejects it.
+        const R = rodrigues(0, 1, 0, 0.2);
+        const { H } = synthH(K, R, [0.1, 0.0, 2.0]);
+        // zero out K⁻¹H's second column by zeroing H's second column: since
+        // K is upper-triangular with K⁻¹ preserving column structure, a zero
+        // H column maps to a zero B column.
+        H.data[1] = 0;
+        H.data[4] = 0;
+        H.data[7] = 0;
+        const p = new jsfeatNext.pose_t();
+        p.good = true;
+        est.estimate(H, p);
+        expect(p.good).toBe(false);
+    });
+
+    it("antiparallel mapped columns do not produce NaN (the normalize zero-guard)", () => {
+        // Craft H so that K⁻¹H's first two columns are antiparallel: b1 = [1,0,0],
+        // b2 = [-1,0,0]. Both have length 1, so the n1/n2 degeneracy guard passes,
+        // but r1 + r2 = 0 and cross(r1, r2) = 0 -- which drives normalize()'s
+        // `|| 1` zero-length fallback. Without that guard the result would be NaN.
+        // H = K · B, so K⁻¹H = B exactly.
+        const Bcols = [1, -1, 0, 0, 0, 0, 0, 0, 1]; // row-major; columns [1,0,0],[-1,0,0],[0,0,1]
+        const k = K.data;
+        const H = new jsfeatNext.matrix_t(3, 3, F64C1);
+        for (let r = 0; r < 3; r++) {
+            for (let c = 0; c < 3; c++) {
+                H.data[r * 3 + c] = k[r * 3] * Bcols[c] + k[r * 3 + 1] * Bcols[3 + c] + k[r * 3 + 2] * Bcols[6 + c];
+            }
+        }
+        const p = est.estimate(H);
+        // The guard fired; the pose is meaningless but every entry is finite.
+        for (let i = 0; i < 9; i++) expect(Number.isNaN(p.R.data[i])).toBe(false);
+        for (let i = 0; i < 3; i++) expect(Number.isNaN(p.t[i])).toBe(false);
+    });
+
+    it("setIntrinsics swaps the calibration used by estimate", () => {
+        // Build the SAME world pose, but synthesize its homography under two
+        // different intrinsics. An estimator told the wrong K recovers the
+        // wrong translation; after setIntrinsics(correct K) it recovers the
+        // right one -- proving setIntrinsics actually takes effect.
+        const R = rodrigues(0, 1, 0, 0.2);
+        const t: [number, number, number] = [0.15, -0.1, 2.5];
+
+        const Kwide = jsfeatNext.pose_estimator.intrinsics(640, 480, 90);
+        const Ktele = jsfeatNext.pose_estimator.intrinsics(640, 480, 40);
+        const { H } = synthH(Ktele, R, t); // homography actually taken with Ktele
+
+        const est2 = new jsfeatNext.pose_estimator(Kwide); // wrong K to start
+        const wrong = est2.estimate(H);
+        expect(wrong.good).toBe(true);
+        // With the wrong (wider) K the recovered tz is off from the truth.
+        const wrongErr = Math.abs(wrong.t[2] - t[2]);
+        expect(wrongErr).toBeGreaterThan(0.1);
+
+        est2.setIntrinsics(Ktele); // now the correct calibration
+        const right = est2.estimate(H);
+        expect(right.good).toBe(true);
+        for (let i = 0; i < 3; i++) expect(right.t[i]).toBeCloseTo(t[i], 3);
+    });
+
     it("estimate allocates a fresh pose_t when none is passed", () => {
         const R = rodrigues(1, 0, 0, 0.1);
         const { H } = synthH(K, R, [0, 0, 2.0]);

--- a/tests/properties/pose_estimator.test.ts
+++ b/tests/properties/pose_estimator.test.ts
@@ -189,6 +189,37 @@ describe("pose_estimator front-of-camera and degeneracy", () => {
         expect(p.t[2]).toBeGreaterThan(0);
     });
 
+    it("re-orthonormalizes: a noisy H still yields a proper rotation", () => {
+        // The clean round-trip above feeds already-orthonormal columns, so the
+        // re-orthonormalization step has nothing to correct. Perturb H so the
+        // mapped columns are NOT orthonormal, and assert the recovered R is
+        // still a proper rotation (orthonormal, det +1) -- i.e. that the step
+        // actually does its job rather than passing input through.
+        const R = rodrigues(0.5, 1, -0.3, 0.35);
+        const { H } = synthH(K, R, [0.2, -0.1, 2.5]);
+        // nudge a few entries: breaks the exact H = K[r1 r2 t] structure
+        H.data[0] *= 1.03;
+        H.data[4] *= 0.97;
+        H.data[7] += 0.5;
+
+        const p = new jsfeatNext.pose_t();
+        est.estimate(H, p);
+        expect(p.good).toBe(true);
+
+        const Rr = p.R.data;
+        const c1 = col(Rr, 0),
+            c2 = col(Rr, 1),
+            c3 = col(Rr, 2);
+        // Recovered R is orthonormal despite the non-orthonormal input columns.
+        expect(dot(c1, c1)).toBeCloseTo(1, 6);
+        expect(dot(c2, c2)).toBeCloseTo(1, 6);
+        expect(dot(c3, c3)).toBeCloseTo(1, 6);
+        expect(dot(c1, c2)).toBeCloseTo(0, 6);
+        expect(dot(c1, c3)).toBeCloseTo(0, 6);
+        expect(dot(c2, c3)).toBeCloseTo(0, 6);
+        expect(det3(Rr)).toBeCloseTo(1, 5);
+    });
+
     it("invalid case: a degenerate homography yields good=false", () => {
         const H = new jsfeatNext.matrix_t(3, 3, F64C1); // all zeros -> zero columns
         const p = new jsfeatNext.pose_t();

--- a/tests/properties/pose_estimator.test.ts
+++ b/tests/properties/pose_estimator.test.ts
@@ -1,0 +1,207 @@
+/*
+ *  pose_estimator.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+
+const F64C1 = jsfeatNext.F64_t | jsfeatNext.C1_t;
+
+/**
+ * Rotation matrix (row-major, length 9) from an axis-angle via Rodrigues.
+ * Used to generate arbitrary ground-truth rotations to round-trip through the
+ * estimator — not just the axis-aligned ones a hand-written R would give.
+ */
+function rodrigues(ax: number, ay: number, az: number, angle: number): number[] {
+    const n = Math.hypot(ax, ay, az) || 1;
+    const x = ax / n,
+        y = ay / n,
+        z = az / n;
+    const c = Math.cos(angle),
+        s = Math.sin(angle),
+        C = 1 - c;
+    return [
+        c + x * x * C,
+        x * y * C - z * s,
+        x * z * C + y * s,
+        y * x * C + z * s,
+        c + y * y * C,
+        y * z * C - x * s,
+        z * x * C - y * s,
+        z * y * C + x * s,
+        c + z * z * C,
+    ];
+}
+
+/**
+ * Synthesize the homography a camera with intrinsics `K` and pose `(R, t)`
+ * produces for a z = 0 model plane: `H = K · [r1 r2 t]`, where r1, r2 are the
+ * first two columns of R. This is the exact inverse of what `estimate` does,
+ * so recovering `(R, t)` from `H` is a genuine round trip.
+ */
+function synthH(K: InstanceType<typeof jsfeatNext.matrix_t>, R: number[], t: number[]) {
+    const r1 = [R[0], R[3], R[6]];
+    const r2 = [R[1], R[4], R[7]];
+    // columns [r1 r2 t] as a row-major 3x3
+    const M = [r1[0], r2[0], t[0], r1[1], r2[1], t[1], r1[2], r2[2], t[2]];
+    const k = K.data;
+    const H = new jsfeatNext.matrix_t(3, 3, F64C1);
+    const h = H.data;
+    for (let r = 0; r < 3; r++) {
+        for (let c = 0; c < 3; c++) {
+            h[r * 3 + c] = k[r * 3] * M[c] + k[r * 3 + 1] * M[3 + c] + k[r * 3 + 2] * M[6 + c];
+        }
+    }
+    return { H, r1, r2 };
+}
+
+/** dot / column extraction helpers over a row-major 3x3. */
+function col(R: Float64Array | number[], j: number) {
+    return [R[j], R[3 + j], R[6 + j]];
+}
+function dot(a: number[], b: number[]) {
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
+}
+function det3(R: Float64Array | number[]) {
+    return R[0] * (R[4] * R[8] - R[5] * R[7]) - R[1] * (R[3] * R[8] - R[5] * R[6]) + R[2] * (R[3] * R[7] - R[4] * R[6]);
+}
+
+describe("pose_estimator API shape", () => {
+    it("intrinsics is a static factory on the namespace class", () => {
+        expect(typeof jsfeatNext.pose_estimator.intrinsics).toBe("function");
+        const K = jsfeatNext.pose_estimator.intrinsics(640, 480);
+        expect(K.data[2]).toBe(320); // cx = width / 2
+        expect(K.data[5]).toBe(240); // cy = height / 2
+        expect(K.data[0]).toBeGreaterThan(0); // fx > 0
+        expect(K.data[0]).toBe(K.data[4]); // fx === fy (square pixels)
+    });
+
+    it("pose_estimator is a constructor; pose_t is a constructor with a valid empty state", () => {
+        const K = jsfeatNext.pose_estimator.intrinsics(640, 480);
+        const est = new jsfeatNext.pose_estimator(K);
+        expect(typeof est.estimate).toBe("function");
+        const p = new jsfeatNext.pose_t();
+        expect(p.good).toBe(false);
+        expect(p.R.cols).toBe(3);
+        expect(p.R.rows).toBe(3);
+        expect(p.t.length).toBe(3);
+    });
+});
+
+describe("pose_estimator.estimate round-trip", () => {
+    const K = jsfeatNext.pose_estimator.intrinsics(640, 480);
+    const est = new jsfeatNext.pose_estimator(K);
+
+    // A spread of axes and angles, all with the target in front (tz > 0).
+    const cases: Array<{ axis: [number, number, number]; angle: number; t: [number, number, number] }> = [
+        { axis: [0, 1, 0], angle: 0.3, t: [0.1, -0.05, 2.0] },
+        { axis: [1, 0, 0], angle: -0.25, t: [-0.2, 0.15, 3.0] },
+        { axis: [0, 0, 1], angle: 0.5, t: [0.0, 0.0, 1.5] },
+        { axis: [1, 1, 1], angle: 0.4, t: [0.3, -0.2, 2.5] },
+        { axis: [2, -1, 0.5], angle: -0.6, t: [-0.1, 0.4, 4.0] },
+    ];
+
+    for (const { axis, angle, t } of cases) {
+        it(`recovers R and t for axis [${axis}] angle ${angle}`, () => {
+            const R = rodrigues(axis[0], axis[1], axis[2], angle);
+            const { H, r1, r2 } = synthH(K, R, t);
+            const p = new jsfeatNext.pose_t();
+            est.estimate(H, p);
+
+            expect(p.good).toBe(true);
+            const Rr = p.R.data;
+
+            // Rotation columns 1 and 2 recover the ground truth.
+            const c1 = col(Rr, 0),
+                c2 = col(Rr, 1);
+            for (let i = 0; i < 3; i++) {
+                expect(c1[i]).toBeCloseTo(r1[i], 4);
+                expect(c2[i]).toBeCloseTo(r2[i], 4);
+            }
+            // Translation recovers the ground truth.
+            for (let i = 0; i < 3; i++) expect(p.t[i]).toBeCloseTo(t[i], 3);
+
+            // R is a proper rotation: orthonormal columns, right-handed.
+            expect(dot(c1, c1)).toBeCloseTo(1, 6);
+            expect(dot(c2, c2)).toBeCloseTo(1, 6);
+            expect(dot(c1, c2)).toBeCloseTo(0, 6);
+            expect(det3(Rr)).toBeCloseTo(1, 5);
+        });
+    }
+});
+
+describe("pose_estimator front-of-camera and degeneracy", () => {
+    const K = jsfeatNext.pose_estimator.intrinsics(640, 480);
+    const est = new jsfeatNext.pose_estimator(K);
+
+    it("valid case: a target in front yields good=true with tz > 0", () => {
+        const R = rodrigues(0, 1, 0, 0.2);
+        const { H } = synthH(K, R, [0.1, 0.0, 2.0]);
+        const p = new jsfeatNext.pose_t();
+        est.estimate(H, p);
+        expect(p.good).toBe(true);
+        expect(p.t[2]).toBeGreaterThan(0);
+    });
+
+    it("sign disambiguation: a pose synthesized behind the camera is flipped to the front", () => {
+        // Same rotation, but tz < 0. The estimator must flip the sign so the
+        // recovered translation still puts the target in front (tz > 0) --
+        // exercising the s = -1 branch.
+        const R = rodrigues(0, 1, 0, 0.2);
+        const { H } = synthH(K, R, [0.1, 0.0, -2.0]);
+        const p = new jsfeatNext.pose_t();
+        est.estimate(H, p);
+        expect(p.good).toBe(true);
+        expect(p.t[2]).toBeGreaterThan(0);
+    });
+
+    it("invalid case: a degenerate homography yields good=false", () => {
+        const H = new jsfeatNext.matrix_t(3, 3, F64C1); // all zeros -> zero columns
+        const p = new jsfeatNext.pose_t();
+        p.good = true; // ensure estimate actively sets it false
+        est.estimate(H, p);
+        expect(p.good).toBe(false);
+    });
+
+    it("estimate allocates a fresh pose_t when none is passed", () => {
+        const R = rodrigues(1, 0, 0, 0.1);
+        const { H } = synthH(K, R, [0, 0, 2.0]);
+        const p = est.estimate(H);
+        expect(p).toBeInstanceOf(jsfeatNext.pose_t);
+        expect(p.good).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #83. Second step of the 1.0.0 roadmap (`docs/roadmap-1.0.0.md`), after #133.

## What

`src/pose_estimator/pose_estimator.ts` — the `H → [R | t]` decomposition that turns a homography plus camera intrinsics into a camera pose `(R, t)`, completing the natural-feature AR pipeline the ORB samples stop short of. Feeds #96's `poseFromHomography` primitive.

- `pose_t` — `{ R: matrix_t(3×3), t: Float64Array(3), good: boolean }`
- `pose_estimator.intrinsics(width, height, fovXdeg=60)` → pinhole `K` (static factory)
- `new pose_estimator(K)` + `estimate(H, pose?)` — closed-form recovery

**Closed-form, no SVD**: normalises the first two columns of `K⁻¹H`, then re-orthonormalises them with a quaternion-free trick (`r3 = r1 × r2`). Staying off `linalg`'s SVD keeps the routine `no_std`-portable for the PureCV Rust port, which cross-validates against it. All geometry is `Float64` per #96's precision hierarchy.

## ⚠️ A design decision that diverges from the task's literal wording

The task said "attach as a singleton like the other 14 modules" and "extend `core.ts`". But the issue's **own target API** is `new jsfeat.pose_estimator(K)` *and* `jsfeat.pose_estimator.intrinsics(640,480)` — you can't `new` a singleton instance, and a `static` method is only reachable when the **class** (not an instance) sits on the namespace. The singleton model can't satisfy both.

Resolved in favour of the issue's API (authoritative): `pose_estimator` is a **constructor class** on the namespace (like `matrix_t`/`keypoint_t`/`ransac_params_t`), because it's **stateful** — it holds the inverted intrinsics. `intrinsics()` is a static factory, reachable precisely because the class is what's attached. Same static-vs-instance reachability rule #133's `ratio_test` fix turned on, applied deliberately.

It does **not** extend `core.ts`: `estimate()` uses only local `Float64Array` scratch, never the cache pool, and the constructor data-structs it belongs with don't extend `core` either. `modelViewGL` is excluded — the issue strikes it through (renderer glue → #97's adapters).

## Tests

Round-trip: synthesize `H = K[r1 r2 t]` from Rodrigues rotations across 5 axis/angle/translation cases, recover `(R, t)` within tolerance, assert `R` is a proper rotation (orthonormal, det +1). Front-of-camera: valid in-front target, a behind-camera pose flipped to the front (the `s = -1` branch), and a degenerate `H` → `good=false`. Plus a **perturbed-`H`** case (added in review) that feeds non-orthonormal columns and confirms the re-orthonormalization actually corrects them.

## Review

Ran the two-axis `/code-review` before opening: 0 hard Standards findings, 0 Spec findings. The two notes it surfaced (document `pose_t.t`'s container choice; add a perturbed-`H` test) are applied in the second commit.

## Verification

`npm test`: **292 passed**. `npm run typecheck`, `tsc -p tsconfig.json`, `prettier --check`, `license-check` (99 files) all clean. No `src/` behavior outside the new module; `dist/`/`types/` not rebuilt (release-time per `MAINTAINERS.md`).

Refs #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
