### PR TITLE
fix: reject S64_t in matrix_t; fix ORB example training coordinate defects

### DIFF
--- a/examples/sample_orb.html
+++ b/examples/sample_orb.html
@@ -108,6 +108,7 @@
             var gui, options;
             var img_u8, img_u8_smooth, screen_corners, num_corners, screen_descriptors;
             var pattern_corners, pattern_descriptors, pattern_preview;
+            var trained_width = 0, trained_height = 0; // lev0_img's actual size, for drawing the outline (#142)
             var matches, homo3x3, match_mask;
             var num_train_levels = 4;
 
@@ -134,6 +135,12 @@
                     new_height = (img_u8.rows * sc0) | 0;
 
                     imgproc.resample(img_u8, lev0_img, new_width, new_height);
+                    // lev0_img.cols/rows is the actual trained size and the
+                    // homography's coordinate frame; pattern_preview (below)
+                    // is a separate, independently-rounded half scale that
+                    // must not be used to reconstruct it (#142).
+                    trained_width = lev0_img.cols;
+                    trained_height = lev0_img.rows;
 
                     // prepare preview
                     pattern_preview = new jsfeat.matrix_t(new_width >> 1, new_height >> 1, jsfeat.U8_t | jsfeat.C1_t);
@@ -162,14 +169,20 @@
 
                     console.log("train " + lev_img.cols + "x" + lev_img.rows + " points: " + corners_num);
 
-                    sc /= sc_inc;
-
                     // lets do multiple scale levels
                     // we can use Canvas context draw method for faster resize
                     // but its nice to demonstrate that you can do everything with jsfeat
                     for (lev = 1; lev < num_train_levels; ++lev) {
                         lev_corners = pattern_corners[lev];
                         lev_descr = pattern_descriptors[lev];
+
+                        // Computed as a power of lev, not by repeatedly
+                        // dividing an accumulator: `sc /= sc_inc` drifts off
+                        // the exact value (e.g. two divisions by sqrt(2)
+                        // yields 0.4999999999999999, not 0.5), which can
+                        // cross an integer boundary in the `| 0` truncation
+                        // below and lose a whole extra pixel (#142).
+                        sc = Math.pow(sc_inc, -lev);
 
                         new_width = (lev0_img.cols * sc) | 0;
                         new_height = (lev0_img.rows * sc) | 0;
@@ -179,15 +192,20 @@
                         corners_num = detect_keypoints(lev_img, lev_corners, max_per_level);
                         orb.describe(lev_img, lev_corners, corners_num, lev_descr);
 
-                        // fix the coordinates due to scale level
+                        // Un-scale by the ACHIEVED per-axis scale
+                        // (new_width/new_height are truncated integers), not
+                        // the requested `sc` -- otherwise every dimension
+                        // whose truncation actually rounded down feeds
+                        // slightly wrong coordinates into the homography
+                        // fit (#142).
+                        var achieved_sc_x = new_width / lev0_img.cols;
+                        var achieved_sc_y = new_height / lev0_img.rows;
                         for (i = 0; i < corners_num; ++i) {
-                            lev_corners[i].x *= 1. / sc;
-                            lev_corners[i].y *= 1. / sc;
+                            lev_corners[i].x *= 1. / achieved_sc_x;
+                            lev_corners[i].y *= 1. / achieved_sc_y;
                         }
 
                         console.log("train " + lev_img.cols + "x" + lev_img.rows + " points: " + corners_num);
-
-                        sc /= sc_inc;
                     }
                 };
             }
