### PR TITLE
feat(orb): expose ic_angle, the keypoint orientation step (#96)

### DIFF
--- a/examples/orb_test.html
+++ b/examples/orb_test.html
@@ -90,10 +90,14 @@
         jsfeatNext.imgproc.gaussian_blur(img, smooth, 5);
         jsfeatNext.imgproc.gaussian_blur(brighter, smoothBright, 5);
 
-        // keypoint_t(x, y, score, level, angle) — angle in radians, or -1 to let
-        // ORB work out the patch orientation itself.
-        const pointP = [new jsfeatNext.keypoint_t(40, 40, 0, 0, -1)];
-        const pointQ = [new jsfeatNext.keypoint_t(80, 70, 0, 0, -1)];
+        // keypoint_t(x, y, score, level, angle) — angle in radians. describe()
+        // does NOT work the orientation out itself: it rotates the patch by
+        // whatever angle it is given, so the keypoint_t default of -1 would
+        // rotate by -1 radian. Real pipelines call orb.ic_angle() first (see
+        // sample_orb.html); this test fixes the angle at 0 because it only
+        // compares a patch against itself under a brightness change.
+        const pointP = [new jsfeatNext.keypoint_t(40, 40, 0, 0, 0)];
+        const pointQ = [new jsfeatNext.keypoint_t(80, 70, 0, 0, 0)];
 
         // Destination matrices: 32 columns (bytes per descriptor) x rows = count.
         const descP = new jsfeatNext.matrix_t(32, 1, jsfeatNext.U8_t | jsfeatNext.C1_t);

--- a/examples/sample_orb.html
+++ b/examples/sample_orb.html
@@ -300,40 +300,10 @@
 
                 // calculate dominant orientation for each keypoint
                 for (var i = 0; i < count; ++i) {
-                    corners[i].angle = ic_angle(img, corners[i].x, corners[i].y);
+                    corners[i].angle = orb.ic_angle(img, corners[i].x, corners[i].y);
                 }
 
                 return count;
-            }
-
-            // central difference using image moments to find dominant orientation
-            var u_max = new Int32Array([15, 15, 15, 15, 14, 14, 14, 13, 13, 12, 11, 10, 9, 8, 6, 3, 0]);
-            function ic_angle(img, px, py) {
-                var half_k = 15; // half patch size
-                var m_01 = 0, m_10 = 0;
-                var src = img.data, step = img.cols;
-                var u = 0, v = 0, center_off = (py * step + px) | 0;
-                var v_sum = 0, d = 0, val_plus = 0, val_minus = 0;
-
-                // Treat the center line differently, v=0
-                for (u = -half_k; u <= half_k; ++u)
-                    m_10 += u * src[center_off + u];
-
-                // Go line by line in the circular patch
-                for (v = 1; v <= half_k; ++v) {
-                    // Proceed over the two lines
-                    v_sum = 0;
-                    d = u_max[v];
-                    for (u = -d; u <= d; ++u) {
-                        val_plus = src[center_off + u + v * step];
-                        val_minus = src[center_off + u - v * step];
-                        v_sum += (val_plus - val_minus);
-                        m_10 += u * (val_plus + val_minus);
-                    }
-                    m_01 += v * v_sum;
-                }
-
-                return Math.atan2(m_01, m_10);
             }
 
             // estimate homography transform between matched points

--- a/examples/sample_orb_pinball.html
+++ b/examples/sample_orb_pinball.html
@@ -337,41 +337,12 @@
 
                     // calculate dominant orientation for each keypoint
                     for (var i = 0; i < count; ++i) {
-                        corners[i].angle = ic_angle(img, corners[i].x, corners[i].y);
+                        corners[i].angle = orb.ic_angle(img, corners[i].x, corners[i].y);
                     }
 
                     return count;
                 }
 
