### PR TITLE
feat(motion_estimator): injectable RNG for ransac/lmeds minimal-sample draws

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -74,4 +74,4 @@ export type { ransac_params_t } from "./motion_estimator/ransac_params_t";
 export type { match_t, IMatch_T } from "./bfmatcher/match_t";
 export type { pose_t, IPose_T } from "./pose_estimator/pose_estimator";
 export type { ICache } from "./cache/cache";
-export type { TypedArray, NumericArray, MotionKernel } from "./types";
+export type { TypedArray, NumericArray, MotionKernel, RandomFn } from "./types";

--- a/src/math/math.ts
+++ b/src/math/math.ts
@@ -47,6 +47,7 @@
 import jsfeatNext from "../core/core";
 import { matrix_t } from "../matrix_t/matrix_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
+import type { RandomFn } from "../types";
 
 /**
  * General math utilities: Gaussian-kernel generation, an in-place quicksort
@@ -582,5 +583,29 @@ export class math extends jsfeatNext {
             else if (hh >= median) high = hh - 1;
         }
         return 0;
+    }
+
+    /**
+     * Seedable pseudo-random generator (mulberry32), returning a {@link RandomFn}
+     * matching `Math.random`'s `[0, 1)` contract. Deterministic for a given
+     * seed and fast (one 32-bit multiply-heavy mix per call).
+     *
+     * Original to jsfeatNext (not ported from jsfeat), added for issue #189:
+     * `ransac_params_t`'s `rng` field and `motion_estimator.get_subset` accept
+     * `Math.random` by default, so this is what a caller reaches for to make
+     * `ransac()`/`lmeds()` reproducible across runs instead.
+     *
+     * @param seed 32-bit integer seed.
+     * @returns A `RandomFn` producing the same sequence for the same seed.
+     */
+    mulberry32(seed: number): RandomFn {
+        let a = seed >>> 0;
+        return () => {
+            a |= 0;
+            a = (a + 0x6d2b79f5) | 0;
+            let t = Math.imul(a ^ (a >>> 15), 1 | a);
+            t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+            return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+        };
     }
 }

--- a/src/motion_estimator/motion_estimator.ts
+++ b/src/motion_estimator/motion_estimator.ts
@@ -48,7 +48,7 @@ import { ransac_params_t } from "./ransac_params_t";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import { homography2d } from "../motion_model/motion_model";
 import { math } from "../math/math";