@@ -435,8 +453,12 @@
             }
 
             function render_pattern_shape(ctx) {
-                // get the projected pattern corners
-                var shape_pts = tCorners(homo3x3.data, pattern_preview.cols * 2, pattern_preview.rows * 2);
+                // get the projected pattern corners. Use the trained
+                // (lev0_img) size, not pattern_preview.cols/rows * 2: the
+                // preview is independently downscaled with `>> 1` and only
+                // round-trips back to the trained size when that size
+                // happens to be even (#142).
+                var shape_pts = tCorners(homo3x3.data, trained_width, trained_height);
 
                 ctx.strokeStyle = "rgb(0,255,0)";
                 ctx.beginPath();

--- a/examples/sample_orb_pinball.html
+++ b/examples/sample_orb_pinball.html
@@ -132,6 +132,7 @@
                 var gui;
                 var img_u8, img_u8_smooth, screen_corners, num_corners, screen_descriptors;
                 var pattern_corners, pattern_descriptors, pattern_preview;
+                var trained_width = 0, trained_height = 0; // lev0_img's actual size, for drawing the outline (#142)
                 var matches, homo3x3, match_mask;
                 var num_train_levels = 4;
 
@@ -164,6 +165,12 @@
                         imgproc.grayscale(imgData.data, image.width, image.height, imgg);
 
                         imgproc.resample(imgg, lev0_img, new_width, new_height);
+                        // lev0_img.cols/rows is the actual trained size and
+                        // the homography's coordinate frame; pattern_preview
+                        // (below) is a separate, independently-rounded half
+                        // scale that must not be used to reconstruct it (#142).
+                        trained_width = lev0_img.cols;
+                        trained_height = lev0_img.rows;
 
                         // prepare preview
                         pattern_preview = new jsfeat.matrix_t(new_width >> 1, new_height >> 1, jsfeat.U8_t | jsfeat.C1_t);
@@ -195,14 +202,20 @@
 
                         console.log("train " + lev_img.cols + "x" + lev_img.rows + " points: " + corners_num);
 
-                        sc /= sc_inc;
-
                         // lets do multiple scale levels
                         // we can use Canvas context draw method for faster resize
                         // but its nice to demonstrate that you can do everything with jsfeat
                         for (lev = 1; lev < num_train_levels; ++lev) {
                             lev_corners = pattern_corners[lev];
                             lev_descr = pattern_descriptors[lev];
+
+                            // Computed as a power of lev, not by repeatedly
+                            // dividing an accumulator: `sc /= sc_inc` drifts
+                            // off the exact value (e.g. two divisions by
+                            // sqrt(2) yields 0.4999999999999999, not 0.5),
+                            // which can cross an integer boundary in the `| 0`
+                            // truncation below and lose a whole extra pixel (#142).
+                            sc = Math.pow(sc_inc, -lev);
 
                             new_width = (lev0_img.cols * sc) | 0;
                             new_height = (lev0_img.rows * sc) | 0;
@@ -212,15 +225,20 @@
                             corners_num = detect_keypoints(lev_img, lev_corners, max_per_level);
                             orb.describe(lev_img, lev_corners, corners_num, lev_descr);
 
-                            // fix the coordinates due to scale level
+                            // Un-scale by the ACHIEVED per-axis scale
+                            // (new_width/new_height are truncated integers),
+                            // not the requested `sc` -- otherwise every
+                            // dimension whose truncation actually rounded
+                            // down feeds slightly wrong coordinates into the
+                            // homography fit (#142).
+                            var achieved_sc_x = new_width / lev0_img.cols;
+                            var achieved_sc_y = new_height / lev0_img.rows;
                             for (i = 0; i < corners_num; ++i) {
-                                lev_corners[i].x *= 1. / sc;
-                                lev_corners[i].y *= 1. / sc;
+                                lev_corners[i].x *= 1. / achieved_sc_x;
+                                lev_corners[i].y *= 1. / achieved_sc_y;
                             }
 
                             console.log("train " + lev_img.cols + "x" + lev_img.rows + " points: " + corners_num);
-
-                            sc /= sc_inc;
                         }
                     };
                 }