-                // central difference using image moments to find dominant orientation
-                var u_max = new Int32Array([15, 15, 15, 15, 14, 14, 14, 13, 13, 12, 11, 10, 9, 8, 6, 3, 0]);
-                function ic_angle(img, px, py) {
-                    var half_k = 15; // half patch size
-                    var m_01 = 0, m_10 = 0;
-                    var src = img.data, step = img.cols;
-                    var u = 0, v = 0, center_off = (py * step + px) | 0;
-                    var v_sum = 0, d = 0, val_plus = 0, val_minus = 0;
-
-                    // Treat the center line differently, v=0
-                    for (u = -half_k; u <= half_k; ++u)
-                        m_10 += u * src[center_off + u];
-
-                    // Go line by line in the circular patch
-                    for (v = 1; v <= half_k; ++v) {
-                        // Proceed over the two lines
-                        v_sum = 0;
-                        d = u_max[v];
-                        for (u = -d; u <= d; ++u) {
-                            val_plus = src[center_off + u + v * step];
-                            val_minus = src[center_off + u - v * step];
-                            v_sum += (val_plus - val_minus);
-                            m_10 += u * (val_plus + val_minus);
-                        }
-                        m_01 += v * v_sum;
-                    }
-
-                    return Math.atan2(m_01, m_10);
-                }
 
                 // estimate homography transform between matched points
                 function find_transform(matches, count) {

--- a/src/orb/orb.ts
+++ b/src/orb/orb.ts
@@ -58,6 +58,16 @@ import { rectify_patch } from "./rectify_patch";
  * Mirrors `jsfeat.orb` from the original library.
  * (Moved out of the src/jsfeatNext.ts monolith in issue #47.)
  */
+/**
+ * Per-row half-widths of the circular patch used by {@link orb.ic_angle},
+ * indexed by `|v|` for `v` in `[-15, 15]`: row `v` spans `u ∈ [-u_max[v], u_max[v]]`.
+ *
+ * Module scope, not an instance field: it is a read-only constant shared by
+ * every call, and hoisting it out of the method keeps the hot loop free of a
+ * per-call allocation (the same reason `bit_pattern_31` lives in its own file).
+ */
+const u_max = new Int32Array([15, 15, 15, 15, 14, 14, 14, 13, 13, 12, 11, 10, 9, 8, 6, 3, 0]);
+
 export class orb extends jsfeatNext {
     /** The learned 256-pair sampling pattern (flat `[x1,y1,x2,y2,…]`). */
     public bit_pattern_31_: Int32Array;
@@ -74,6 +84,77 @@ export class orb extends jsfeatNext {
         this.H = new matrix_t(3, 3, JSFEAT_CONSTANTS.F32_t | JSFEAT_CONSTANTS.C1_t);
         this.patch_img = new matrix_t(32, 32, JSFEAT_CONSTANTS.U8_t | JSFEAT_CONSTANTS.C1_t);
         this.imgproc = new imgproc();
+    }
+
+    /**
+     * Dominant orientation of the patch around `(px, py)`, in radians — the
+     * "intensity centroid" measure ORB uses to make its descriptors
+     * rotation-invariant.
+     *
+     * The angle points from the patch centre toward its intensity centroid,
+     * computed from the first-order image moments `m01`/`m10` over a circular
+     * patch of radius 15 (see {@link u_max}), then `atan2(m01, m10)`.
+     *
+     * @remarks
+     * **This is a required step before {@link describe}, not an optional one.**
+     * `describe` reads each keypoint's `angle` and rotates the sampling patch by
+     * it; it does *not* compute the orientation itself. A `keypoint_t` left at
+     * the default `angle = -1` is therefore described with the patch rotated by
+     * −1 **radian** (≈ −57°), not "unrotated" — so detectors, which never set
+     * `angle`, must be followed by a pass through this method:
+     *
+     * ```ts
+     * const count = jsfeatNext.yape06.detect(img, corners, 17);
+     * for (let i = 0; i < count; ++i) {
+     *     corners[i].angle = jsfeatNext.orb.ic_angle(img, corners[i].x, corners[i].y);
+     * }
+     * jsfeatNext.orb.describe(img, corners, count, descriptors);
+     * ```
+     *
+     * **Keep `(px, py)` at least 15 px from every image edge.** The patch is
+     * read directly from `src` with no bounds check (matching the original
+     * implementation, and mirroring {@link describe}'s own margin requirement —
+     * pass a detector `border` of ≥ 20 and both are satisfied at once).
+     *
+     * @param src Source grayscale image (single-channel `U8`).
+     * @param px  Keypoint X (column) coordinate, in pixels.
+     * @param py  Keypoint Y (row) coordinate, in pixels.
+     * @returns   Orientation in radians, in `(-π, π]`.
+     */
+    ic_angle(src: matrix_t, px: number, py: number): number {
+        const half_k = 15; // half patch size
+        let m_01 = 0,
+            m_10 = 0;
+        const s = src.data,
+            step = src.cols;
+        let u = 0,
+            v = 0;
+        const center_off = (py * step + px) | 0;
+        let v_sum = 0,
+            d = 0,
+            val_plus = 0,
+            val_minus = 0;
+
+        // Treat the centre line differently, v = 0.
+        for (u = -half_k; u <= half_k; ++u) {
+            m_10 += u * s[center_off + u];
+        }
+
+        // Go line by line in the circular patch, processing the symmetric pair
+        // of rows (+v, -v) together.
+        for (v = 1; v <= half_k; ++v) {
+            v_sum = 0;
+            d = u_max[v];
+            for (u = -d; u <= d; ++u) {
+                val_plus = s[center_off + u + v * step];
+                val_minus = s[center_off + u - v * step];
+                v_sum += val_plus - val_minus;
+                m_10 += u * (val_plus + val_minus);
+            }
+            m_01 += v * v_sum;
+        }
+
+        return Math.atan2(m_01, m_10);
     }
 
     /**

--- a/tests/parity/orb_ic_angle.test.ts
+++ b/tests/parity/orb_ic_angle.test.ts
@@ -1,0 +1,233 @@
+/*
+ *  orb_ic_angle.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import { noiseImage, image, uniformImage } from "../properties/helpers";
+
+/**
+ * Parity target: `ic_angle()` in `examples/sample_orb.html` /
+ * `examples/sample_orb_pinball.html` — where this routine lived, duplicated,
+ * before it moved into `orb` (issue #96).
+ *
+ * There is no vendored jsfeat oracle for this one: original jsfeat never
+ * shipped keypoint orientation in the library either, it too kept `ic_angle`
+ * in its ORB sample. So the reference below is the sample's own
+ * implementation, transcribed verbatim — the same arrangement as
+ * `tests/parity/bfmatcher.test.ts`.
+ */
+const u_max_ref = new Int32Array([15, 15, 15, 15, 14, 14, 14, 13, 13, 12, 11, 10, 9, 8, 6, 3, 0]);
+
+function reference_ic_angle(img: { data: ArrayLike<number>; cols: number }, px: number, py: number): number {
+    const half_k = 15;
+    let m_01 = 0,
+        m_10 = 0;
+    const src = img.data,
+        step = img.cols;
+    let u = 0,
+        v = 0;
+    const center_off = (py * step + px) | 0;
+    let v_sum = 0,
+        d = 0,
+        val_plus = 0,
+        val_minus = 0;
+
+    for (u = -half_k; u <= half_k; ++u) m_10 += u * src[center_off + u];
+
+    for (v = 1; v <= half_k; ++v) {
+        v_sum = 0;
+        d = u_max_ref[v];
+        for (u = -d; u <= d; ++u) {
+            val_plus = src[center_off + u + v * step];
+            val_minus = src[center_off + u - v * step];
+            v_sum += val_plus - val_minus;
+            m_10 += u * (val_plus + val_minus);
+        }
+        m_01 += v * v_sum;
+    }
+
+    return Math.atan2(m_01, m_10);
+}
+
+describe("parity: orb.ic_angle vs the examples' inline ic_angle", () => {
+    it("agrees bit-for-bit across a textured image", () => {
+        const img = noiseImage(128, 128, 7001);
+        const orb = jsfeatNext.orb;
+
+        // stay >= 15 px from every edge: the patch is read without bounds checks
+        for (let py = 16; py < 112; py += 7) {
+            for (let px = 16; px < 112; px += 7) {
+                expect(orb.ic_angle(img, px, py)).toBe(reference_ic_angle(img, px, py));
+            }
+        }
+    });
+
+    it("agrees on a smooth gradient, where the centroid is unambiguous", () => {
+        const img = image(96, 96, (x) => x * 2);
+        const orb = jsfeatNext.orb;
+        for (let py = 20; py < 76; py += 11) {
+            for (let px = 20; px < 76; px += 11) {
+                expect(orb.ic_angle(img, px, py)).toBe(reference_ic_angle(img, px, py));
+            }
+        }
+    });
+});
+
+describe("properties: orb.ic_angle", () => {
+    const orb = jsfeatNext.orb;
+
+    it("points along the intensity gradient: +x ramp gives angle 0", () => {
+        // brightness increasing with x puts the intensity centroid to the right
+        // of the patch centre, so m_10 > 0, m_01 == 0 -> atan2(0, +) == 0.
+        const img = image(96, 96, (x) => 40 + x);
+        expect(orb.ic_angle(img, 48, 48)).toBeCloseTo(0, 10);
+    });
+
+    it("+y ramp gives angle +pi/2", () => {
+        const img = image(96, 96, (_x, y) => 40 + y);
+        expect(orb.ic_angle(img, 48, 48)).toBeCloseTo(Math.PI / 2, 10);
+    });
+
+    it("rotating the ramp rotates the angle by the same amount", () => {
+        // a diagonal ramp (x + y) has its centroid at 45 degrees
+        const img = image(96, 96, (x, y) => 40 + x + y);
+        expect(orb.ic_angle(img, 48, 48)).toBeCloseTo(Math.PI / 4, 10);
+    });
+
+    it("is invariant to a uniform brightness lift", () => {
+        // a constant added to every pixel is symmetric about the centre, so it
+        // cancels in both moments and must not move the angle.
+        const base = image(96, 96, (x, y) => 40 + ((x * 3 + y * 7) % 60));
+        const lifted = image(96, 96, (x, y) => 40 + ((x * 3 + y * 7) % 60) + 30);
+        expect(orb.ic_angle(lifted, 48, 48)).toBeCloseTo(orb.ic_angle(base, 48, 48), 10);
+    });
+
+    it("returns 0 for a flat patch (both moments vanish)", () => {
+        // atan2(0, 0) is 0 by IEEE-754; the angle is meaningless but must not
+        // be NaN, since describe() feeds it straight into cos/sin.
+        const flat = uniformImage(64, 64, 128);
+        const a = orb.ic_angle(flat, 32, 32);
+        expect(Number.isNaN(a)).toBe(false);
+        expect(a).toBe(0);
+    });
+
+    it("stays within (-pi, pi]", () => {
+        const img = noiseImage(128, 128, 7002);
+        for (let py = 16; py < 112; py += 13) {
+            for (let px = 16; px < 112; px += 13) {
+                const a = orb.ic_angle(img, px, py);
+                expect(a).toBeGreaterThan(-Math.PI);
+                expect(a).toBeLessThanOrEqual(Math.PI);
+            }
+        }
+    });
+});
+
+/**
+ * A smooth, blobby scene and its exact 90 degree rotation.
+ *
+ * `rot(x, y) = gen(y, M - 1 - x)` turns the image a quarter turn about
+ * `((M-1)/2, (M-1)/2)`, which lands on a pixel centre only when `M` is ODD.
+ * With an odd size the rotation is a pure permutation of the pixel grid, so
+ * the patch at the fixpoint sees exactly the same pixels, merely turned --
+ * no resampling, no interpolation error. An even size puts the fixpoint on a
+ * half-pixel and the equivariance below degrades to ~5 degrees of slop.
+ *
+ * The content is deliberately SMOOTH (a product of sines, ~11 px period).
+ * Pixel-scale noise would defeat the descriptor comparison: ORB rectifies the
+ * patch by bilinear resampling, which does not preserve content at the Nyquist
+ * limit, so two views of a noise field give uncorrelated descriptors however
+ * well the orientation is recovered.
+ */
+const M = 97;
+const M_CENTRE = (M - 1) / 2;
+const smoothGen = (x: number, y: number) => 128 + 90 * Math.sin(x / 11) * Math.cos(y / 13);
+
+describe("orb.ic_angle closes the detect -> describe gap (issue #96)", () => {
+    const orb = jsfeatNext.orb;
+    const upright = image(M, M, smoothGen);
+    const turned = image(M, M, (x, y) => smoothGen(y, M - 1 - x));
+
+    it("is rotation-equivariant: turning the image 90 degrees turns the angle 90 degrees", () => {
+        // This is the property that makes the method worth having: the measured
+        // orientation tracks the feature, so rectifying by it cancels rotation.
+        const a = orb.ic_angle(upright, M_CENTRE, M_CENTRE);
+        const b = orb.ic_angle(turned, M_CENTRE, M_CENTRE);
+        // exact to the last bit for this fixpoint-aligned rotation
+        expect(b - a).toBeCloseTo(Math.PI / 2, 12);
+    });
+
+    it("gives descriptors that survive rotation, where the default angle does not", () => {
+        // Detectors never set `angle`, and describe() rotates the patch by
+        // whatever it finds there. Left at the keypoint_t default of -1, the
+        // patch is rotated by -1 RADIAN (about -57 degrees) -- not a no-op --
+        // so the same feature seen at two orientations yields unrelated
+        // descriptors. Feeding ic_angle instead makes them nearly equal.
+        const U8C1 = jsfeatNext.U8_t | jsfeatNext.C1_t;
+        const describeAt = (img: typeof upright, angle: number) => {
+            const kp = [new jsfeatNext.keypoint_t(M_CENTRE, M_CENTRE, 0, 0, angle)];
+            const d = new jsfeatNext.matrix_t(32, 1, U8C1);
+            orb.describe(img, kp, 1, d);
+            return d;
+        };
+
+        const popcount = (n: number) => {
+            n -= (n >> 1) & 0x55555555;
+            n = (n & 0x33333333) + ((n >> 2) & 0x33333333);
+            return (((n + (n >> 4)) & 0xf0f0f0f) * 0x1010101) >> 24;
+        };
+        const hamming = (p: { data: ArrayLike<number> }, q: { data: ArrayLike<number> }) => {
+            let d = 0;
+            for (let i = 0; i < 32; i++) d += popcount(p.data[i] ^ q.data[i]);
+            return d;
+        };
+
+        const oriented = hamming(
+            describeAt(upright, orb.ic_angle(upright, M_CENTRE, M_CENTRE)),
+            describeAt(turned, orb.ic_angle(turned, M_CENTRE, M_CENTRE))
+        );
+        const unoriented = hamming(describeAt(upright, -1), describeAt(turned, -1));
+
+        // Measured at the time of writing: 11 bits apart with orientation,
+        // 87 without, out of 256. The bounds leave room for resampling jitter
+        // while still failing loudly if orientation stops being applied.
+        expect(oriented).toBeLessThan(40);
+        expect(unoriented).toBeGreaterThan(60);
+        expect(oriented).toBeLessThan(unoriented / 2);
+    });
+});


### PR DESCRIPTION
Part of #96 — the jsfeatNext-side work item ("stream A": keep the modules adapter-ready). The `CvBackend` contract and the adapter itself live in `webarkit/webarkit` and are **not** part of this PR.

## The audit

Four of the five primitives the adapter delegates to are already adapter-ready — public, neutral-mappable I/O, no hidden state:

| contract method | jsfeatNext primitive | status |
|---|---|---|
| `match` | `bfmatcher.match` / `knnMatch` / `ratio_test` | ready (`matrix_t` in, `match_t[]` out) |
| `estimateHomography` | `motion_estimator.ransac` + `homography2d` | ready (mask is a `matrix_t` → `Uint8Array`) |
| `poseFromHomography` | `pose_estimator.estimate` | ready (`matrix_t` + `Float64Array`) |
| `detect` | `fast_corners` / `yape` / `yape06` | ready |
| `describe` | `orb.describe` | ready |

Useful incidental finding for whoever writes the adapter: `point_t` and `keypoint_t` are structurally identical (`x, y, score, level, angle`), so a single pre-allocated pool can be passed to both `fast_corners.detect` (typed `point_t[]`) and `orb.describe` (typed `keypoint_t[]`).

## The gap this PR closes

**Keypoint orientation was missing from the library.** `ic_angle` — the intensity-centroid measure that makes ORB descriptors rotation-invariant — existed only in the example pages, duplicated verbatim in `sample_orb.html` and `sample_orb_pinball.html`. Nothing under `src/` ever assigned `keypoint_t.angle`.

This is the same shape of gap #133 closed for `match_pattern`.

Why it matters for #96: the contract's `Keypoint` type has an `angle` field and `detect()` is expected to return it populated. jsfeatNext's detectors never set it, so an out-of-repo adapter would have to reimplement the orientation itself — leaving PureCV's Rust port with no TypeScript oracle to cross-validate against, which is half the reason the jsfeatNext backend exists.

To be precise about severity: this is not a hard blocker. An adapter could pass `angle = 0` and the code would run — it would just produce descriptors that are not rotation-invariant.

`ic_angle` now lives in `orb` as a public method, with the `u_max` table at module scope so the hot loop allocates nothing per call. Placement follows the ORB paper (the "o" in oFAST is that paper's own contribution) and OpenCV, which keeps `IC_Angle` in `orb.cpp`; `bit_pattern_31` is the existing precedent for ORB-specific data living here.

Both examples now call the library method instead of carrying their own copy.

## Documentation fix

`examples/orb_test.html` claimed `angle = -1` lets ORB work out the patch orientation itself. That was never true: `rectify_patch` feeds the value straight into `cos`/`sin`, so `-1` rotates the patch by **−1 radian** (≈ −57°) rather than leaving it upright. The page now fixes the angle at 0 — it only compares a patch against itself under a brightness change — and says why. `describe`'s own docs now state that orientation is a required prior step, not an optional one.

## Tests

10 new (295 → 305, all green).

- **Parity** against the examples' inline implementation — the only available oracle, since original jsfeat also kept `ic_angle` in its sample rather than the library. Same arrangement as `tests/parity/bfmatcher.test.ts`.
- **Invariants**: gradient direction (+x ramp → 0, +y ramp → π/2, diagonal → π/4), brightness invariance, `atan2(0,0)` returning 0 rather than NaN on a flat patch, and range.
- **Rotation equivariance**: turning the image a quarter turn turns the angle by exactly π/2 — to the last bit. This only holds on an odd-sized image, where the rotation's fixpoint lands on a pixel centre; an even size puts it on a half-pixel and the error grows to ~5°. Documented in the test.
- **A closing test pins the point of the method**: 11 bits apart with orientation versus 87 without, out of 256.

One note on that last test, since the numbers look suspiciously convenient: the first version used a pixel-noise image and failed at 131 vs 130. That was not a defect in `ic_angle` — ORB rectifies the patch by bilinear resampling, which does not preserve content at the Nyquist limit, so two views of a noise field give uncorrelated descriptors however well the orientation is recovered. The test now uses smooth structure, and the comment explains the constraint.

## Verification

- `npm test` — 305 passed
- `npm run typecheck` — clean
- `npm run format-check` — clean
- `node scripts/check-license-headers.mjs` — 100 files OK
- Built locally and both webcam examples confirmed working by @kalwalt. `dist/` and `types/` are deliberately **not** committed — they are rebuilt at release time.

## Not in this PR

- Folding the #128 / #129 amendments into `@webarkit/cv-backend-spec` (that package is still at its pre-amendment version).
- The `cv-backend-jsfeatnext` adapter package itself.

Both are `webarkit/webarkit` work.