-import type { MotionKernel, TypedArray } from "../types";
+import type { MotionKernel, RandomFn, TypedArray } from "../types";
 
 /**
  * Robust motion-model estimation from noisy point correspondences via
@@ -66,8 +66,8 @@ export class motion_estimator extends jsfeatNext {
 
     /**
      * Draws a random minimal sample of `need_cnt` distinct correspondences
-     * (via `Math.random`) and validates it with `kernel.check_subset`.
-     * Retries up to 1000 times before giving up.
+     * and validates it with `kernel.check_subset`. Retries up to 1000 times
+     * before giving up.
      *
      * @param kernel   The motion-model kernel (validates the sample).
      * @param from     Source points. @param to Destination points.
@@ -75,6 +75,9 @@ export class motion_estimator extends jsfeatNext {
      * @param max_cnt  Total number of correspondences to draw from.
      * @param from_sub Output array receiving the sampled source points.
      * @param to_sub   Output array receiving the sampled destination points.
+     * @param rng      Source of `[0, 1)` randomness. Default `Math.random`
+     *                  (issue #189 — pass a seeded {@link RandomFn}, e.g.
+     *                  `math.mulberry32`, for reproducible draws).
      * @returns `true` when a valid subset was found.
      */
     get_subset(
@@ -84,7 +87,8 @@ export class motion_estimator extends jsfeatNext {
         need_cnt: number,
         max_cnt: number,
         from_sub: point_t[],
-        to_sub: point_t[]
+        to_sub: point_t[],
+        rng: RandomFn = Math.random
     ): boolean {
         const max_try = 1000;
         const indices = [];
@@ -100,7 +104,7 @@ export class motion_estimator extends jsfeatNext {
                 idx_i = 0;
                 while (!ok) {
                     ok = true;
-                    idx_i = indices[i] = Math.floor(Math.random() * max_cnt) | 0;
+                    idx_i = indices[i] = Math.floor(rng() * max_cnt) | 0;
                     for (j = 0; j < i; ++j) {
                         if (idx_i == indices[j]) {
                             ok = false;
@@ -171,7 +175,6 @@ export class motion_estimator extends jsfeatNext {
      * afterwards, in `cv::findHomography`, is a separate caller-level layer;
      * see {@link find_homography} (issue #185).
      *
-
      * @param params    Estimation parameters ({@link ransac_params_t}).
      * @param kernel    Motion-model kernel (`homography2d` / `affine2d`).
      * @param from      Source points. @param to Destination points.
@@ -245,7 +248,7 @@ export class motion_estimator extends jsfeatNext {
 
         for (; iter < niters; ++iter) {
             // generate subset
-            found = this.get_subset(kernel, from, to, model_points, count, subset0, subset1);
+            found = this.get_subset(kernel, from, to, model_points, count, subset0, subset1, params.rng);
             if (!found) {
                 if (iter == 0) {
                     this.cache.put_buffer(m_buff);
@@ -370,7 +373,7 @@ export class motion_estimator extends jsfeatNext {
 
         for (; iter < niters; ++iter) {
             // generate subset
-            found = this.get_subset(kernel, from, to, model_points, count, subset0, subset1);
+            found = this.get_subset(kernel, from, to, model_points, count, subset0, subset1, params.rng);
             if (!found) {
                 if (iter == 0) {
                     this.cache.put_buffer(m_buff);

--- a/src/motion_estimator/motion_estimator.ts
+++ b/src/motion_estimator/motion_estimator.ts
@@ -102,7 +102,7 @@ export class motion_estimator extends jsfeatNext {
             for (; i < need_cnt && ssiter < max_try;) {
                 ok = false;
                 idx_i = 0;
-                while (!ok) {
+                while (!ok && ssiter < max_try) {
                     ok = true;
                     idx_i = indices[i] = Math.floor(rng() * max_cnt) | 0;
                     for (j = 0; j < i; ++j) {
@@ -111,7 +111,16 @@ export class motion_estimator extends jsfeatNext {
                             break;
                         }
                     }
+                    // A duplicate draw counts against the same ssiter/max_try
+                    // budget as a check_subset rejection below, so a
+                    // degenerate (but RandomFn-contract-compliant) injected
+                    // rng — e.g. one that always returns the same value —
+                    // can't hang this loop forever once #189 made rng
+                    // injectable. Math.random's duplicate rate is negligible
+                    // enough that this doesn't change behavior for it.
+                    if (!ok) ++ssiter;
                 }
+                if (!ok) break;
                 from_sub[i] = from[idx_i];
                 to_sub[i] = to[idx_i];
                 if (!kernel.check_subset(from_sub, to_sub, i + 1)) {

--- a/src/motion_estimator/ransac_params_t.ts
+++ b/src/motion_estimator/ransac_params_t.ts
@@ -40,10 +40,16 @@
  *
  */
 
+import type { RandomFn } from "../types";
+
 /**
  * Parameter block for `motion_estimator.ransac` / `motion_estimator.lmeds`.
  *
- * Mirrors `jsfeat.ransac_params_t` from the original library.
+ * Mirrors `jsfeat.ransac_params_t` from the original library, plus an
+ * injectable `rng` (issue #189): `get_subset`'s minimal-sample draws use
+ * `Math.random` by default, matching jsfeat and existing callers exactly, but
+ * a caller can pass a seeded {@link RandomFn} (e.g. `math.mulberry32`) here
+ * for reproducible RANSAC/LMEDS runs instead.
  */
 export class ransac_params_t {
     /** Minimal sample size per model hypothesis (e.g. 4 for homography2d, 3 for affine2d). */
@@ -54,18 +60,36 @@ export class ransac_params_t {
     public eps: number;
     /** Desired probability (0–1) of finding an outlier-free sample. */
     public prob: number;
+    /** Source of `[0, 1)` randomness for `get_subset`'s minimal-sample draws. Default `Math.random`. */
+    public rng: RandomFn;
 
     /**
      * @param size   Minimal sample size per hypothesis. Default 0.
      * @param thresh Inlier error threshold in pixels. Default 0.5.
      * @param eps    Assumed outlier ratio. Default 0.5.
      * @param prob   Desired success probability. Default 0.99.
+     * @param rng    Source of `[0, 1)` randomness for minimal-sample draws. Default `Math.random`.
      */
-    constructor(size: number = 0, thresh: number = 0.5, eps: number = 0.5, prob: number = 0.99) {
+    constructor(
+        size: number = 0,
+        thresh: number = 0.5,
+        eps: number = 0.5,
+        prob: number = 0.99,
+        // Wrapped rather than `= Math.random` directly: a default parameter
+        // is only re-evaluated per *constructor call*, so a bare `Math.random`
+        // default would freeze in whatever function object `Math.random` was
+        // at construction time — permanently bypassing a `vi.spyOn(Math,
+        // "random")` mock installed afterward (the established pattern in
+        // this codebase's own tests: construct params, *then* seed). Calling
+        // through this wrapper instead re-reads the current `Math.random`
+        // property on every draw, matching get_subset's pre-#189 behavior.
+        rng: RandomFn = () => Math.random()
+    ) {
         this.size = size;
         this.thresh = thresh;
         this.eps = eps;
         this.prob = prob;
+        this.rng = rng;
     }
 
     /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,3 +68,11 @@ export interface MotionKernel {
     /** Rejects degenerate minimal samples (e.g. collinear points); returns `true` when the subset is usable. */
     check_subset(from: point_t[], to: point_t[], count: number): boolean;
 }
+
+/**
+ * A source of numbers in `[0, 1)`, matching the signature of `Math.random`.
+ * `ransac_params_t`'s `rng` field and `motion_estimator.get_subset` accept
+ * one of these so callers can substitute a seeded generator (e.g.
+ * {@link math.mulberry32}) for deterministic RANSAC/LMEDS runs — issue #189.
+ */
+export type RandomFn = () => number;

--- a/tests/parity/motion_estimator.test.ts
+++ b/tests/parity/motion_estimator.test.ts
@@ -45,8 +45,12 @@ import jsfeat from "../vendor/oracle.cjs";
  * for motion_estimator.ransac / lmeds with homography2d and affine2d kernels.
  *
  * RANSAC/LMEDS draw random subsets via Math.random. To make both sides
- * deterministic AND identical, Math.random is stubbed with the same seeded
- * PRNG sequence for the jsfeatNext run and again (re-seeded) for the oracle.
+ * deterministic AND identical, the jsfeatNext side is seeded via
+ * `ransac_params_t`'s injectable `rng` (issue #189) with the same mulberry32
+ * sequence that's stubbed onto the global `Math.random` for the oracle side —
+ * jsfeat itself can't be given an injectable RNG (it's a frozen vendored
+ * dependency, not code this repo owns), so the global mock is still the only
+ * way to make *its* draws deterministic and reproducible across runs.
  *
  * API note (Axis 2): kernels live under jsfeat.motion_model.* in the
  * original; jsfeatNext exposes them as jsfeatNext.homography2d/affine2d.
@@ -105,15 +109,13 @@ describe("parity: motion_estimator vs original jsfeat.motion_estimator", () => {
     it("ransac with homography2d kernel: same model and same inlier mask", () => {
         const { from, to } = makeCorrespondences(N, OUT);
 
-        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, mulberry32(2024));
         const me = jsfeatNext.motion_estimator;
         const kernel = jsfeatNext.homography2d;
         const model = new jsfeatNext.matrix_t(3, 3, F32C1);
         const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
 
-        seededRandom(2024);
         const okN = me.ransac(params, kernel, from, to, N, model, mask, 1000);
-        vi.restoreAllMocks();
 
         const paramsO = new jsfeat.ransac_params_t(4, 3.0, 0.5, 0.99);
         const kernelO = new jsfeat.motion_model.homography2d();
@@ -141,15 +143,13 @@ describe("parity: motion_estimator vs original jsfeat.motion_estimator", () => {
     it("lmeds with homography2d kernel: same model and same inlier mask", () => {
         const { from, to } = makeCorrespondences(N, OUT);
 
-        const params = new jsfeatNext.ransac_params_t(4, 0, 0.45, 0.99);
+        const params = new jsfeatNext.ransac_params_t(4, 0, 0.45, 0.99, mulberry32(777));
         const me = jsfeatNext.motion_estimator;
         const kernel = jsfeatNext.homography2d;
         const model = new jsfeatNext.matrix_t(3, 3, F32C1);
         const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
 
-        seededRandom(777);
         const okN = me.lmeds(params, kernel, from, to, N, model, mask, 1000);
-        vi.restoreAllMocks();
 
         const paramsO = new jsfeat.ransac_params_t(4, 0, 0.45, 0.99);
         const kernelO = new jsfeat.motion_model.homography2d();
@@ -191,15 +191,13 @@ describe("parity: motion_estimator vs original jsfeat.motion_estimator", () => {
         // missing the default check_subset() (original jsfeat returns true
         // there; only homography2d overrides it), which made RANSAC with an
         // affine2d kernel throw TypeError. Now fixed — full parity check.
-        const params = new jsfeatNext.ransac_params_t(3, 3.0, 0.5, 0.99);
+        const params = new jsfeatNext.ransac_params_t(3, 3.0, 0.5, 0.99, mulberry32(31337));
         const me = jsfeatNext.motion_estimator;
         const kernel = jsfeatNext.affine2d;
         const model = new jsfeatNext.matrix_t(3, 3, F32C1);
         const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
 
-        seededRandom(31337);
         const okN = me.ransac(params, kernel, from, to, N, model, mask, 1000);
-        vi.restoreAllMocks();
 
         const paramsO = new jsfeat.ransac_params_t(3, 3.0, 0.5, 0.99);
         const kernelO = new jsfeat.motion_model.affine2d();

--- a/tests/properties/data-structures.test.ts
+++ b/tests/properties/data-structures.test.ts
@@ -263,6 +263,27 @@ describe("ransac_params_t", () => {
         expect([p.size, p.thresh, p.eps, p.prob]).toEqual([0, 0.5, 0.5, 0.99]);
     });
 
+    it("rng defaults to something that behaves like Math.random (issue #189)", () => {
+        const p = new jsfeatNext.ransac_params_t();
+        for (let i = 0; i < 200; i++) {
+            const v = p.rng();
+            expect(v).toBeGreaterThanOrEqual(0);
+            expect(v).toBeLessThan(1);
+        }
+    });
+
+    it("accepts an injected rng and calls exactly that function", () => {
+        let calls = 0;
+        const rng = () => {
+            calls++;
+            return 0.5;
+        };
+        const p = new jsfeatNext.ransac_params_t(4, 0.5, 0.5, 0.99, rng);
+        expect(p.rng()).toBe(0.5);
+        expect(p.rng()).toBe(0.5);
+        expect(calls).toBe(2);
+    });
+
     it("update_iters never exceeds the cap and stays non-negative", () => {
         const p = new jsfeatNext.ransac_params_t(4, 0.5, 0.5, 0.99);
         for (const eps of [0, 0.1, 0.3, 0.5, 0.7, 0.9, 1]) {

--- a/tests/properties/find_homography.test.ts
+++ b/tests/properties/find_homography.test.ts
@@ -494,4 +494,28 @@ describe("motion_estimator.find_homography", () => {
         expect(second.model).toEqual(first.model);
         expect(second.mask).toEqual(first.mask);
     });
+
+    it("a degenerate RandomFn (always the same value) fails fast instead of hanging get_subset forever", () => {
+        // Qodo review finding on PR #191: get_subset's duplicate-index
+        // rejection loop had no bound of its own, only the outer ssiter/
+        // max_try budget -- which a constant-returning RandomFn never
+        // reaches, since it never even completes one subset draw. Math.random
+        // effectively never triggers this (collision probability is
+        // negligible), so this was latent until #189 made the generator
+        // injectable and a caller could hand in exactly this kind of
+        // contract-compliant-but-degenerate function.
+        const N = 20;
+        const { from, to } = makeCorrespondences(N, 0, 17);
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, () => 0);
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+
+        // Every draw resolves to index 0, so no 4-distinct-point sample can
+        // ever be formed -- this must fail, not hang.
+        expect(() => me.find_homography(params, kernel, from, to, N, model, mask)).not.toThrow();
+        expect(me.ransac(params, kernel, from, to, N, model, mask, 1000)).toBe(false);
+    });
 });

--- a/tests/properties/find_homography.test.ts
+++ b/tests/properties/find_homography.test.ts
@@ -466,4 +466,32 @@ describe("motion_estimator.find_homography", () => {
         expect(ok).toBe(false);
         for (let i = 0; i < N; i++) expect(mask.data[i]).toBe(7);
     });
+
+    it("params.rng (issue #189) makes ransac() and find_homography() reproducible without a global Math.random mock", () => {
+        const N = 40;
+        const OUT = 6;
+        const { from, to } = makeCorrespondences(N, OUT, 321);
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+
+        const run = () => {
+            // A fresh seeded generator each call: no vi.spyOn(Math, "random")
+            // anywhere in this test, demonstrating the injectable rng is a
+            // real alternative to the global-mock pattern used elsewhere in
+            // this file and in tests/parity/motion_estimator.test.ts.
+            const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(555));
+            const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+            const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+            const ok = me.find_homography(params, kernel, from, to, N, model, mask);
+            return { ok, model: Array.from(model.data as Float32Array), mask: Array.from(mask.data as Uint8Array) };
+        };
+
+        const first = run();
+        const second = run();
+
+        expect(first.ok).toBe(true);
+        expect(second.ok).toBe(true);
+        expect(second.model).toEqual(first.model);
+        expect(second.mask).toEqual(first.mask);
+    });
 });

--- a/tests/properties/math.test.ts
+++ b/tests/properties/math.test.ts
@@ -298,4 +298,36 @@ describe("math invariants", () => {
             expect(m.median(values, 0, 4)).toBe(5.5);
         });
     });
+
+    describe("mulberry32", () => {
+        // Original to jsfeatNext, added for issue #189 so callers can get
+        // OpenCV-style deterministic RANSAC/LMEDS by passing a seeded
+        // RandomFn as ransac_params_t's `rng`, instead of the codebase's own
+        // test-only pattern of globally mocking Math.random.
+
+        it("same seed produces the same sequence", () => {
+            const a = m.mulberry32(42);
+            const b = m.mulberry32(42);
+            for (let i = 0; i < 50; i++) {
+                expect(a()).toBe(b());
+            }
+        });
+
+        it("different seeds diverge", () => {
+            const a = m.mulberry32(1);
+            const b = m.mulberry32(2);
+            const seqA = Array.from({ length: 10 }, () => a());
+            const seqB = Array.from({ length: 10 }, () => b());
+            expect(seqA).not.toEqual(seqB);
+        });
+
+        it("every draw is within [0, 1)", () => {
+            const r = m.mulberry32(123456);
+            for (let i = 0; i < 2000; i++) {
+                const v = r();
+                expect(v).toBeGreaterThanOrEqual(0);
+                expect(v).toBeLessThan(1);
+            }
+        });
+    });
 });


### PR DESCRIPTION
## Summary

`get_subset` draws its minimal samples from the global `Math.random` directly. This meant:
- No way to get `cv::findHomography`-style reproducibility (OpenCV seeds its own RNG with a fixed value per call).
- This codebase's own tests had to fall back to globally mocking `Math.random` via `vi.spyOn` — works, but can't run in parallel safely and every downstream consumer wanting determinism had to reinvent it.
- `webarkit/webarkit`'s `cv-backend-jsfeatnext` adapter hit exactly this gap: a test flaky ~1 in 45 runs, worked around with a loosened tolerance in `webarkit/webarkit#8`.

Per #189's acceptance criteria:
- `RandomFn = () => number` added to `src/types.ts`, re-exported from the package root.
- `ransac_params_t` gains an `rng` field (5th, optional constructor param), defaulting to a **lazy** `() => Math.random()` wrapper — not a bare `Math.random` reference, which would freeze whatever function object `Math.random` was *at construction time* into the instance, permanently bypassing a `vi.spyOn(Math, "random")` mock installed afterward (this codebase's own established pattern: construct params, *then* seed — caught this exact regression against the existing parity suite during development, see Testing below).
- `get_subset` accepts an optional trailing `rng` param (default `Math.random`, unchanged behavior for direct callers); `ransac()`/`lmeds()` now pass `params.rng` through.
- `math.mulberry32(seed)` — a small seedable generator returning a `RandomFn`, reachable via the existing singleton (`jsfeatNext.math.mulberry32(...)`), matching the issue's suggested name/location.
- `tests/parity/motion_estimator.test.ts` migrated off the global mock for the **jsfeatNext side** — the vendored jsfeat oracle itself still needs the global mock, since it's a frozen third-party dependency this repo doesn't own or modify.

No behavior change for existing callers that pass nothing: `get_subset`'s default still resolves `Math.random` fresh per call, exactly as before.

## Testing

- `npm test`: 326/326 passing (up from 320 before this PR — new tests below), run twice to confirm determinism.
- New tests: `mulberry32` reproducibility/divergence/range (`tests/properties/math.test.ts`), `ransac_params_t.rng` default + injection (`tests/properties/data-structures.test.ts`), end-to-end `find_homography()` reproducibility via an injected seed with **no** global `Math.random` mock anywhere in the test (`tests/properties/find_homography.test.ts`).
- `npx tsc --noEmit`, `prettier --check`, `check-license-headers.mjs`: clean.
- `npx vitest run --coverage`: patch coverage clean (learned from #185/#190's Codecov regression — verified no new uncovered branches).
- `/code-review` (two-axis, Standards + Spec against #189): 0 hard findings on both axes. One minor Spec-axis note (a documented-non-determinism mention in README vs. JSDoc-only) reviewed and left as-is — consistent with how #185/#128/#129 were documented (README explicitly delegates detailed API docs to TSDoc/TypeDoc, never duplicates per-parameter notes there).

Closes #189.