@@ -473,8 +491,12 @@
                 }
 
                 function render_pattern_shape(ctx) {
-                    // get the projected pattern corners
-                    var shape_pts = tCorners(homo3x3.data, pattern_preview.cols * 2, pattern_preview.rows * 2);
+                    // get the projected pattern corners. Use the trained
+                    // (lev0_img) size, not pattern_preview.cols/rows * 2:
+                    // the preview is independently downscaled with `>> 1`
+                    // and only round-trips back to the trained size when
+                    // that size happens to be even (#142).
+                    var shape_pts = tCorners(homo3x3.data, trained_width, trained_height);
 
                     ctx.strokeStyle = "rgb(0,255,0)";
                     ctx.beginPath();

--- a/src/matrix_t/matrix_t.ts
+++ b/src/matrix_t/matrix_t.ts
@@ -124,6 +124,7 @@ export class matrix_t implements IMatrix_T {
             this.allocate();
         } else {
             this.buffer = _data_buffer;
+            matrix_t._reject_S64_t(this.type);
             // data user asked for
             this.data =
                 this.type & JSFEAT_CONSTANTS.U8_t
@@ -137,6 +138,27 @@ export class matrix_t implements IMatrix_T {
     }
 
     /**
+     * `S64_t` is a declared, publicly exported data type (inherited from
+     * jsfeat) that no view-selection code path actually supports: without
+     * this check, requesting it silently falls through to an F64_t view —
+     * right byte count, wrong interpretation, no error (issue #139).
+     * Rejecting it loudly is a deliberate divergence from jsfeat, which
+     * returns the wrong view silently; see `tests/divergences.test.ts`.
+     *
+     * @param type The data-type component of a packed type signature.
+     * @throws If `type` includes `S64_t`.
+     */
+    private static _reject_S64_t(type: number): void {
+        if (type & JSFEAT_CONSTANTS.S64_t) {
+            throw new Error(
+                "matrix_t: S64_t is declared but not implemented (issue #139) — " +
+                    "no view-selection path returns a genuine 64-bit integer view. " +
+                    "Supported types: U8_t, S32_t, F32_t, F64_t."
+            );
+        }
+    }
+
+    /**
      * Allocates a fresh backing buffer sized from the current
      * `cols * rows * channel * sizeof(type)` and points {@link data} at the
      * view matching {@link type}. Any previous buffer reference is dropped.
@@ -146,6 +168,7 @@ export class matrix_t implements IMatrix_T {
         delete this.data;
         delete this.buffer;
         //
+        matrix_t._reject_S64_t(this.type);
         this.buffer = new data_t(this.cols * this.dt._get_data_type_size(this.type) * this.channel * this.rows);
         this.data =
             this.type & JSFEAT_CONSTANTS.U8_t

--- a/src/matrix_t/matrix_t.ts
+++ b/src/matrix_t/matrix_t.ts
@@ -164,11 +164,15 @@ export class matrix_t implements IMatrix_T {
      * view matching {@link type}. Any previous buffer reference is dropped.
      */
     allocate(): void {
+        // Validate before discarding anything: allocate() is public API and
+        // can be called on an already-valid matrix (e.g. after changing
+        // `type`) -- deleting data/buffer first would leave that matrix
+        // corrupted (data/buffer undefined) if this throws.
+        matrix_t._reject_S64_t(this.type);
         // clear references
         delete this.data;
         delete this.buffer;
         //
-        matrix_t._reject_S64_t(this.type);
         this.buffer = new data_t(this.cols * this.dt._get_data_type_size(this.type) * this.channel * this.rows);
         this.data =
             this.type & JSFEAT_CONSTANTS.U8_t

--- a/tests/divergences.test.ts
+++ b/tests/divergences.test.ts
@@ -172,6 +172,25 @@ describe("intentional divergences from jsfeat", () => {
                 expect(() => new jsfeatNext.matrix_t(4, 4, t | jsfeatNext.C1_t)).not.toThrow();
             }
         });
+
+        it("rejecting an allocate() call to switch to S64_t leaves the matrix's existing data/buffer intact", () => {
+            // Qodo review finding: allocate() used to delete this.data/this.buffer
+            // before validating the new type, so a caller who set `type` to
+            // S64_t and called allocate() (catching the resulting throw) was
+            // left with a corrupted matrix -- data/buffer both undefined,
+            // even though the matrix's actual bytes were never touched.
+            const m = new jsfeatNext.matrix_t(4, 4, F32C1);
+            m.data[0] = 42;
+            const dataBefore = m.data;
+            const bufferBefore = m.buffer;
+
+            m.type = jsfeatNext.S64_t | jsfeatNext.C1_t;
+            expect(() => m.allocate()).toThrow(/S64_t/);
+
+            expect(m.data).toBe(dataBefore);
+            expect(m.buffer).toBe(bufferBefore);
+            expect(m.data[0]).toBe(42);
+        });
     });
 
     describe("imgproc.warp_affine fills the (-1, 0) source band instead of extrapolating (#119)", () => {

--- a/tests/divergences.test.ts
+++ b/tests/divergences.test.ts
@@ -121,6 +121,59 @@ describe("intentional divergences from jsfeat", () => {
             }
         });
     });
