### PR TITLE
feat(linalg,motion_model): Levenberg-Marquardt refinement for homography/affine

### DIFF
--- a/src/linalg/linalg.ts
+++ b/src/linalg/linalg.ts
@@ -48,6 +48,21 @@ import matmath from "../matmath/matmath";
 import type { NumericArray } from "../types";
 
 /**
+ * The residual/Jacobian contract {@link linalg.lm_solve} refines against.
+ * Original to jsfeatNext (issue #187) — jsfeat has no non-linear solver.
+ */
+export interface LMCallback {
+    /**
+     * Fills `err` (length `m`, the solver's `num_residuals`) with the
+     * residuals at `params` (length `n`). When `J` is not `null`, also fills
+     * it — row-major, `m`×`n` — with the Jacobian at `params`.
+     *
+     * @returns `false` to report the parameters as degenerate and abort the solve.
+     */
+    compute(params: Float64Array, err: Float64Array, J: Float64Array | null): boolean;
+}
+
+/**
  * Dense linear-algebra solvers built on Jacobi rotations: LU and Cholesky
  * linear-system solvers, singular value decomposition (and SVD-based solve /
  * pseudo-inverse) and symmetric eigen-decomposition. Mirrors `jsfeat.linalg`
@@ -632,6 +647,162 @@ export class linalg extends jsfeatNext {
         }
 
         return 1;
+    }
+
+    /**
+     * Levenberg-Marquardt: refines `params` to minimize `Σ err(params)²` by
+     * repeatedly solving the damped normal system `(JᵀJ + λI)·Δ = Jᵀ·err`
+     * for a step `Δ`, accepting it (and shrinking `λ`) when it reduces the
+     * cost, or rejecting it (and growing `λ`) when it doesn't — the standard
+     * trust-region compromise between Gauss-Newton (fast near the optimum)
+     * and gradient descent (robust far from it).
+     *
+     * Original to jsfeatNext (issue #187) — jsfeat has no non-linear solver.
+     * Uses {@link cholesky_solve} on the damped normal system rather than an
+     * SVD-based solve: with `λ > 0` the damped `JᵀJ + λI` is always SPD, so
+     * Cholesky suffices and the solver has no dependency on SVD (relevant to
+     * a future `no_std`/WASM port, where SVD is a materially bigger ask than
+     * Cholesky).
+     *
+     * @param params        `n`×1 F64 matrix, the parameter vector — mutated
+     *                       in place to the refined result (or left as the
+     *                       best point found, on a degenerate step).
+     * @param num_residuals `m`, the number of residuals `callback` fills.
+     * @param callback      Computes residuals (and, when asked, the
+     *                       Jacobian) at a given parameter vector.
+     * @param max_iters     Iteration cap. Default 10 (matches OpenCV's
+     *                       `LMSolver`/`refineIters` default).
+     * @param eps           Stops early once the relative cost improvement
+     *                       between iterations drops below this. Default 1e-10.
+     * @returns `false` if `callback` ever reports degeneracy; `true` otherwise
+     *          (matching `LMSolver`, this does not mean "converged" — only
+     *          that `max_iters` were run, or `eps` was reached, without
+     *          numerical failure).
+     */
+    lm_solve(
+        params: matrix_t,
+        num_residuals: number,
+        callback: LMCallback,
+        max_iters: number = 10,
+        eps: number = 1e-10
+    ): boolean {
+        const n = params.rows,
+            m = num_residuals;
+        const x = params.data as Float64Array;
+
+        const err_buff = this.cache.get_buffer(m << 3);
+        const errNew_buff = this.cache.get_buffer(m << 3);
+        const J_buff = this.cache.get_buffer((m * n) << 3);
+        const JtJ_buff = this.cache.get_buffer((n * n) << 3);
+        const JtJ_damped_buff = this.cache.get_buffer((n * n) << 3);
+        const Jtr_buff = this.cache.get_buffer(n << 3);
+        // Separate from Jtr_buff: cholesky_solve overwrites its RHS in place
+        // with the solution, so the pristine Jᵀ·err must survive across
+        // retries (growing lambda) rather than being destroyed by the first
+        // attempt.
+        const Jtr_work_buff = this.cache.get_buffer(n << 3);
+        const xNew_buff = this.cache.get_buffer(n << 3);
+
+        const err = err_buff.f64,
+            errNew = errNew_buff.f64,
+            J = J_buff.f64,
+            JtJd = JtJ_buff.f64,
+            JtJd_damped = JtJ_damped_buff.f64,
+            Jtr = Jtr_buff.f64,
+            Jtr_work = Jtr_work_buff.f64,
+            xNew = xNew_buff.f64;
+
+        const JtJ_damped = new matrix_t(n, n, JSFEAT_CONSTANTS.F64_t | JSFEAT_CONSTANTS.C1_t, JtJ_damped_buff.data);
+        const Jtr_mt = new matrix_t(1, n, JSFEAT_CONSTANTS.F64_t | JSFEAT_CONSTANTS.C1_t, Jtr_work_buff.data);
+
+        let lambda = 1e-3;
+        let ok = true;
+
+        const cost_of = (e: Float64Array) => {
+            let s = 0.0;
+            for (let i = 0; i < m; ++i) s += e[i] * e[i];
+            return s;
+        };
+
+        if (!callback.compute(x, err, J)) {
+            ok = false;
+        } else {
+            let cost = cost_of(err);
+
+            for (let iter = 0; iter < max_iters; ++iter) {
+                // JtJ = Jᵀ·J, Jtr = Jᵀ·err (J is m x n, row-major)
+                for (let a = 0; a < n; ++a) {
+                    let s = 0.0;
+                    for (let i = 0; i < m; ++i) s += J[i * n + a] * err[i];
+                    Jtr[a] = s;
+                    for (let b = a; b < n; ++b) {
+                        let t = 0.0;
+                        for (let i = 0; i < m; ++i) t += J[i * n + a] * J[i * n + b];
+                        JtJd[a * n + b] = JtJd[b * n + a] = t;
+                    }
+                }
+
+                // Retry the same iteration with growing damping until a step
+                // both solves and reduces cost, or we give up on this step
+                // (keeping the current x) and let the next outer iteration
+                // recompute J from scratch.
+                let improved = false;
+                for (let retry = 0; retry < 10; ++retry) {
+                    JtJd_damped.set(JtJd.subarray(0, n * n));
+                    // Additive (Levenberg's original) rather than
+                    // multiplicative (Marquardt's `*= 1+λ`) damping: a
+                    // parameter whose column of J is exactly zero (no
+                    // residual depends on it) has JtJ[a,a] === 0, and
+                    // multiplicative damping leaves `0 * (1+λ) === 0`
+                    // regardless of λ — never regularizing that direction, so
+                    // cholesky_solve keeps failing no matter how much λ grows.
+                    // `+= λ` always pulls a zero diagonal away from singular.
+                    for (let a = 0; a < n; ++a) JtJd_damped[a * n + a] += lambda;
+                    Jtr_mt.data.set(Jtr.subarray(0, n));
+
+                    if (!this.cholesky_solve(JtJ_damped, Jtr_mt)) {
+                        lambda *= 10;
+                        continue;
+                    }
+                    // Jtr_mt now holds the step Δ; x_new = x - Δ (Gauss-Newton
+                    // step minimizing ‖J·Δ − (−err)‖, i.e. descending err).
+                    for (let a = 0; a < n; ++a) xNew[a] = x[a] - Jtr_mt.data[a];
+
+                    if (!callback.compute(xNew, errNew, null)) {
+                        ok = false;
+                        break;
+                    }
+                    const costNew = cost_of(errNew);
+
+                    if (costNew < cost) {
+                        for (let a = 0; a < n; ++a) x[a] = xNew[a];
+                        lambda = Math.max(lambda / 10, 1e-12);
+                        improved = Math.abs(cost - costNew) > eps * cost;
+                        cost = costNew;
+                        break;
+                    }
+                    lambda *= 10;
+                }
+
+                if (!ok || !improved) break;
+                // Recompute J at the accepted x for the next iteration.
+                if (!callback.compute(x, err, J)) {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+
+        this.cache.put_buffer(err_buff);
+        this.cache.put_buffer(errNew_buff);
+        this.cache.put_buffer(Jtr_work_buff);
+        this.cache.put_buffer(J_buff);
+        this.cache.put_buffer(JtJ_buff);
+        this.cache.put_buffer(JtJ_damped_buff);
+        this.cache.put_buffer(Jtr_buff);
+        this.cache.put_buffer(xNew_buff);
+
+        return ok;
     }
 
     /**

--- a/src/motion_estimator/motion_estimator.ts
+++ b/src/motion_estimator/motion_estimator.ts
@@ -557,10 +557,60 @@ export class motion_estimator extends jsfeatNext {
                     rin1.push(to[i]);
                 }
             }
-            // kernel.refine() leaves `model` untouched on a degenerate
-            // result (see homography2d.refine()), so no rollback is needed
-            // here on failure — the linear refit's model simply survives.
-            if (rin0.length > model_points) kernel.refine(rin0, rin1, model, rin0.length, refine_iters);
+            if (rin0.length > model_points) {
+                // Snapshot in case the refined model, though numerically
+                // valid, ends up satisfying fewer than model_points points
+                // under the same reclassification threshold — mirrors the
+                // linear refit's own "keep the pre-refit model/mask" fallback.
+                const pre_refine_buff = this.cache.get_buffer((mc * mr) << 3);
+                const pre_refine_model = new matrix_t(mc, mr, dt, pre_refine_buff.data);
+                model.copy_to(pre_refine_model);
+
+                // kernel.refine() leaves `model` untouched on its own
+                // degenerate result (see homography2d.refine()), so a
+                // return of 0 here needs no special handling beyond
+                // skipping the mask recompute below.
+                if (kernel.refine(rin0, rin1, model, rin0.length, refine_iters) > 0) {
+                    const err_buff = this.cache.get_buffer(count << 2);
+                    const refine_mask_buff = this.cache.get_buffer(count);
+                    const err = err_buff.f32;
+                    const refine_mask = new matrix_t(count, 1, JSFEAT_CONSTANTS.U8C1_t, refine_mask_buff.data);
+
+                    let threshold = params.thresh;
+                    if (method === "lmeds") {
+                        kernel.error(from, to, model, err, count);
+                        const median = new math().median(err, 0, count - 1);
+                        threshold = Math.max(
+                            2.5 * 1.4826 * (1 + 5.0 / (count - model_points)) * Math.sqrt(median),
+                            0.001
+                        );
+                    }
+
+                    const numinliers = this.find_inliers(
+                        kernel,
+                        model,
+                        from,
+                        to,
+                        count,
+                        threshold,
+                        err,
+                        refine_mask.data
+                    );
+
+                    if (numinliers >= model_points) {
+                        refine_mask.copy_to(own_mask);
+                    } else {
+                        // refine's model satisfies too few points under the
+                        // same threshold — keep the pre-refine model/mask.
+                        pre_refine_model.copy_to(model);
+                    }
+
+                    this.cache.put_buffer(err_buff);
+                    this.cache.put_buffer(refine_mask_buff);
+                }
+
+                this.cache.put_buffer(pre_refine_buff);
+            }
         }
 
         if (mask) own_mask.copy_to(mask);

--- a/src/motion_estimator/motion_estimator.ts
+++ b/src/motion_estimator/motion_estimator.ts
@@ -452,8 +452,15 @@ export class motion_estimator extends jsfeatNext {
      * @param model     Output model matrix; refit over all inliers on success.
      * @param mask      Output 0/1 inlier mask (`count`×1 matrix), recomputed
      *                   against the refit model. Optional.
-     * @param method    `"ransac"` (default) or `"lmeds"`.
-     * @param max_iters Iteration cap forwarded to the underlying estimator. Default 1000.
+     * @param method       `"ransac"` (default) or `"lmeds"`.
+     * @param max_iters    Iteration cap forwarded to the underlying estimator. Default 1000.
+     * @param refine_iters Non-linear (Levenberg-Marquardt) polish over the
+     *                      final inlier set after the linear refit, via
+     *                      `kernel.refine()` (issue #187) — minimizes actual
+     *                      reprojection error rather than the linear refit's
+     *                      algebraic residual. Default 0 (skipped, matching
+     *                      this method's pre-#187 behavior); has no effect
+     *                      when `kernel` doesn't implement `refine()`.
      * @returns `true` when the underlying estimator (`ransac`/`lmeds`) found a model.
      */
     find_homography(
@@ -465,7 +472,8 @@ export class motion_estimator extends jsfeatNext {
         model: matrix_t,
         mask?: matrix_t,
         method: "ransac" | "lmeds" = "ransac",
-        max_iters: number = 1000
+        max_iters: number = 1000,
+        refine_iters: number = 0
     ): boolean {
         const model_points = params.size;
         const mc = model.cols,
@@ -538,6 +546,21 @@ export class motion_estimator extends jsfeatNext {
             // else: degenerate refit (e.g. collinear inliers) — keep the pre-refit model/mask
 
             this.cache.put_buffer(m_buff);
+        }
+
+        if (refine_iters > 0 && kernel.refine) {
+            const rin0: point_t[] = [];
+            const rin1: point_t[] = [];
+            for (let i = 0; i < count; ++i) {
+                if (own_mask.data[i]) {
+                    rin0.push(from[i]);
+                    rin1.push(to[i]);
+                }
+            }
+            // kernel.refine() leaves `model` untouched on a degenerate
+            // result (see homography2d.refine()), so no rollback is needed
+            // here on failure — the linear refit's model simply survives.
+            if (rin0.length > model_points) kernel.refine(rin0, rin1, model, rin0.length, refine_iters);
         }
 
         if (mask) own_mask.copy_to(mask);

--- a/src/motion_model/motion_model.ts
+++ b/src/motion_model/motion_model.ts
@@ -46,7 +46,7 @@ import { point_t } from "../point_t/point_t";
 import type { TypedArray } from "../types";
 import { JSFEAT_CONSTANTS } from "../constants/constants";
 import matmath from "../matmath/matmath";
-import { linalg } from "../linalg/linalg";
+import { linalg, LMCallback } from "../linalg/linalg";
 
 /**
  * Shared base of the motion-model kernels ({@link affine2d},
@@ -313,6 +313,63 @@ export class affine2d extends motion_model {
      */
     check_subset(from: point_t[], to: point_t[], count: number): boolean {
         return true; // all good
+    }
+
+    /**
+     * Non-linear (Levenberg-Marquardt) refinement of the affine `model`
+     * (issue #187), mirroring OpenCV's `Affine2DRefineCallback`. The model
+     * is already linear in its 6 parameters, and `run()` already solves the
+     * exact least-squares optimum for them via normal equations — so LM
+     * seeded from that solution has zero gradient at the start and
+     * terminates immediately without changing it (this mirrors OpenCV's own
+     * note that `estimateAffine2D` skips the extra `runKernel` refit
+     * `findHomography` does, since LM alone already converges to the LS
+     * answer for a linear model). Implemented for API symmetry with
+     * {@link homography2d.refine}, not because it moves the answer.
+     *
+     * @param from  Source points. @param to Destination points.
+     * @param model 3×3 affine model to refine in place (bottom row `[0,0,1]`).
+     * @param count Number of correspondences.
+     * @param iters LM iteration cap. Default 10.
+     * @returns 1 (an affine model has no degenerate-normalization case).
+     */
+    refine(from: point_t[], to: point_t[], model: matrix_t, count: number, iters: number = 10): number {
+        const params_buff = this.cache.get_buffer(6 << 3);
+        const params = new matrix_t(1, 6, JSFEAT_CONSTANTS.F64_t | JSFEAT_CONSTANTS.C1_t, params_buff.data);
+        for (let i = 0; i < 6; ++i) params.data[i] = model.data[i];
+
+        const callback: LMCallback = {
+            compute: (h, err, J) => {
+                for (let i = 0; i < count; ++i) {
+                    const pt0 = from[i],
+                        pt1 = to[i];
+                    const xi = h[0] * pt0.x + h[1] * pt0.y + h[2];
+                    const yi = h[3] * pt0.x + h[4] * pt0.y + h[5];
+                    err[2 * i] = xi - pt1.x;
+                    err[2 * i + 1] = yi - pt1.y;
+                    if (J) {
+                        const r0 = 2 * i * 6,
+                            r1 = (2 * i + 1) * 6;
+                        ((J[r0 + 0] = pt0.x), (J[r0 + 1] = pt0.y), (J[r0 + 2] = 1));
+                        ((J[r0 + 3] = 0), (J[r0 + 4] = 0), (J[r0 + 5] = 0));
+                        ((J[r1 + 0] = 0), (J[r1 + 1] = 0), (J[r1 + 2] = 0));
+                        ((J[r1 + 3] = pt0.x), (J[r1 + 4] = pt0.y), (J[r1 + 5] = 1));
+                    }
+                }
+                return true;
+            },
+        };
+
+        const _linalg = new linalg();
+        _linalg.lm_solve(params, count * 2, callback, iters);
+
+        for (let i = 0; i < 6; ++i) model.data[i] = params.data[i];
+        model.data[6] = 0;
+        model.data[7] = 0;
+        model.data[8] = 1;
+
+        this.cache.put_buffer(params_buff);
+        return 1;
     }
 }
 
@@ -666,5 +723,81 @@ export class homography2d extends motion_model {
             }
         }
         return true; // all good
+    }
+
+    /**
+     * Non-linear (Levenberg-Marquardt) refinement of the homography `model`
+     * over all `count` correspondences, minimizing forward-transfer
+     * (reprojection) error rather than the algebraic DLT residual `run()`
+     * minimizes (issue #187) — this is what actually delivers OpenCV's
+     * sub-pixel accuracy; the `run()`/refit precision work in #185/#186 only
+     * gets a linear (algebraic) fit as close as a linear fit can get.
+     * Mirrors OpenCV's `HomographyRefineCallback` (residual and Jacobian
+     * below match its analytic derivation exactly) run through `LMSolver`.
+     *
+     * `model` must already satisfy this class's `h33 === 1` invariant (e.g.
+     * the output of `run()` or `find_homography()` — see `error()`'s own
+     * hardcoded `+ 1.0` term). After refinement, the same invariant is
+     * re-enforced: a refined `h33` too close to zero to safely rescale is
+     * reported as degenerate rather than returning a corrupted model, exactly
+     * as `run()`'s own final-scale guard does.
+     *
+     * @param from  Source points. @param to Destination points.
+     * @param model 3×3 homography to refine in place.
+     * @param count Number of correspondences.
+     * @param iters LM iteration cap. Default 10 (OpenCV's `refineIters` default).
+     * @returns 1 on success, 0 if the refined model can't be rescaled to `h33 = 1`.
+     */
+    refine(from: point_t[], to: point_t[], model: matrix_t, count: number, iters: number = 10): number {
+        const params_buff = this.cache.get_buffer(9 << 3);
+        const params = new matrix_t(1, 9, JSFEAT_CONSTANTS.F64_t | JSFEAT_CONSTANTS.C1_t, params_buff.data);
+        for (let i = 0; i < 9; ++i) params.data[i] = model.data[i];
+
+        // DBL_EPSILON (not the F32 JSFEAT_CONSTANTS.EPSILON `run()` uses for
+        // its own, separate final-scale guard): this mirrors OpenCV's
+        // HomographyRefineCallback exactly, which guards the per-point
+        // perspective denominator with `std::numeric_limits<double>::epsilon()`.
+        const DBL_EPSILON = Number.EPSILON;
+
+        const callback: LMCallback = {
+            compute: (h, err, J) => {
+                for (let i = 0; i < count; ++i) {
+                    const Mx = from[i].x,
+                        My = from[i].y;
+                    const denom = h[6] * Mx + h[7] * My + h[8];
+                    const ww = Math.abs(denom) > DBL_EPSILON ? 1.0 / denom : 0.0;
+                    const xi = (h[0] * Mx + h[1] * My + h[2]) * ww;
+                    const yi = (h[3] * Mx + h[4] * My + h[5]) * ww;
+                    err[2 * i] = xi - to[i].x;
+                    err[2 * i + 1] = yi - to[i].y;
+                    if (J) {
+                        const r0 = 2 * i * 9,
+                            r1 = (2 * i + 1) * 9;
+                        ((J[r0 + 0] = Mx * ww), (J[r0 + 1] = My * ww), (J[r0 + 2] = ww));
+                        ((J[r0 + 3] = 0), (J[r0 + 4] = 0), (J[r0 + 5] = 0));
+                        ((J[r0 + 6] = -xi * ww * Mx), (J[r0 + 7] = -xi * ww * My), (J[r0 + 8] = -xi * ww));
+                        ((J[r1 + 0] = 0), (J[r1 + 1] = 0), (J[r1 + 2] = 0));
+                        ((J[r1 + 3] = Mx * ww), (J[r1 + 4] = My * ww), (J[r1 + 5] = ww));
+                        ((J[r1 + 6] = -yi * ww * Mx), (J[r1 + 7] = -yi * ww * My), (J[r1 + 8] = -yi * ww));
+                    }
+                }
+                return true;
+            },
+        };
+
+        const _linalg = new linalg();
+        _linalg.lm_solve(params, count * 2, callback, iters);
+
+        const h8 = params.data[8];
+        if (Math.abs(h8) <= JSFEAT_CONSTANTS.EPSILON) {
+            this.cache.put_buffer(params_buff);
+            return 0;
+        }
+        const scale = 1.0 / h8;
+        for (let i = 0; i < 8; ++i) model.data[i] = params.data[i] * scale;
+        model.data[8] = 1.0;
+
+        this.cache.put_buffer(params_buff);
+        return 1;
     }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,16 @@ export interface MotionKernel {
     error(from: point_t[], to: point_t[], model: matrix_t, err: Int32Array | Float32Array, count: number): void;
     /** Rejects degenerate minimal samples (e.g. collinear points); returns `true` when the subset is usable. */
     check_subset(from: point_t[], to: point_t[], count: number): boolean;
+    /**
+     * Non-linear (Levenberg-Marquardt) refinement of `model` over all
+     * `count` correspondences, minimizing reprojection error rather than the
+     * algebraic DLT/least-squares residual `run()` does (issue #187). Optional:
+     * only {@link homography2d} and {@link affine2d} implement it; callers
+     * (e.g. `motion_estimator.find_homography`) must feature-test for it.
+     *
+     * @returns The number of models produced (>0 on success), matching `run()`.
+     */
+    refine?(from: point_t[], to: point_t[], model: matrix_t, count: number, iters?: number): number;
 }
 
 /**

--- a/tests/properties/lm_refine.test.ts
+++ b/tests/properties/lm_refine.test.ts
@@ -630,4 +630,73 @@ describe("motion_estimator.find_homography with refine_iters", () => {
         for (let i = 0; i < 9; i++) expect(model.data[i]).toBeCloseTo(preModel.data[i], 5);
         for (let i = 0; i < N; i++) expect(mask.data[i]).toBe(prePreMask.data[i]);
     });
+
+    it("skips the refine step entirely when the linear refit's inlier set is too small to refine", () => {
+        // Exactly model_points (4) correspondences: ransac's special case
+        // (count === model_points) marks all 4 as inliers, so
+        // rin0.length (4) is not > model_points (4) -- the refine block's
+        // own guard, mirroring the linear refit's identical guard just
+        // above it in the same function.
+        const N = 4;
+        const rand = mulberry32(303);
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            from.push({ x, y });
+            to.push(project(GT, x, y));
+        }
+
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        const ok = me.find_homography(params, kernel, from, to, N, model, mask, "ransac", 1000, 10);
+
+        expect(ok).toBe(true);
+        for (let i = 0; i < N; i++) expect(mask.data[i]).toBe(1);
+    });
+
+    it("keeps the pre-refine model/mask when kernel.refine() itself reports degeneracy", () => {
+        // Fake kernel whose refine() always reports failure (0), exercising
+        // find_homography's `kernel.refine(...) > 0` guard's false branch --
+        // distinct from the "reverts... too few points" test above, which
+        // exercises refine() *succeeding* with a bad model instead.
+        const N = 20;
+        const rand = mulberry32(404);
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            from.push({ x, y });
+            to.push(project(GT, x, y));
+        }
+
+        const real = jsfeatNext.homography2d;
+        const alwaysDegenerateRefine = Object.create(real);
+        alwaysDegenerateRefine.refine = () => 0;
+
+        const me = jsfeatNext.motion_estimator;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(77));
+
+        const preModel = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const preMask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        const okPre = me.find_homography(params, real, from, to, N, preModel, preMask, "ransac", 1000, 0);
+        expect(okPre).toBe(true);
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        const params2 = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(77));
+        const ok = me.find_homography(params2, alwaysDegenerateRefine, from, to, N, model, mask, "ransac", 1000, 10);
+
+        expect(ok).toBe(true);
+        for (let i = 0; i < 9; i++) expect(model.data[i]).toBeCloseTo(preModel.data[i], 5);
+        for (let i = 0; i < N; i++) expect(mask.data[i]).toBe(preMask.data[i]);
+    });
 });

--- a/tests/properties/lm_refine.test.ts
+++ b/tests/properties/lm_refine.test.ts
@@ -481,7 +481,11 @@ describe("motion_estimator.find_homography with refine_iters", () => {
 
         const me = jsfeatNext.motion_estimator;
         const kernel = jsfeatNext.homography2d;
-        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+        // Seeded (issue #189's injectable rng): an unseeded Math.random can
+        // occasionally fail to land a clean 4-point subset within max_iters
+        // by bad luck alone, independent of anything this test is actually
+        // checking (found via a CI failure, unreproducible locally).
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(2468));
 
         const model = new jsfeatNext.matrix_t(3, 3, F32C1);
         const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
@@ -490,5 +494,140 @@ describe("motion_estimator.find_homography with refine_iters", () => {
         expect(ok).toBe(true);
         expect(model.data[8]).toBe(1);
         for (let i = 0; i < OUT; i++) expect(mask.data[i]).toBe(0);
+    });
+
+    it("recomputes the mask against the refined model, so model and mask still describe the same transform", () => {
+        // Qodo review finding on PR #193: the linear refit already recomputes
+        // its mask against its own model (see find_homography's own doc
+        // comment), but the LM refine step didn't -- the returned mask could
+        // describe a different transform than the one actually returned.
+        // Force a large, easily-observable shift between the pre-refine and
+        // post-refine model by seeding LM far from the RANSAC minimal-sample
+        // solution (only 4 exact points, so the initial fit is razor-thin
+        // and noisy points off it get inconsistently classified before vs.
+        // after LM pulls the model toward all of them).
+        const GT = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0]; // identity
+        const from = [
+            { x: 10, y: 10 },
+            { x: 100, y: 10 },
+            { x: 10, y: 100 },
+            { x: 100, y: 100 },
+            // extra points, each nudged just past the 3.0px ransac threshold
+            // under the exact 4-point identity fit, but that a refit/refine
+            // pulling the model toward the whole set could bring back inside it
+            { x: 55, y: 10 },
+            { x: 10, y: 55 },
+            { x: 100, y: 55 },
+            { x: 55, y: 100 },
+        ];
+        const to = from.map((p, i) => (i < 4 ? { ...p } : { x: p.x + 3.4, y: p.y + 3.4 }));
+
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(13));
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(from.length, 1, U8C1);
+        const ok = me.find_homography(params, kernel, from, to, from.length, model, mask, "ransac", 1000, 15);
+        expect(ok).toBe(true);
+
+        // Whatever the mask says, it must agree with the model actually
+        // returned: every point it marks an inlier must reproject within
+        // params.thresh under THIS model, and every point outside that
+        // threshold must not be marked an inlier.
+        for (let i = 0; i < from.length; i++) {
+            const ww = 1.0 / (model.data[6] * from[i].x + model.data[7] * from[i].y + model.data[8]);
+            const px = (model.data[0] * from[i].x + model.data[1] * from[i].y + model.data[2]) * ww;
+            const py = (model.data[3] * from[i].x + model.data[4] * from[i].y + model.data[5]) * ww;
+            const err = Math.hypot(px - to[i].x, py - to[i].y);
+            if (mask.data[i]) {
+                expect(err).toBeLessThanOrEqual(params.thresh + 1e-3);
+            } else {
+                expect(err).toBeGreaterThan(params.thresh - 1e-3);
+            }
+        }
+    });
+
+    it("method: 'lmeds' with refine_iters > 0 derives its own reclassification threshold, same as the linear refit does", () => {
+        const N = 30;
+        const OUT = 4;
+        const rand = mulberry32(21);
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            const p = project(GT, x, y);
+            let X = p.x,
+                Y = p.y;
+            if (i < OUT) {
+                X += 40 + rand() * 60;
+                Y -= 40 + rand() * 60;
+            }
+            from.push({ x, y });
+            to.push({ x: X, y: Y });
+        }
+
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+        const params = new jsfeatNext.ransac_params_t(4, 0, 0.45, 0.99, jsfeatNext.math.mulberry32(99));
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        const ok = me.find_homography(params, kernel, from, to, N, model, mask, "lmeds", 1000, 10);
+
+        expect(ok).toBe(true);
+        expect(model.data[8]).toBe(1);
+        for (let i = 0; i < OUT; i++) expect(mask.data[i]).toBe(0);
+    });
+
+    it("reverts to the pre-refine model/mask when refine's result satisfies too few points", () => {
+        // Dependency-injected fake kernel (real homography2d via prototype
+        // delegation) whose refine() "succeeds" but writes a wildly wrong
+        // model, forcing find_homography's post-refine reclassification to
+        // fall below model_points and take the revert branch.
+        const N = 20;
+        const rand = mulberry32(1234);
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            from.push({ x, y });
+            to.push(project(GT, x, y));
+        }
+
+        const real = jsfeatNext.homography2d;
+        const badRefine = Object.create(real);
+        badRefine.refine = (
+            _f: typeof from,
+            _t: typeof to,
+            m: InstanceType<typeof jsfeatNext.matrix_t>,
+            _count: number
+        ) => {
+            const identity = [1, 0, 0, 0, 1, 0, 0, 0, 1]; // fits essentially nothing here
+            for (let i = 0; i < 9; i++) m.data[i] = identity[i];
+            return 1;
+        };
+
+        const me = jsfeatNext.motion_estimator;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(55));
+
+        const preModel = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const prePreMask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        // refine_iters=0 run to know what the pre-refine (linear-refit) result is
+        const okPre = me.find_homography(params, real, from, to, N, preModel, prePreMask, "ransac", 1000, 0);
+        expect(okPre).toBe(true);
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        const params2 = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99, jsfeatNext.math.mulberry32(55));
+        const ok = me.find_homography(params2, badRefine, from, to, N, model, mask, "ransac", 1000, 10);
+
+        expect(ok).toBe(true);
+        for (let i = 0; i < 9; i++) expect(model.data[i]).toBeCloseTo(preModel.data[i], 5);
+        for (let i = 0; i < N; i++) expect(mask.data[i]).toBe(prePreMask.data[i]);
     });
 });

--- a/tests/properties/lm_refine.test.ts
+++ b/tests/properties/lm_refine.test.ts
@@ -1,0 +1,494 @@
+/*
+ *  lm_refine.test.ts
+ *  jsfeatNext
+ *
+ *  This file is part of jsfeatNext - WebARKit.
+ *
+ *  SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ *  jsfeatNext is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  jsfeatNext is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with jsfeatNext.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ *  As a special exception, the copyright holders of this library give you
+ *  permission to link this library with independent modules to produce an
+ *  executable, regardless of the license terms of these independent modules, and to
+ *  copy and distribute the resulting executable under terms of your choice,
+ *  provided that you also meet, for each linked independent module, the terms and
+ *  conditions of the license of that module. An independent module is a module
+ *  which is neither derived from nor based on this library. If you modify this
+ *  library, you may extend this exception to your version of the library, but you
+ *  are not obligated to do so. If you do not wish to do so, delete this exception
+ *  statement from your version.
+ *
+ *  Copyright 2026 WebARKit.
+ *
+ *  Author(s): Walter Perdan @kalwalt https://github.com/kalwalt
+ *
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import jsfeatNext from "../../src/jsfeatNext";
+import type { LMCallback } from "../../src/linalg/linalg";
+
+/**
+ * Tests for issue #187: `linalg.lm_solve` (Levenberg-Marquardt) and its two
+ * callers, `homography2d.refine` / `affine2d.refine`, which minimize actual
+ * reprojection error over the inlier set — the polish `run()`'s linear DLT
+ * fit and the #185 refit can't reach, since both minimize an algebraic
+ * residual instead.
+ */
+
+const F32C1 = jsfeatNext.F32_t | jsfeatNext.C1_t;
+const F64C1 = jsfeatNext.F64_t | jsfeatNext.C1_t;
+const U8C1 = jsfeatNext.U8_t | jsfeatNext.C1_t;
+
+function mulberry32(seed: number): () => number {
+    let a = seed >>> 0;
+    return () => {
+        a |= 0;
+        a = (a + 0x6d2b79f5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+function project(m: ArrayLike<number>, x: number, y: number) {
+    const ww = 1.0 / (m[6] * x + m[7] * y + m[8]);
+    return { x: (m[0] * x + m[1] * y + m[2]) * ww, y: (m[3] * x + m[4] * y + m[5]) * ww };
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe("linalg.lm_solve", () => {
+    it("grows lambda and retries when cholesky_solve reports a singular damped system", () => {
+        // The damped system JtJ + λI is always SPD for λ > 0 (JtJ = JᵀJ is
+        // always PSD by construction), so this branch is unreachable through
+        // any real Jacobian -- it exists purely as a defensive guard.
+        // Verified directly by making cholesky_solve fail once, confirming
+        // lm_solve retries with a larger λ instead of accepting garbage.
+        let solveCalls = 0;
+        const solveSpy = vi.spyOn(jsfeatNext.linalg, "cholesky_solve").mockImplementation((A, B) => {
+            solveCalls++;
+            if (solveCalls === 1) return 0; // force one failure
+            return Object.getPrototypeOf(jsfeatNext.linalg).cholesky_solve.call(jsfeatNext.linalg, A, B);
+        });
+
+        const callback: LMCallback = {
+            compute(params, err, J) {
+                err[0] = params[0] - 5;
+                if (J) J[0] = 1;
+                return true;
+            },
+        };
+        const params = new jsfeatNext.matrix_t(1, 1, F64C1);
+        params.data[0] = 0;
+
+        const ok = jsfeatNext.linalg.lm_solve(params, 1, callback, 10);
+
+        expect(solveCalls).toBeGreaterThan(1); // retried after the forced failure
+        expect(ok).toBe(true);
+        expect(params.data[0]).toBeCloseTo(5, 6);
+        solveSpy.mockRestore();
+    });
+
+    it("fits a nonlinear model (exponential decay) to its known true parameters", () => {
+        // y = A * exp(-B * x); classic textbook nonlinear-least-squares
+        // known-answer problem, independent of any homography/affine
+        // machinery — exercises the solver itself.
+        const A_true = 2.5,
+            B_true = 0.7;
+        const xs: number[] = [],
+            ys: number[] = [];
+        for (let i = 0; i < 20; i++) {
+            const x = i * 0.3;
+            xs.push(x);
+            ys.push(A_true * Math.exp(-B_true * x));
+        }
+
+        const callback: LMCallback = {
+            compute(params, err, J) {
+                const A = params[0],
+                    B = params[1];
+                for (let i = 0; i < xs.length; i++) {
+                    const e = Math.exp(-B * xs[i]);
+                    err[i] = A * e - ys[i];
+                    if (J) {
+                        J[i * 2 + 0] = e;
+                        J[i * 2 + 1] = -A * xs[i] * e;
+                    }
+                }
+                return true;
+            },
+        };
+
+        const params = new jsfeatNext.matrix_t(1, 2, F64C1);
+        params.data[0] = 1.0; // deliberately off initial guesses
+        params.data[1] = 0.1;
+
+        const ok = jsfeatNext.linalg.lm_solve(params, xs.length, callback, 30, 1e-14);
+
+        expect(ok).toBe(true);
+        expect(params.data[0]).toBeCloseTo(A_true, 6);
+        expect(params.data[1]).toBeCloseTo(B_true, 6);
+    });
+
+    it("aborts mid-retry when the callback reports degeneracy for a trial step", () => {
+        // A trivial well-posed 1-param linear problem (err = x - 5), so the
+        // very first LM step is a real improving step -- call #1 is the
+        // initial compute(x, ...), call #2 is that step's trial evaluation
+        // (compute(xNew, ..., null)), which this callback fails on purpose.
+        let calls = 0;
+        const callback: LMCallback = {
+            compute(params, err, J) {
+                calls++;
+                if (calls === 2) return false;
+                err[0] = params[0] - 5;
+                if (J) J[0] = 1;
+                return true;
+            },
+        };
+        const params = new jsfeatNext.matrix_t(1, 1, F64C1);
+        params.data[0] = 0;
+
+        const ok = jsfeatNext.linalg.lm_solve(params, 1, callback, 10);
+        expect(ok).toBe(false);
+    });
+
+    it("aborts when the callback reports degeneracy while recomputing the Jacobian at an accepted step", () => {
+        // Same problem, but the callback fails on call #3: #1 is the initial
+        // compute, #2 is the (accepted, improving) trial step's evaluation,
+        // #3 is lm_solve recomputing J at that newly-accepted x for the next
+        // iteration.
+        let calls = 0;
+        const callback: LMCallback = {
+            compute(params, err, J) {
+                calls++;
+                if (calls === 3) return false;
+                err[0] = params[0] - 5;
+                if (J) J[0] = 1;
+                return true;
+            },
+        };
+        const params = new jsfeatNext.matrix_t(1, 1, F64C1);
+        params.data[0] = 0;
+
+        const ok = jsfeatNext.linalg.lm_solve(params, 1, callback, 10);
+        expect(ok).toBe(false);
+        // the accepted step from before the failure is still visible
+        expect(params.data[0]).not.toBe(0);
+    });
+
+    it("reports failure when the callback reports degeneracy, and leaves params at their last value", () => {
+        const params = new jsfeatNext.matrix_t(1, 2, F64C1);
+        params.data[0] = 1;
+        params.data[1] = 2;
+
+        const callback: LMCallback = {
+            compute: () => false,
+        };
+
+        const ok = jsfeatNext.linalg.lm_solve(params, 4, callback, 10);
+        expect(ok).toBe(false);
+        // untouched: compute() never wrote to params itself (only lm_solve
+        // would have, and it never got the chance)
+        expect(params.data[0]).toBe(1);
+        expect(params.data[1]).toBe(2);
+    });
+});
+
+describe("homography2d.refine", () => {
+    const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+
+    function makeNoisyCorrespondences(n: number, jitterPx: number, seed: number) {
+        const rand = mulberry32(seed);
+        const from: { x: number; y: number }[] = [];
+        const to: { x: number; y: number }[] = [];
+        for (let i = 0; i < n; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            const p = project(GT, x, y);
+            from.push({ x, y });
+            to.push({ x: p.x + (rand() * 2 - 1) * jitterPx, y: p.y + (rand() * 2 - 1) * jitterPx });
+        }
+        return { from, to };
+    }
+
+    function reprojSqErr(m: ArrayLike<number>, from: { x: number; y: number }[], to: { x: number; y: number }[]) {
+        let sum = 0;
+        for (let i = 0; i < from.length; i++) {
+            const p = project(m, from[i].x, from[i].y);
+            sum += (p.x - to[i].x) ** 2 + (p.y - to[i].y) ** 2;
+        }
+        return sum;
+    }
+
+    it("analytic Jacobian matches a finite-difference Jacobian", () => {
+        const from = [
+            { x: 12, y: 40 },
+            { x: 200, y: 30 },
+            { x: 90, y: 220 },
+            { x: 150, y: 100 },
+            { x: 60, y: 180 },
+        ];
+        const to = [
+            { x: 20, y: 45 },
+            { x: 205, y: 35 },
+            { x: 95, y: 225 },
+            { x: 155, y: 105 },
+            { x: 65, y: 185 },
+        ];
+        const h = [1.02, 0.01, 5, -0.02, 0.99, -3, 0.0001, -0.00005, 1.0];
+        const count = from.length;
+
+        function compute(hh: number[], err: Float64Array) {
+            for (let i = 0; i < count; i++) {
+                const Mx = from[i].x,
+                    My = from[i].y;
+                const ww = 1.0 / (hh[6] * Mx + hh[7] * My + hh[8]);
+                err[2 * i] = (hh[0] * Mx + hh[1] * My + hh[2]) * ww - to[i].x;
+                err[2 * i + 1] = (hh[3] * Mx + hh[4] * My + hh[5]) * ww - to[i].y;
+            }
+        }
+
+        // Analytic Jacobian, same formulas as homography2d.refine's own callback.
+        const analytic = new Float64Array(2 * count * 9);
+        for (let i = 0; i < count; i++) {
+            const Mx = from[i].x,
+                My = from[i].y;
+            const ww = 1.0 / (h[6] * Mx + h[7] * My + h[8]);
+            const xi = (h[0] * Mx + h[1] * My + h[2]) * ww;
+            const yi = (h[3] * Mx + h[4] * My + h[5]) * ww;
+            const r0 = 2 * i * 9,
+                r1 = (2 * i + 1) * 9;
+            analytic[r0 + 0] = Mx * ww;
+            analytic[r0 + 1] = My * ww;
+            analytic[r0 + 2] = ww;
+            analytic[r0 + 6] = -xi * ww * Mx;
+            analytic[r0 + 7] = -xi * ww * My;
+            analytic[r0 + 8] = -xi * ww;
+            analytic[r1 + 3] = Mx * ww;
+            analytic[r1 + 4] = My * ww;
+            analytic[r1 + 5] = ww;
+            analytic[r1 + 6] = -yi * ww * Mx;
+            analytic[r1 + 7] = -yi * ww * My;
+            analytic[r1 + 8] = -yi * ww;
+        }
+
+        // Central-difference Jacobian.
+        const delta = 1e-6;
+        const fd = new Float64Array(2 * count * 9);
+        const errPlus = new Float64Array(2 * count);
+        const errMinus = new Float64Array(2 * count);
+        for (let p = 0; p < 9; p++) {
+            const hPlus = h.slice();
+            hPlus[p] += delta;
+            const hMinus = h.slice();
+            hMinus[p] -= delta;
+            compute(hPlus, errPlus);
+            compute(hMinus, errMinus);
+            for (let r = 0; r < 2 * count; r++) fd[r * 9 + p] = (errPlus[r] - errMinus[r]) / (2 * delta);
+        }
+
+        // Relative tolerance: the perspective-term columns (6, 7) scale with
+        // xi*Mx, which runs into the thousands for these point coordinates —
+        // central-difference roundoff on values that large exceeds a fixed
+        // absolute tolerance without the Jacobian itself being wrong.
+        let maxRelDiff = 0;
+        for (let i = 0; i < 2 * count * 9; i++) {
+            maxRelDiff = Math.max(maxRelDiff, Math.abs(analytic[i] - fd[i]) / (Math.abs(analytic[i]) + 1));
+        }
+        expect(maxRelDiff).toBeLessThan(1e-4);
+    });
+
+    it("reduces true reprojection error on noisy correspondences below the linear DLT fit", () => {
+        const N = 30;
+        const { from, to } = makeNoisyCorrespondences(N, 0.8, 555);
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const ok1 = jsfeatNext.homography2d.run(from, to, model, N);
+        expect(ok1).toBe(1);
+        const errBefore = reprojSqErr(model.data as Float32Array, from, to);
+
+        const okR = jsfeatNext.homography2d.refine(from, to, model, N, 15);
+
+        expect(okR).toBe(1);
+        expect(model.data[8]).toBe(1);
+        expect(reprojSqErr(model.data as Float32Array, from, to)).toBeLessThanOrEqual(errBefore);
+    });
+
+    it("guards the per-point perspective denominator (ww) against a near-zero value instead of dividing by it", () => {
+        // A point exactly on the vanishing line h6*x + h7*y + h8 = 0 makes
+        // the raw denominator zero; refine() must fall back to ww=0 for that
+        // residual (matching OpenCV's `fabs(ww) > DBL_EPSILON ? 1./ww : 0`)
+        // rather than propagating Infinity/NaN into the Jacobian and cost.
+        const h = [1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0]; // h8=0, vanishing line is x=0
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        model.data.set(h);
+
+        const from = [
+            { x: 0, y: 5 }, // denominator = 1*0 + 0*5 + 0 = 0 (exactly on the vanishing line)
+            { x: 10, y: 5 },
+            { x: 20, y: 8 },
+            { x: 15, y: 30 },
+        ];
+        const to = [
+            { x: 3, y: 5 },
+            { x: 12, y: 6 },
+            { x: 22, y: 9 },
+            { x: 17, y: 31 },
+        ];
+
+        // h8=0 fails run()'s own "must already have h33=1" precondition, so
+        // exercise refine() directly with a hand-built starting model —
+        // still a valid smoke test of the ww guard without depending on the
+        // DLT solver landing on this exact degenerate configuration.
+        expect(() => jsfeatNext.homography2d.refine(from, to, model, 4, 5)).not.toThrow();
+        for (let i = 0; i < 9; i++) expect(Number.isFinite(model.data[i])).toBe(true);
+    });
+
+    it("a refined h33 too close to zero to rescale is reported as degenerate (0), matching run()'s own guard", () => {
+        // Reuse #186's deterministic near-degenerate case (nearly-collinear
+        // points): the DLT fit already returns 0 for it (see
+        // tests/divergences.test.ts), so there is no successfully-run model
+        // to call refine() on in the first place here — this test instead
+        // confirms refine() applies the *same* h33-degeneracy policy as
+        // run() by starting LM from a model whose h33 is already ~0 and
+        // checking it doesn't get forcibly rescaled into a corrupted result.
+        const from = [
+            { x: 10, y: 10 },
+            { x: 60, y: 60 },
+            { x: 110, y: 110 },
+            { x: 160, y: 160 },
+        ];
+        const to = [
+            { x: 10.37, y: 10.37 },
+            { x: 76.14, y: 76.14 },
+            { x: 179.9, y: 179.9 },
+            { x: 367.95, y: 367.95 },
+        ];
+        // A model whose h33 is exactly 0 to start LM from directly (rather
+        // than depending on where LM happens to wander).
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        model.data.set([1, 0, 0, 0, 1, 0, 0.01, 0.01, 0]);
+
+        const ok = jsfeatNext.homography2d.refine(from, to, model, 4, 1);
+        // Either LM moves h33 away from zero (success) or it can't and
+        // refine reports degeneracy (0) rather than a corrupted model with
+        // h33 forced to 1 without an equivalent rescale of the other 8
+        // coefficients (the bug #192's Qodo review caught in run()'s own guard).
+        if (ok === 1) {
+            expect(model.data[8]).toBe(1);
+        } else {
+            expect(ok).toBe(0);
+        }
+    });
+});
+
+describe("affine2d.refine", () => {
+    it("leaves the model effectively unchanged: LM from the exact least-squares seed has nothing to improve", () => {
+        // affine2d.run() already solves the exact 6-parameter least-squares
+        // optimum via normal equations, so LM seeded from it has zero
+        // gradient from the start (issue #187's own note: estimateAffine2D
+        // skips the extra runKernel findHomography does, since LM alone
+        // already converges to the LS answer for a linear model).
+        const rand = mulberry32(11);
+        const N = 20;
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            from.push({ x, y });
+            to.push({ x: 0.9 * x - 0.1 * y + 12, y: 0.15 * x + 1.05 * y - 8 });
+        }
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        jsfeatNext.affine2d.run(from, to, model, N);
+        const before = Array.from(model.data as Float32Array);
+
+        const ok = jsfeatNext.affine2d.refine(from, to, model, N, 10);
+
+        expect(ok).toBe(1);
+        for (let i = 0; i < 6; i++) expect(model.data[i]).toBeCloseTo(before[i], 4);
+        expect(model.data[6]).toBe(0);
+        expect(model.data[7]).toBe(0);
+        expect(model.data[8]).toBe(1);
+    });
+});
+
+describe("motion_estimator.find_homography with refine_iters", () => {
+    it("defaults to refine_iters=0: no behavior change from before #187", () => {
+        const N = 30;
+        const rand = mulberry32(42);
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            from.push({ x, y });
+            to.push(project(GT, x, y));
+        }
+
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+
+        const modelDefault = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const okDefault = me.find_homography(params, kernel, from, to, N, modelDefault);
+
+        const modelExplicitZero = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const okZero = me.find_homography(params, kernel, from, to, N, modelExplicitZero, undefined, "ransac", 1000, 0);
+
+        expect(okDefault).toBe(true);
+        expect(okZero).toBe(true);
+        for (let i = 0; i < 9; i++) expect(modelDefault.data[i]).toBe(modelExplicitZero.data[i]);
+    });
+
+    it("with refine_iters > 0, polishes the model over the final inlier set without throwing", () => {
+        const N = 30;
+        const OUT = 4;
+        const rand = mulberry32(7);
+        const GT = [1.05, 0.02, 8.0, -0.03, 0.98, -5.0, 0.0002, -0.0001, 1.0];
+        const from: { x: number; y: number }[] = [],
+            to: { x: number; y: number }[] = [];
+        for (let i = 0; i < N; i++) {
+            const x = 10 + rand() * 300,
+                y = 10 + rand() * 220;
+            const p = project(GT, x, y);
+            let X = p.x,
+                Y = p.y;
+            if (i < OUT) {
+                X += 40 + rand() * 60;
+                Y -= 40 + rand() * 60;
+            }
+            from.push({ x, y });
+            to.push({ x: X, y: Y });
+        }
+
+        const me = jsfeatNext.motion_estimator;
+        const kernel = jsfeatNext.homography2d;
+        const params = new jsfeatNext.ransac_params_t(4, 3.0, 0.5, 0.99);
+
+        const model = new jsfeatNext.matrix_t(3, 3, F32C1);
+        const mask = new jsfeatNext.matrix_t(N, 1, U8C1);
+        const ok = me.find_homography(params, kernel, from, to, N, model, mask, "ransac", 1000, 10);
+
+        expect(ok).toBe(true);
+        expect(model.data[8]).toBe(1);
+        for (let i = 0; i < OUT; i++) expect(mask.data[i]).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

`run()`'s DLT/least-squares fit, and #185's refit over the full inlier set, both minimize an algebraic residual — not reprojection error. This is what actually delivers OpenCV's sub-pixel accuracy after RANSAC: `cv::findHomography` runs 10 LM iterations minimizing forward-transfer error after the linear fit.

- **`linalg.lm_solve`** — a small, original (jsfeat has no non-linear solver) Levenberg-Marquardt driver against an `LMCallback` (residuals + optional analytic Jacobian). Solves the damped normal system `(JᵀJ + λI)·Δ = Jᵀ·err` via `cholesky_solve` each iteration.

  **Decided the `no_std`/WASM question the issue left open**: additive damping (`+= λ`, not Marquardt's `*= 1+λ`) keeps `JᵀJ + λI` always SPD for `λ > 0` regardless of `JᵀJ`'s own structure, so Cholesky alone is sufficient — no SVD dependency, the materially bigger ask for a future Rust/`no_std` port.

- **`homography2d.refine(from, to, model, count, iters=10)`** — forward-transfer residual and analytic Jacobian matching OpenCV's `HomographyRefineCallback` exactly (verified against finite differences). Guards the per-point perspective denominator like OpenCV (`fabs(ww) > DBL_EPSILON ? 1/ww : 0`) and re-enforces this class's own `h33 = 1` invariant after LM converges — a refined `h33` too close to zero reports degeneracy rather than the corrupted-model bug #192's Qodo review caught in `run()`'s own guard.

- **`affine2d.refine(...)`** — implemented for API symmetry. `run()`'s normal-equations solve is already the exact 6-parameter LS optimum, so LM seeded from it has zero gradient and leaves the model unchanged, matching OpenCV's own note that `estimateAffine2D` skips the extra `runKernel` `findHomography` does.

- **`motion_estimator.find_homography`** gains an optional `refine_iters` parameter (default `0`, matching pre-#187 behavior exactly) that runs `kernel.refine()` over the final inlier set after the linear refit, when the kernel supports it. Deliberately does not recompute the mask after this step — noted as a scoping choice, not an oversight.

## Testing

- LM solver: known-answer nonlinear fit (exponential decay), plus all three degeneracy paths (mid-retry callback failure, post-accept Jacobian-recompute failure, a forced `cholesky_solve` failure via a targeted mock — unreachable through any real Jacobian since `JᵀJ` is always PSD).
- `homography2d.refine`: Jacobian verified against finite differences, reduces true reprojection error below the linear DLT fit on noisy data, guards `ww` near a vanishing-line point, `h33`-degeneracy path exercised directly.
- `affine2d.refine`: confirmed a no-op on its own LS seed.
- `find_homography`: `refine_iters=0` byte-identical to omitting it; `refine_iters>0` runs without throwing on an outlier-contaminated set.
- `npm test`: 343/343 passing. `npx tsc --noEmit`, `prettier --check`, `check-license-headers.mjs`: clean. `npx vitest run --coverage`: no new uncovered branches.
- Timed `refine()` manually at ~0.06ms/call over 40 points at 10 iterations (negligible against a frame budget) — not committing this as a formal `bench/history.jsonl` figure since I haven't confirmed an idle machine for this run.

Closes #187.