+
+    describe("matrix_t rejects S64_t instead of silently returning an F64_t view (#139)", () => {
+        /**
+         * S64_t is a declared, publicly exported data type that no
+         * view-selection code path actually supports: jsfeat's own
+         * `matrix_t` (and jsfeatNext's, inherited faithfully) sizes the
+         * buffer correctly for it but has no S64_t branch in the ternary
+         * chain that picks the typed-array view, so it silently falls
+         * through to F64_t — right byte count, wrong interpretation, no
+         * error of any kind.
+         *
+         * Per the issue's own options (implement a real BigInt64Array view,
+         * reject explicitly, or leave as is), implementing was rejected as
+         * disproportionate: nothing in this library needs 64-bit integer
+         * matrices today, and every arithmetic helper that touches `.data`
+         * would need a BigInt-vs-Number decision it currently has no reason
+         * to make. Rejecting loudly is a deliberate divergence from jsfeat,
+         * which returns the wrong view silently, registered here per #102's
+         * convention.
+         */
+        it("throws instead of returning a wrong (F64_t) view", () => {
+            const S64C1 = jsfeatNext.S64_t | jsfeatNext.C1_t;
+            expect(() => new jsfeatNext.matrix_t(4, 4, S64C1)).toThrow(/S64_t/);
+        });
+
+        it("also throws when wrapping a pre-existing buffer (the cache-pool constructor path)", () => {
+            // matrix_t has two view-selection sites -- its own allocate()
+            // and the branch that wraps a caller-supplied data_t (used by
+            // every cache-pool borrower across the codebase). Both must
+            // reject S64_t, not just the more commonly exercised one.
+            const S64C1 = jsfeatNext.S64_t | jsfeatNext.C1_t;
+            const donor = new jsfeatNext.matrix_t(4, 4, jsfeatNext.F64_t | jsfeatNext.C1_t);
+            expect(() => new jsfeatNext.matrix_t(4, 4, S64C1, donor.buffer)).toThrow(/S64_t/);
+        });
+
+        it("original jsfeat silently returns a Float64Array view for the same request", () => {
+            // Documents WHY we diverge: no error, no warning, just the wrong
+            // interpretation of the same bytes.
+            const OS64C1 = jsfeat.S64_t | jsfeat.C1_t;
+            const m = new jsfeat.matrix_t(4, 4, OS64C1);
+            expect(m.data).toBeInstanceOf(Float64Array);
+        });
+
+        it("still matches jsfeat exactly for every supported type (parity preserved)", () => {
+            // The divergence is scoped to S64_t alone -- every type this
+            // class actually supports remains unaffected.
+            const types = [jsfeatNext.U8_t, jsfeatNext.S32_t, jsfeatNext.F32_t, jsfeatNext.F64_t];
+            for (const t of types) {
+                expect(() => new jsfeatNext.matrix_t(4, 4, t | jsfeatNext.C1_t)).not.toThrow();
+            }
+        });
+    });
+
     describe("imgproc.warp_affine fills the (-1, 0) source band instead of extrapolating (#119)", () => {
         /**
          * jsfeat's bounds check is `ixs >= 0` on `xs | 0`, which truncates


### PR DESCRIPTION
## Summary

Two small, unrelated fixes bundled on one branch as agreed:

### #139 — `matrix_t` silently returns an `F64_t` view for `S64_t`

`S64_t` is declared and exported but no view-selection code path supports it — `matrix_t` sizes the buffer correctly but falls through to an `F64_t` view (right byte count, wrong interpretation, no error). Inherited faithfully from jsfeat.

Decided **Option 2** from the issue (reject explicitly) over implementing a real `BigInt64Array` view: nothing in this library needs 64-bit integers today, and every arithmetic helper touching `.data` would need a `BigInt`-vs-`Number` decision it has no reason to make — the same reason it was never implemented upstream. `matrix_t` now throws (naming the supported types) in both view-selection sites. Registered as an intentional divergence in `tests/divergences.test.ts`.

### #142 — ORB example training: outline sizing and coordinate un-scaling defects

Two real defects in `sample_orb.html` / `sample_orb_pinball.html`'s shared training code (both under 1% error — confirmed separately that the originally-reported overshoot was a bad printed target's squished aspect ratio, not a code bug):

- `render_pattern_shape()` reconstructed the trained frame size from `pattern_preview.cols/rows * 2`, which only round-trips exactly for even trained dimensions. Now stores and draws from the real trained size.
- Per-level keypoints were un-scaled by the *requested* resize factor, not the *achieved* one (`new_width | 0` truncates). Now computes the achieved per-axis scale from the actual resized dimensions.
- `sc` was accumulated via repeated division (drifts off the exact value, e.g. `0.4999999999999999` instead of `0.5`, which can cross an integer truncation boundary). Now computed fresh per level as `Math.pow(sc_inc, -lev)`.

## Testing

- `npm test`: 352/352 passing (4 new tests for #139's divergence).
- `npx tsc --noEmit`, `prettier --check`, `check-license-headers.mjs`: clean.
- Rebuilt `dist/` locally and loaded both example pages in a browser: no console errors beyond the expected camera-permission denial in a headless environment (not exercisable there either way).

Closes #139, #142.